### PR TITLE
PIA-882: Login feature for tvOS

### DIFF
--- a/PIA VPN-tvOS/Login/CompositionRoot/LoginFactory.swift
+++ b/PIA VPN-tvOS/Login/CompositionRoot/LoginFactory.swift
@@ -27,6 +27,7 @@ class LoginFactory {
     }
     
     private static func makeLoginProvider() -> LoginProviderType {
-        LoginProvider(accountProvider: Client.providers.accountProvider)
+        LoginProvider(accountProvider: Client.providers.accountProvider, 
+                      userAccountMapper: UserAccountMapper())
     }
 }

--- a/PIA VPN-tvOS/Login/CompositionRoot/LoginFactory.swift
+++ b/PIA VPN-tvOS/Login/CompositionRoot/LoginFactory.swift
@@ -1,0 +1,32 @@
+//
+//  LoginFactory.swift
+//  PIA VPN-tvOS
+//
+//  Created by Said Rehouni on 4/12/23.
+//  Copyright © 2023 Private Internet Access Inc. All rights reserved.
+//
+
+import Foundation
+import PIALibrary
+
+class LoginFactory {
+    static func makeLoginView() -> LoginView {
+        LoginView(viewModel: makeLoginViewModel())
+    }
+    
+    private static func makeLoginViewModel() -> LoginViewModel {
+        LoginViewModel(loginWithCredentialsUseCase: makeLoginWithCredentialsUseCase(),
+                       checkLoginAvailability: CheckLoginAvailability(),
+                       validateLoginCredentials: ValidateCredentialsFormat(),
+                       errorMapper: LoginPresentableErrorMapper())
+    }
+    
+    private static func makeLoginWithCredentialsUseCase() -> LoginWithCredentialsUseCaseType {
+        LoginWithCredentialsUseCase(loginProvider: makeLoginProvider(),
+                                    errorMapper: LoginDomainErrorMapper())
+    }
+    
+    private static func makeLoginProvider() -> LoginProviderType {
+        LoginProvider(accountProvider: Client.providers.accountProvider)
+    }
+}

--- a/PIA VPN-tvOS/Login/Data/LoginDomainErrorMapper.swift
+++ b/PIA VPN-tvOS/Login/Data/LoginDomainErrorMapper.swift
@@ -1,0 +1,31 @@
+//
+//  LoginDomainErrorMapper.swift
+//  PIA VPN-tvOS
+//
+//  Created by Said Rehouni on 4/12/23.
+//  Copyright © 2023 Private Internet Access Inc. All rights reserved.
+//
+
+import Foundation
+import PIALibrary
+
+class LoginDomainErrorMapper: LoginDomainErrorMapperType {
+    func map(error: Error?) -> LoginError {
+        guard let clientError = error as? ClientError else {
+            return .generic(message: error?.localizedDescription)
+        }
+        
+        switch clientError {
+        case .unauthorized:
+            return .unauthorized
+
+        case .throttled(retryAfter: let retryAfter):
+            return .throttled(retryAfter: Double(retryAfter))
+            
+        case .expired:
+            return .expired
+        default:
+            return .generic(message: error?.localizedDescription)
+        }
+    }
+}

--- a/PIA VPN-tvOS/Login/Data/LoginProvider.swift
+++ b/PIA VPN-tvOS/Login/Data/LoginProvider.swift
@@ -1,0 +1,22 @@
+//
+//  LoginProvider.swift
+//  PIA VPN-tvOS
+//
+//  Created by Said Rehouni on 4/12/23.
+//  Copyright © 2023 Private Internet Access Inc. All rights reserved.
+//
+
+import Foundation
+import PIALibrary
+
+class LoginProvider: LoginProviderType {
+    private var accountProvider: AccountProvider
+    
+    init(accountProvider: AccountProvider) {
+        self.accountProvider = accountProvider
+    }
+    
+    func login(with request: LoginRequest, _ callback: LibraryCallback<UserAccount>?) {
+        accountProvider.login(with: request, callback)
+    }
+}

--- a/PIA VPN-tvOS/Login/Data/UserAccountMapper.swift
+++ b/PIA VPN-tvOS/Login/Data/UserAccountMapper.swift
@@ -1,0 +1,49 @@
+//
+//  UserAccountMapper.swift
+//  PIA VPN-tvOS
+//
+//  Created by Said Rehouni on 12/12/23.
+//  Copyright © 2023 Private Internet Access Inc. All rights reserved.
+//
+
+import Foundation
+import PIALibrary
+
+class UserAccountMapper {
+    func map(userAccount: PIALibrary.UserAccount) -> UserAccount {
+        let credentials = Credentials(username: userAccount.credentials.username,
+                                      password: userAccount.credentials.password)
+        
+        guard let info = userAccount.info else {
+            return UserAccount(credentials: credentials, info: nil)
+        }
+        
+        let accountInfo = AccountInfo(email: info.email,
+                                      username: info.username,
+                                      plan: Plan.map(plan: info.plan),
+                                      productId: info.productId,
+                                      isRenewable: info.isRenewable,
+                                      isRecurring: info.isRecurring,
+                                      expirationDate: info.expirationDate,
+                                      canInvite: info.canInvite,
+                                      shouldPresentExpirationAlert: info.shouldPresentExpirationAlert,
+                                      renewUrl: info.renewUrl)
+        
+        return UserAccount(credentials: credentials, info: accountInfo)
+    }
+}
+
+extension Plan {
+    static func map(plan: PIALibrary.Plan) -> Plan {
+        switch plan {
+            case .monthly:
+                return .monthly
+            case .yearly:
+                return .yearly
+            case .trial:
+                return .trial
+            case .other:
+                return .other
+        }
+    }
+}

--- a/PIA VPN-tvOS/Login/Domain/Entities/AccountInfo.swift
+++ b/PIA VPN-tvOS/Login/Domain/Entities/AccountInfo.swift
@@ -1,0 +1,46 @@
+//
+//  AccountInfo.swift
+//  PIA VPN-tvOS
+//
+//  Created by Said Rehouni on 12/12/23.
+//  Copyright © 2023 Private Internet Access Inc. All rights reserved.
+//
+
+import Foundation
+
+enum Plan: String {
+    case monthly
+    case yearly
+    case trial
+    case other
+}
+
+struct AccountInfo {
+    let email: String?
+    let username: String
+    let plan: Plan
+    let productId: String?
+    let isRenewable: Bool
+    let isRecurring: Bool
+    let expirationDate: Date
+    let canInvite: Bool
+    
+    public var isExpired: Bool {
+        return (expirationDate.timeIntervalSinceNow < 0)
+    }
+    
+    public var dateComponentsBeforeExpiration: DateComponents {
+        return Calendar.current.dateComponents([.day, .hour], from: Date(), to: expirationDate)
+    }
+    
+    public let shouldPresentExpirationAlert: Bool
+    public let renewUrl: URL?
+    
+    public func humanReadableExpirationDate(usingLocale locale: Locale = Locale.current) -> String {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateStyle = .long
+        dateFormatter.timeStyle = .none
+        dateFormatter.locale = locale
+        return dateFormatter.string(from: self.expirationDate)
+    }
+}

--- a/PIA VPN-tvOS/Login/Domain/Entities/Credentials.swift
+++ b/PIA VPN-tvOS/Login/Domain/Entities/Credentials.swift
@@ -1,0 +1,19 @@
+//
+//  Credentials.swift
+//  PIA VPN-tvOS
+//
+//  Created by Said Rehouni on 12/12/23.
+//  Copyright © 2023 Private Internet Access Inc. All rights reserved.
+//
+
+import Foundation
+
+struct Credentials {
+    let username: String
+    let password: String
+    
+    init(username: String, password: String) {
+        self.username = username
+        self.password = password
+    }
+}

--- a/PIA VPN-tvOS/Login/Domain/Entities/LoginError.swift
+++ b/PIA VPN-tvOS/Login/Domain/Entities/LoginError.swift
@@ -1,0 +1,18 @@
+//
+//  LoginError.swift
+//  PIA VPN-tvOS
+//
+//  Created by Said Rehouni on 29/11/23.
+//  Copyright © 2023 Private Internet Access Inc. All rights reserved.
+//
+
+import Foundation
+
+enum LoginError: Error {
+    case unauthorized
+    case throttled(retryAfter: Double)
+    case expired
+    case usernameWrongFormat
+    case passwordWrongFormat
+    case generic(message: String?)
+}

--- a/PIA VPN-tvOS/Login/Domain/Entities/UserAccount.swift
+++ b/PIA VPN-tvOS/Login/Domain/Entities/UserAccount.swift
@@ -1,0 +1,23 @@
+//
+//  UserAccount.swift
+//  PIA VPN-tvOS
+//
+//  Created by Said Rehouni on 12/12/23.
+//  Copyright © 2023 Private Internet Access Inc. All rights reserved.
+//
+
+import Foundation
+
+struct UserAccount {
+    let credentials: Credentials
+    let info: AccountInfo?
+
+    var isRenewable: Bool {
+        return info?.isRenewable ?? false
+    }
+
+    init(credentials: Credentials, info: AccountInfo?) {
+        self.credentials = credentials
+        self.info = info
+    }
+}

--- a/PIA VPN-tvOS/Login/Domain/Interfaces/LoginDomainErrorMapperType.swift
+++ b/PIA VPN-tvOS/Login/Domain/Interfaces/LoginDomainErrorMapperType.swift
@@ -1,0 +1,13 @@
+//
+//  LoginDomainErrorMapperType.swift
+//  PIA VPN-tvOS
+//
+//  Created by Said Rehouni on 4/12/23.
+//  Copyright © 2023 Private Internet Access Inc. All rights reserved.
+//
+
+import Foundation
+
+protocol LoginDomainErrorMapperType {
+    func map(error: Error?) -> LoginError
+}

--- a/PIA VPN-tvOS/Login/Domain/Interfaces/LoginProviderType.swift
+++ b/PIA VPN-tvOS/Login/Domain/Interfaces/LoginProviderType.swift
@@ -1,0 +1,14 @@
+//
+//  LoginProviderType.swift
+//  PIA VPN-tvOS
+//
+//  Created by Said Rehouni on 27/11/23.
+//  Copyright © 2023 Private Internet Access Inc. All rights reserved.
+//
+
+import Foundation
+import PIALibrary
+
+protocol LoginProviderType {
+    func login(with request: LoginRequest, _ callback: LibraryCallback<UserAccount>?)
+}

--- a/PIA VPN-tvOS/Login/Domain/Interfaces/LoginProviderType.swift
+++ b/PIA VPN-tvOS/Login/Domain/Interfaces/LoginProviderType.swift
@@ -7,8 +7,7 @@
 //
 
 import Foundation
-import PIALibrary
 
 protocol LoginProviderType {
-    func login(with request: LoginRequest, _ callback: LibraryCallback<UserAccount>?)
+    func login(with credentials: Credentials, completion: @escaping (Result<UserAccount, Error>) -> Void)
 }

--- a/PIA VPN-tvOS/Login/Domain/Use cases/LoginWithCredentialsUseCase.swift
+++ b/PIA VPN-tvOS/Login/Domain/Use cases/LoginWithCredentialsUseCase.swift
@@ -7,7 +7,6 @@
 //
 
 import Foundation
-import PIALibrary
 
 protocol LoginWithCredentialsUseCaseType {
     func execute(username: String, password: String, completion: @escaping (Result<UserAccount, LoginError>) -> Void)
@@ -25,22 +24,16 @@ class LoginWithCredentialsUseCase: LoginWithCredentialsUseCaseType {
     func execute(username: String, password: String, completion: @escaping (Result<UserAccount, LoginError>) -> Void) {
         let credentials = Credentials(username: username, 
                                       password: password)
-        let request = LoginRequest(credentials: credentials)
         
-        loginProvider.login(with: request) { [weak self] userAccount, error in
+        loginProvider.login(with: credentials) { [weak self] result in
             guard let self = self else { return }
             
-            if let error = error {
-                completion(.failure(errorMapper.map(error: error)))
-                return
+            switch result {
+                case .success(let userAccount):
+                    completion(.success(userAccount))
+                case .failure(let error):
+                    completion(.failure(errorMapper.map(error: error)))
             }
-            
-            guard let userAccount = userAccount else {
-                completion(.failure(.generic(message: nil)))
-                return
-            }
-            
-            completion(.success(userAccount))
         }
     }
 }

--- a/PIA VPN-tvOS/Login/Domain/Use cases/LoginWithCredentialsUseCase.swift
+++ b/PIA VPN-tvOS/Login/Domain/Use cases/LoginWithCredentialsUseCase.swift
@@ -1,0 +1,50 @@
+//
+//  LoginWithCredentialsUseCase.swift
+//  PIA VPN-tvOS
+//
+//  Created by Said Rehouni on 27/11/23.
+//  Copyright © 2023 Private Internet Access Inc. All rights reserved.
+//
+
+import Foundation
+import PIALibrary
+
+protocol LoginWithCredentialsUseCaseType {
+    func execute(username: String, password: String, completion: @escaping (Result<UserAccount, LoginError>) -> Void)
+}
+
+class LoginWithCredentialsUseCase: LoginWithCredentialsUseCaseType {
+    private let loginProvider: LoginProviderType
+    private let errorMapper: LoginDomainErrorMapperType
+    
+    init(loginProvider: LoginProviderType, errorMapper: LoginDomainErrorMapperType) {
+        self.loginProvider = loginProvider
+        self.errorMapper = errorMapper
+    }
+    
+    func execute(username: String, password: String, completion: @escaping (Result<UserAccount, LoginError>) -> Void) {
+        let credentials = Credentials(username: username, 
+                                      password: password)
+        let request = LoginRequest(credentials: credentials)
+        
+        loginProvider.login(with: request) { [weak self] userAccount, error in
+            guard let self = self else { return }
+            
+            if let error = error {
+                completion(.failure(errorMapper.map(error: error)))
+                return
+            }
+            
+            guard let userAccount = userAccount else {
+                completion(.failure(.generic(message: nil)))
+                return
+            }
+            
+            completion(.success(userAccount))
+        }
+    }
+}
+
+
+
+

--- a/PIA VPN-tvOS/Login/Presentation/CheckLoginAvailability.swift
+++ b/PIA VPN-tvOS/Login/Presentation/CheckLoginAvailability.swift
@@ -7,7 +7,6 @@
 //
 
 import Foundation
-import PIALibrary
 
 protocol CheckLoginAvailabilityType {
     func disableLoginFor(_ delay: Double)

--- a/PIA VPN-tvOS/Login/Presentation/CheckLoginAvailability.swift
+++ b/PIA VPN-tvOS/Login/Presentation/CheckLoginAvailability.swift
@@ -1,0 +1,31 @@
+//
+//  CheckLoginAvailability.swift
+//  PIA VPN-tvOS
+//
+//  Created by Said Rehouni on 29/11/23.
+//  Copyright © 2023 Private Internet Access Inc. All rights reserved.
+//
+
+import Foundation
+import PIALibrary
+
+protocol CheckLoginAvailabilityType {
+    func disableLoginFor(_ delay: Double)
+    func callAsFunction() -> Result<Void, LoginError>
+}
+
+class CheckLoginAvailability: CheckLoginAvailabilityType {
+    private var timeToRetryCredentials: TimeInterval? = nil
+    
+    func disableLoginFor(_ delay: Double) {
+        timeToRetryCredentials = delay
+    }
+    
+    func callAsFunction() -> Result<Void, LoginError> {
+        if let timeUntilNextTry = timeToRetryCredentials?.timeSinceNow() {
+            return .failure(.throttled(retryAfter: timeUntilNextTry))
+        }
+        
+        return .success(())
+    }
+}

--- a/PIA VPN-tvOS/Login/Presentation/LoginPresentableErrorMapper.swift
+++ b/PIA VPN-tvOS/Login/Presentation/LoginPresentableErrorMapper.swift
@@ -1,0 +1,15 @@
+//
+//  LoginPresentableErrorMapper.swift
+//  PIA VPN-tvOS
+//
+//  Created by Said Rehouni on 28/11/23.
+//  Copyright © 2023 Private Internet Access Inc. All rights reserved.
+//
+
+import Foundation
+
+class LoginPresentableErrorMapper {
+    func map(error: LoginError) -> String? {
+        return nil
+    }
+}

--- a/PIA VPN-tvOS/Login/Presentation/LoginViewModel.swift
+++ b/PIA VPN-tvOS/Login/Presentation/LoginViewModel.swift
@@ -1,0 +1,76 @@
+//
+//  LoginViewModel.swift
+//  PIA VPN-tvOS
+//
+//  Created by Said Rehouni on 23/11/23.
+//  Copyright © 2023 Private Internet Access Inc. All rights reserved.
+//
+
+import Foundation
+import PIALibrary
+
+enum LoginStatus {
+    case none
+    case isLogging
+    case failed(error: LoginError)
+    case succeeded(userAccount: UserAccount)
+}
+
+class LoginViewModel: ObservableObject {
+    private let loginWithCredentialsUseCase: LoginWithCredentialsUseCaseType
+    private let checkLoginAvailability: CheckLoginAvailabilityType
+    private let validateLoginCredentials: ValidateCredentialsFormatType
+    private let errorMapper: LoginPresentableErrorMapper
+    
+    var loginStatus: LoginStatus = .none
+    
+    init(loginWithCredentialsUseCase: LoginWithCredentialsUseCaseType, checkLoginAvailability: CheckLoginAvailabilityType, validateLoginCredentials: ValidateCredentialsFormatType, errorMapper: LoginPresentableErrorMapper) {
+        self.loginWithCredentialsUseCase = loginWithCredentialsUseCase
+        self.checkLoginAvailability = checkLoginAvailability
+        self.validateLoginCredentials = validateLoginCredentials
+        self.errorMapper = errorMapper
+    }
+    
+    func login(username: String, password: String) async {
+        if case .isLogging = loginStatus {
+            return
+        }
+        
+        if case .failure(let error) = checkLoginAvailability() {
+            handleError(error: error)
+            return
+        }
+        
+        if case .failure(let error) = validateLoginCredentials(username: username, password: password) {
+            // Handle credentials wrong format
+            loginStatus = .failed(error: error)
+            return
+        }
+        
+        loginStatus = .isLogging
+        
+        await withCheckedContinuation { continuation in
+            loginWithCredentialsUseCase.execute(username: username, password: password) { [weak self] result in
+                guard let self = self else { return }
+                
+                switch result {
+                    case .success(let userAccount):
+                        self.loginStatus = .succeeded(userAccount: userAccount)
+                    
+                    case .failure(let error):
+                        self.handleError(error: error)
+                }
+                continuation.resume()
+            }
+        }
+    }
+    
+    private func handleError(error: LoginError) {
+        if case .throttled(let delay) = error {
+            checkLoginAvailability.disableLoginFor(delay)
+        }
+        
+        let errorMessage = errorMapper.map(error: error)
+        loginStatus = .failed(error: error)
+    }
+}

--- a/PIA VPN-tvOS/Login/Presentation/LoginViewModel.swift
+++ b/PIA VPN-tvOS/Login/Presentation/LoginViewModel.swift
@@ -7,7 +7,6 @@
 //
 
 import Foundation
-import PIALibrary
 
 enum LoginStatus {
     case none

--- a/PIA VPN-tvOS/Login/Presentation/ValidateCredentialsFormat.swift
+++ b/PIA VPN-tvOS/Login/Presentation/ValidateCredentialsFormat.swift
@@ -1,0 +1,28 @@
+//
+//  ValidateCredentialsFormat.swift
+//  PIA VPN-tvOS
+//
+//  Created by Said Rehouni on 26/11/23.
+//  Copyright © 2023 Private Internet Access Inc. All rights reserved.
+//
+
+import Foundation
+import PIALibrary
+
+
+
+protocol ValidateCredentialsFormatType {
+    func callAsFunction(username: String, password: String) -> Result<Void, LoginError>
+}
+
+class ValidateCredentialsFormat: ValidateCredentialsFormatType {
+    func callAsFunction(username: String, password: String) -> Result<Void, LoginError> {
+        let usernameText = username.trimmingCharacters(in: .whitespacesAndNewlines)
+        let passwordText = password.trimmingCharacters(in: .whitespacesAndNewlines)
+        
+        guard !usernameText.isEmpty else { return .failure(.usernameWrongFormat) }
+        guard !passwordText.isEmpty else { return .failure(.passwordWrongFormat) }
+        
+        return .success(())
+    }
+}

--- a/PIA VPN-tvOS/Login/Presentation/ValidateCredentialsFormat.swift
+++ b/PIA VPN-tvOS/Login/Presentation/ValidateCredentialsFormat.swift
@@ -7,9 +7,6 @@
 //
 
 import Foundation
-import PIALibrary
-
-
 
 protocol ValidateCredentialsFormatType {
     func callAsFunction(username: String, password: String) -> Result<Void, LoginError>

--- a/PIA VPN-tvOS/Login/UI/LoginView.swift
+++ b/PIA VPN-tvOS/Login/UI/LoginView.swift
@@ -1,0 +1,36 @@
+//
+//  LoginView.swift
+//  PIA VPN-tvOS
+//
+//  Created by Said Rehouni on 23/11/23.
+//  Copyright © 2023 Private Internet Access Inc. All rights reserved.
+//
+
+import SwiftUI
+
+struct LoginView: View {
+    @State private var userName: String = ""
+    @State private var password: String = ""
+    
+    @ObservedObject private var viewModel: LoginViewModel
+    
+    init(viewModel: LoginViewModel) {
+        self.viewModel = viewModel
+    }
+    
+    var body: some View {
+        VStack {
+            Text("Sign in to your account")
+                .font(.system(size: 36))
+            TextField("Username(p1234567)", text: $userName)
+            TextField("Password", text: $password)
+            Button(action: {
+                Task {
+                    await viewModel.login(username: userName, password: password)
+                }
+            }, label: {
+                Text("LOGIN")
+            })
+        }
+    }
+}

--- a/PIA VPN-tvOS/Login/Utils/Foundation+PIA.swift
+++ b/PIA VPN-tvOS/Login/Utils/Foundation+PIA.swift
@@ -1,0 +1,18 @@
+//
+//  Foundation+PIA.swift
+//  PIA VPN-tvOS
+//
+//  Created by Said Rehouni on 13/12/23.
+//  Copyright © 2023 Private Internet Access Inc. All rights reserved.
+//
+
+import Foundation
+
+extension TimeInterval {
+    /// Returns time in seconds between receiver & now
+    /// and a nil if now has already gone ahead of the receiver.
+    public func timeSinceNow() -> Double? {
+        let now = Date().timeIntervalSince1970
+        return now > self ? nil : self - now
+    }
+}

--- a/PIA VPN-tvOS/PIA_VPN_tvOSApp.swift
+++ b/PIA VPN-tvOS/PIA_VPN_tvOSApp.swift
@@ -12,7 +12,7 @@ import SwiftUI
 struct PIA_VPN_tvOSApp: App {
     var body: some Scene {
         WindowGroup {
-            ContentView()
+            LoginFactory.makeLoginView()
         }
     }
 }

--- a/PIA VPN-tvOSTests/Login/CheckLoginAvailabilityTests.swift
+++ b/PIA VPN-tvOSTests/Login/CheckLoginAvailabilityTests.swift
@@ -1,0 +1,63 @@
+//
+//  CheckLoginAvailabilityTests.swift
+//  PIA VPN-tvOSTests
+//
+//  Created by Said Rehouni on 29/11/23.
+//  Copyright © 2023 Private Internet Access Inc. All rights reserved.
+//
+
+import XCTest
+@testable import PIA_VPN_tvOS
+
+final class CheckLoginAvailabilityTests: XCTestCase {
+    
+    func test_checkLoginAvailability_returns_success_when_there_is_no_delay() {
+        // GIVEN
+        let sut = CheckLoginAvailability()
+        
+        // WHEN
+        let result = sut()
+        
+        // THEN
+        guard case .success = result else {
+            XCTFail("Expected success, got failure")
+            return
+        }
+    }
+
+    func test_checkLoginAvailability_returns_success_when_delay_expired() {
+        // GIVEN
+        let sut = CheckLoginAvailability()
+        
+        // WHEN
+        sut.disableLoginFor(Date().timeIntervalSince1970 - 1)
+        let result = sut()
+        
+        // THEN
+        guard case .success = result else {
+            XCTFail("Expected success, got failure")
+            return
+        }
+    }
+    
+    func test_checkLoginAvailability_returns_failure_when_delay_has_not_expired_yet() {
+        // GIVEN
+        let date = Date()
+        let sut = CheckLoginAvailability()
+        
+        // WHEN
+        sut.disableLoginFor(date.timeIntervalSince1970 + 10)
+        let result = sut()
+        
+        // THEN
+        guard case .failure(let error) = result else {
+            XCTFail("Expected success, got failure")
+            return
+        }
+    
+        guard case .throttled = error else {
+            XCTFail("Expected throttled error, got \(error)")
+            return
+        }
+    }
+}

--- a/PIA VPN-tvOSTests/Login/Helpers/AccountProviderMock.swift
+++ b/PIA VPN-tvOSTests/Login/Helpers/AccountProviderMock.swift
@@ -1,0 +1,57 @@
+//
+//  AccountProviderMock.swift
+//  PIA VPN-tvOSTests
+//
+//  Created by Said Rehouni on 12/12/23.
+//  Copyright © 2023 Private Internet Access Inc. All rights reserved.
+//
+
+import Foundation
+import PIALibrary
+
+class AccountProviderMock: AccountProvider {
+    var planProducts: [PIALibrary.Plan : PIALibrary.InAppProduct]?
+    var shouldCleanAccount: Bool = true
+    var isLoggedIn: Bool = true
+    var currentUser: PIALibrary.UserAccount?
+    var oldToken: String?
+    var apiToken: String?
+    var vpnToken: String?
+    var vpnTokenUsername: String?
+    var vpnTokenPassword: String?
+    var publicUsername: String?
+    var currentPasswordReference: Data?
+    var lastSignupRequest: PIALibrary.SignupRequest?
+    func migrateOldTokenIfNeeded(_ callback: PIALibrary.SuccessLibraryCallback?) {}
+    
+    private let userResult: PIALibrary.UserAccount?
+    private let errorResult: Error?
+    
+    init(userResult: PIALibrary.UserAccount?, errorResult: Error?) {
+        self.userResult = userResult
+        self.errorResult = errorResult
+    }
+    
+    func login(with request: PIALibrary.LoginRequest, _ callback: PIALibrary.LibraryCallback<PIALibrary.UserAccount>?) {
+        callback?(userResult, errorResult)
+    }
+    
+    func login(with receiptRequest: PIALibrary.LoginReceiptRequest, _ callback: PIALibrary.LibraryCallback<PIALibrary.UserAccount>?) {}
+    func login(with linkToken: String, _ callback: ((PIALibrary.UserAccount?, Error?) -> Void)?) {}
+    func refreshAccountInfo(_ callback: PIALibrary.LibraryCallback<PIALibrary.AccountInfo>?) {}
+    func accountInformation(_ callback: ((PIALibrary.AccountInfo?, Error?) -> Void)?) {}
+    func update(with request: PIALibrary.UpdateAccountRequest, resetPassword reset: Bool, andPassword password: String, _ callback: PIALibrary.LibraryCallback<PIALibrary.AccountInfo>?) {}
+    func logout(_ callback: PIALibrary.SuccessLibraryCallback?) {}
+    func deleteAccount(_ callback: PIALibrary.SuccessLibraryCallback?) {}
+    func cleanDatabase() {}
+    func featureFlags(_ callback: PIALibrary.SuccessLibraryCallback?) {}
+    func listPlanProducts(_ callback: PIALibrary.LibraryCallback<[PIALibrary.Plan : PIALibrary.InAppProduct]>?) {}
+    func purchase(plan: PIALibrary.Plan, _ callback: PIALibrary.LibraryCallback<PIALibrary.InAppTransaction>?) {}
+    func isAPIEndpointAvailable(_ callback: PIALibrary.LibraryCallback<Bool>?) {}
+    func restorePurchases(_ callback: PIALibrary.SuccessLibraryCallback?) {}
+    func loginUsingMagicLink(withEmail email: String, _ callback: PIALibrary.SuccessLibraryCallback?) {}
+    func signup(with request: PIALibrary.SignupRequest, _ callback: PIALibrary.LibraryCallback<PIALibrary.UserAccount>?) {}
+    func listRenewablePlans(_ callback: PIALibrary.LibraryCallback<[PIALibrary.Plan]>?) {}
+    func subscriptionInformation(_ callback: PIALibrary.LibraryCallback<PIALibrary.AppStoreInformation>?) {}
+    func renew(with request: PIALibrary.RenewRequest, _ callback: PIALibrary.LibraryCallback<PIALibrary.UserAccount>?) {}
+}

--- a/PIA VPN-tvOSTests/Login/Helpers/CheckLoginAvailabilityMock.swift
+++ b/PIA VPN-tvOSTests/Login/Helpers/CheckLoginAvailabilityMock.swift
@@ -1,0 +1,24 @@
+//
+//  CheckLoginAvailabilityMock.swift
+//  PIA VPN-tvOSTests
+//
+//  Created by Said Rehouni on 29/11/23.
+//  Copyright © 2023 Private Internet Access Inc. All rights reserved.
+//
+
+import Foundation
+@testable import PIA_VPN_tvOS
+
+class CheckLoginAvailabilityMock: CheckLoginAvailabilityType {
+    private let result: Result<Void, LoginError>
+    
+    init(result: Result<Void, LoginError>) {
+        self.result = result
+    }
+    
+    func disableLoginFor(_ delay: Double) {}
+    
+    func callAsFunction() -> Result<Void, LoginError> {
+        return result
+    }
+}

--- a/PIA VPN-tvOSTests/Login/Helpers/Equatable.swift
+++ b/PIA VPN-tvOSTests/Login/Helpers/Equatable.swift
@@ -1,0 +1,68 @@
+//
+//  Equatable.swift
+//  PIA VPN-tvOSTests
+//
+//  Created by Said Rehouni on 29/11/23.
+//  Copyright © 2023 Private Internet Access Inc. All rights reserved.
+//
+
+import Foundation
+@testable import PIA_VPN_tvOS
+import PIALibrary
+
+extension LoginStatus: Equatable {
+    public static func == (lhs: LoginStatus, rhs: LoginStatus) -> Bool {
+        switch (lhs, rhs) {
+            case (.none, .none), (.isLogging, .isLogging):
+                return true
+            case let (.failed(lhsError), .failed(rhsError)):
+                return lhsError == rhsError
+            case let (.succeeded(lhsAccount), .succeeded(rhsAccount)):
+                return lhsAccount == rhsAccount
+            default:
+                return false
+        }
+    }
+}
+
+extension LoginError: Equatable {
+    public static func == (lhs: LoginError, rhs: LoginError) -> Bool {
+        switch (lhs, rhs) {
+            case (.unauthorized, .unauthorized), (.expired, .expired), (.usernameWrongFormat, .usernameWrongFormat), (.passwordWrongFormat, .passwordWrongFormat):
+                return true
+            case let (.throttled(lhsDelay), .throttled(rhsDelay)):
+                return lhsDelay == rhsDelay
+            default:
+                return false
+        }
+    }
+}
+
+extension UserAccount: Equatable {
+    public static func == (lhs: PIALibrary.UserAccount, rhs: PIALibrary.UserAccount) -> Bool {
+        lhs.credentials == rhs.credentials
+        && lhs.info == rhs.info
+    }
+}
+
+extension Credentials: Equatable {
+    public static func == (lhs: Credentials, rhs: Credentials) -> Bool {
+        lhs.username == rhs.username && lhs.password == rhs.password
+    }
+}
+
+extension AccountInfo: Equatable {
+    public static func == (lhs: AccountInfo, rhs: AccountInfo) -> Bool {
+        lhs.email == rhs.email
+        && lhs.username == rhs.username
+        && lhs.plan == rhs.plan
+        && lhs.productId == rhs.productId
+        && lhs.isRenewable == rhs.isRenewable
+        && lhs.isRecurring == rhs.isRecurring
+        && lhs.expirationDate == rhs.expirationDate
+        && lhs.canInvite == rhs.canInvite
+        && lhs.isExpired == rhs.isExpired
+        && lhs.shouldPresentExpirationAlert == rhs.shouldPresentExpirationAlert
+        && lhs.renewUrl == rhs.renewUrl
+    }
+}

--- a/PIA VPN-tvOSTests/Login/Helpers/Equatable.swift
+++ b/PIA VPN-tvOSTests/Login/Helpers/Equatable.swift
@@ -37,32 +37,3 @@ extension LoginError: Equatable {
         }
     }
 }
-
-extension UserAccount: Equatable {
-    public static func == (lhs: PIALibrary.UserAccount, rhs: PIALibrary.UserAccount) -> Bool {
-        lhs.credentials == rhs.credentials
-        && lhs.info == rhs.info
-    }
-}
-
-extension Credentials: Equatable {
-    public static func == (lhs: Credentials, rhs: Credentials) -> Bool {
-        lhs.username == rhs.username && lhs.password == rhs.password
-    }
-}
-
-extension AccountInfo: Equatable {
-    public static func == (lhs: AccountInfo, rhs: AccountInfo) -> Bool {
-        lhs.email == rhs.email
-        && lhs.username == rhs.username
-        && lhs.plan == rhs.plan
-        && lhs.productId == rhs.productId
-        && lhs.isRenewable == rhs.isRenewable
-        && lhs.isRecurring == rhs.isRecurring
-        && lhs.expirationDate == rhs.expirationDate
-        && lhs.canInvite == rhs.canInvite
-        && lhs.isExpired == rhs.isExpired
-        && lhs.shouldPresentExpirationAlert == rhs.shouldPresentExpirationAlert
-        && lhs.renewUrl == rhs.renewUrl
-    }
-}

--- a/PIA VPN-tvOSTests/Login/Helpers/LoginProviderMock.swift
+++ b/PIA VPN-tvOSTests/Login/Helpers/LoginProviderMock.swift
@@ -1,0 +1,25 @@
+//
+//  LoginProviderMock.swift
+//  PIA VPN-tvOSTests
+//
+//  Created by Said Rehouni on 4/12/23.
+//  Copyright © 2023 Private Internet Access Inc. All rights reserved.
+//
+
+import Foundation
+import PIALibrary
+@testable import PIA_VPN_tvOS
+
+class LoginProviderMock: LoginProviderType {
+    private let userResult: UserAccount?
+    private let errorResult: Error?
+    
+    init(userResult: UserAccount?, errorResult: Error?) {
+        self.userResult = userResult
+        self.errorResult = errorResult
+    }
+    
+    func login(with request: LoginRequest, _ callback: LibraryCallback<UserAccount>?) {
+        callback?(userResult, errorResult)
+    }
+}

--- a/PIA VPN-tvOSTests/Login/Helpers/LoginProviderMock.swift
+++ b/PIA VPN-tvOSTests/Login/Helpers/LoginProviderMock.swift
@@ -7,19 +7,16 @@
 //
 
 import Foundation
-import PIALibrary
 @testable import PIA_VPN_tvOS
 
 class LoginProviderMock: LoginProviderType {
-    private let userResult: UserAccount?
-    private let errorResult: Error?
+    private let result: Result<UserAccount, Error>
     
-    init(userResult: UserAccount?, errorResult: Error?) {
-        self.userResult = userResult
-        self.errorResult = errorResult
+    init(result: Result<UserAccount, Error>) {
+        self.result = result
     }
     
-    func login(with request: LoginRequest, _ callback: LibraryCallback<UserAccount>?) {
-        callback?(userResult, errorResult)
+    func login(with credentials: Credentials, completion: @escaping (Result<UserAccount, Error>) -> Void) {
+        completion(result)
     }
 }

--- a/PIA VPN-tvOSTests/Login/Helpers/LoginWithCredentialsUseCaseMock.swift
+++ b/PIA VPN-tvOSTests/Login/Helpers/LoginWithCredentialsUseCaseMock.swift
@@ -1,0 +1,23 @@
+//
+//  LoginWithCredentialsUseCaseMock.swift
+//  PIA VPN-tvOSTests
+//
+//  Created by Said Rehouni on 29/11/23.
+//  Copyright © 2023 Private Internet Access Inc. All rights reserved.
+//
+
+import Foundation
+@testable import PIA_VPN_tvOS
+import PIALibrary
+
+class LoginWithCredentialsUseCaseMock: LoginWithCredentialsUseCaseType {
+    private let result: Result<UserAccount, LoginError>
+    
+    init(result: Result<UserAccount, LoginError>) {
+        self.result = result
+    }
+    
+    func execute(username: String, password: String, completion: @escaping (Result<UserAccount, LoginError>) -> Void) {
+        completion(result)
+    }
+}

--- a/PIA VPN-tvOSTests/Login/Helpers/LoginWithCredentialsUseCaseMock.swift
+++ b/PIA VPN-tvOSTests/Login/Helpers/LoginWithCredentialsUseCaseMock.swift
@@ -8,7 +8,6 @@
 
 import Foundation
 @testable import PIA_VPN_tvOS
-import PIALibrary
 
 class LoginWithCredentialsUseCaseMock: LoginWithCredentialsUseCaseType {
     private let result: Result<UserAccount, LoginError>

--- a/PIA VPN-tvOSTests/Login/Helpers/Stubs.swift
+++ b/PIA VPN-tvOSTests/Login/Helpers/Stubs.swift
@@ -2,13 +2,12 @@
 //  Stubs.swift
 //  PIA VPN-tvOSTests
 //
-//  Created by Said Rehouni on 29/11/23.
+//  Created by Said Rehouni on 12/12/23.
 //  Copyright © 2023 Private Internet Access Inc. All rights reserved.
 //
 
 import Foundation
-import PIALibrary
-import account
+@testable import PIA_VPN_tvOS
 
 extension UserAccount {
     static func makeStub() -> UserAccount {
@@ -21,22 +20,44 @@ extension UserAccount {
 
 extension AccountInfo {
     static func makeStub() -> AccountInfo {
-        let account = AccountInformation(active: true,
-                                         canInvite: true,
-                                         canceled: true,
-                                         daysRemaining: 0,
-                                         email: "email",
-                                         expirationTime: 0,
-                                         expireAlert: true,
-                                         expired: true,
-                                         needsPayment: true,
-                                         plan: "monthly",
-                                         productId: "productId",
-                                         recurring: true,
-                                         renewUrl: "renewUrl",
-                                         renewable: true,
-                                         username: "username")
-        
-        return AccountInfo(accountInformation: account)
+        return AccountInfo(email: "email",
+                           username: "username",
+                           plan: Plan.monthly,
+                           productId: "productId",
+                           isRenewable: true,
+                           isRecurring: true,
+                           expirationDate: Date(),
+                           canInvite: true,
+                           shouldPresentExpirationAlert: true,
+                           renewUrl: URL(string: "https://an-url.com"))
+    }
+}
+
+extension UserAccount: Equatable {
+    public static func == (lhs: UserAccount, rhs: UserAccount) -> Bool {
+        lhs.credentials == rhs.credentials
+        && lhs.info == rhs.info
+    }
+}
+
+extension Credentials: Equatable {
+    public static func == (lhs: Credentials, rhs: Credentials) -> Bool {
+        lhs.username == rhs.username && lhs.password == rhs.password
+    }
+}
+
+extension AccountInfo: Equatable {
+    public static func == (lhs: AccountInfo, rhs: AccountInfo) -> Bool {
+        lhs.email == rhs.email
+        && lhs.username == rhs.username
+        && lhs.plan == rhs.plan
+        && lhs.productId == rhs.productId
+        && lhs.isRenewable == rhs.isRenewable
+        && lhs.isRecurring == rhs.isRecurring
+        && lhs.expirationDate == rhs.expirationDate
+        && lhs.canInvite == rhs.canInvite
+        && lhs.isExpired == rhs.isExpired
+        && lhs.shouldPresentExpirationAlert == rhs.shouldPresentExpirationAlert
+        && lhs.renewUrl == rhs.renewUrl
     }
 }

--- a/PIA VPN-tvOSTests/Login/Helpers/Stubs.swift
+++ b/PIA VPN-tvOSTests/Login/Helpers/Stubs.swift
@@ -1,0 +1,42 @@
+//
+//  Stubs.swift
+//  PIA VPN-tvOSTests
+//
+//  Created by Said Rehouni on 29/11/23.
+//  Copyright © 2023 Private Internet Access Inc. All rights reserved.
+//
+
+import Foundation
+import PIALibrary
+import account
+
+extension UserAccount {
+    static func makeStub() -> UserAccount {
+        let credentials = Credentials(username: "username",
+                                      password: "password")
+        return UserAccount(credentials: credentials,
+                           info: AccountInfo.makeStub())
+    }
+}
+
+extension AccountInfo {
+    static func makeStub() -> AccountInfo {
+        let account = AccountInformation(active: true,
+                                         canInvite: true,
+                                         canceled: true,
+                                         daysRemaining: 0,
+                                         email: "email",
+                                         expirationTime: 0,
+                                         expireAlert: true,
+                                         expired: true,
+                                         needsPayment: true,
+                                         plan: "monthly",
+                                         productId: "productId",
+                                         recurring: true,
+                                         renewUrl: "renewUrl",
+                                         renewable: true,
+                                         username: "username")
+        
+        return AccountInfo(accountInformation: account)
+    }
+}

--- a/PIA VPN-tvOSTests/Login/LoginIntegrationTests.swift
+++ b/PIA VPN-tvOSTests/Login/LoginIntegrationTests.swift
@@ -1,0 +1,56 @@
+//
+//  LoginIntegrationTests.swift
+//  PIA VPN-tvOSTests
+//
+//  Created by Said Rehouni on 11/12/23.
+//  Copyright © 2023 Private Internet Access Inc. All rights reserved.
+//
+
+import XCTest
+import PIALibrary
+@testable import PIA_VPN_tvOS
+
+final class LoginIntegrationTests: XCTestCase {
+
+    func test_login_succeeds() async throws {
+        // GIVEN
+        let userAccount = UserAccount.makeStub()
+        let loginProviderMock = LoginProviderMock(userResult: userAccount, errorResult: nil)
+        let loginWithCredentialsUseCase = LoginWithCredentialsUseCase(loginProvider: loginProviderMock,
+                                    errorMapper: LoginDomainErrorMapper())
+        
+        let sut = LoginViewModel(loginWithCredentialsUseCase: loginWithCredentialsUseCase,
+                                 checkLoginAvailability: CheckLoginAvailability(),
+                                 validateLoginCredentials: ValidateCredentialsFormat(),
+                                 errorMapper: LoginPresentableErrorMapper())
+        
+        XCTAssertEqual(sut.loginStatus, .none)
+        
+        // WHEN
+        await sut.login(username: "username", password: "password")
+        
+        // THEN
+        XCTAssertEqual(sut.loginStatus, LoginStatus.succeeded(userAccount: userAccount))
+    }
+    
+    func test_login_fails() async throws {
+        // GIVEN
+        let userAccount = UserAccount.makeStub()
+        let loginProviderMock = LoginProviderMock(userResult: userAccount, errorResult: ClientError.expired)
+        let loginWithCredentialsUseCase = LoginWithCredentialsUseCase(loginProvider: loginProviderMock,
+                                    errorMapper: LoginDomainErrorMapper())
+        
+        let sut = LoginViewModel(loginWithCredentialsUseCase: loginWithCredentialsUseCase,
+                                 checkLoginAvailability: CheckLoginAvailability(),
+                                 validateLoginCredentials: ValidateCredentialsFormat(),
+                                 errorMapper: LoginPresentableErrorMapper())
+        
+        XCTAssertEqual(sut.loginStatus, .none)
+        
+        // WHEN
+        await sut.login(username: "username", password: "password")
+        
+        // THEN
+        XCTAssertEqual(sut.loginStatus, .failed(error: .expired))
+    }
+}

--- a/PIA VPN-tvOSTests/Login/LoginIntegrationTests.swift
+++ b/PIA VPN-tvOSTests/Login/LoginIntegrationTests.swift
@@ -14,10 +14,15 @@ final class LoginIntegrationTests: XCTestCase {
 
     func test_login_succeeds() async throws {
         // GIVEN
-        let userAccount = UserAccount.makeStub()
-        let loginProviderMock = LoginProviderMock(userResult: userAccount, errorResult: nil)
-        let loginWithCredentialsUseCase = LoginWithCredentialsUseCase(loginProvider: loginProviderMock,
-                                    errorMapper: LoginDomainErrorMapper())
+        let userAccount = PIALibrary.UserAccount.makeStub()
+        let accountProviderMock = AccountProviderMock(userResult: userAccount,
+                                                      errorResult: nil)
+        
+        let loginProvider = LoginProvider(accountProvider: accountProviderMock,
+                                          userAccountMapper: UserAccountMapper())
+        
+        let loginWithCredentialsUseCase = LoginWithCredentialsUseCase(loginProvider: loginProvider,
+                                                                      errorMapper: LoginDomainErrorMapper())
         
         let sut = LoginViewModel(loginWithCredentialsUseCase: loginWithCredentialsUseCase,
                                  checkLoginAvailability: CheckLoginAvailability(),
@@ -30,14 +35,44 @@ final class LoginIntegrationTests: XCTestCase {
         await sut.login(username: "username", password: "password")
         
         // THEN
-        XCTAssertEqual(sut.loginStatus, LoginStatus.succeeded(userAccount: userAccount))
+        guard case .succeeded(let capturedUserResult) = sut.loginStatus else {
+            XCTFail("Expected success, got failure")
+            return
+        }
+        
+        XCTAssertEqual(capturedUserResult.credentials.username, userAccount.credentials.username)
+        XCTAssertEqual(capturedUserResult.credentials.password, userAccount.credentials.password)
+        XCTAssertEqual(capturedUserResult.isRenewable, userAccount.isRenewable)
+        XCTAssertEqual(capturedUserResult.info?.email, userAccount.info?.email)
+        XCTAssertEqual(capturedUserResult.info?.username, userAccount.info?.username)
+        XCTAssertEqual(capturedUserResult.info?.productId, userAccount.info?.productId)
+        XCTAssertEqual(capturedUserResult.info?.isRenewable, userAccount.info?.isRenewable)
+        XCTAssertEqual(capturedUserResult.info?.isRecurring, userAccount.info?.isRecurring)
+        XCTAssertEqual(capturedUserResult.info?.expirationDate, userAccount.info?.expirationDate)
+        XCTAssertEqual(capturedUserResult.info?.canInvite, userAccount.info?.canInvite)
+    
+        let capturedPlan = try XCTUnwrap(capturedUserResult.info?.plan)
+        let userPlan = try XCTUnwrap(userAccount.info?.plan)
+        
+        switch (capturedPlan, userPlan) {
+            case (PIA_VPN_tvOS.Plan.monthly, PIALibrary.Plan.monthly), (PIA_VPN_tvOS.Plan.yearly, PIALibrary.Plan.yearly), (PIA_VPN_tvOS.Plan.trial, PIALibrary.Plan.trial), (PIA_VPN_tvOS.Plan.other, PIALibrary.Plan.other):
+                XCTAssertTrue(true)
+            default:
+                XCTFail("Expected the same plan, got \(capturedPlan) and \(userPlan)")
+        }
+        
+        
     }
     
     func test_login_fails() async throws {
         // GIVEN
-        let userAccount = UserAccount.makeStub()
-        let loginProviderMock = LoginProviderMock(userResult: userAccount, errorResult: ClientError.expired)
-        let loginWithCredentialsUseCase = LoginWithCredentialsUseCase(loginProvider: loginProviderMock,
+        let accountProviderMock = AccountProviderMock(userResult: nil,
+                                                      errorResult: ClientError.expired)
+        
+        let loginProvider = LoginProvider(accountProvider: accountProviderMock,
+                                          userAccountMapper: UserAccountMapper())
+        
+        let loginWithCredentialsUseCase = LoginWithCredentialsUseCase(loginProvider: loginProvider,
                                     errorMapper: LoginDomainErrorMapper())
         
         let sut = LoginViewModel(loginWithCredentialsUseCase: loginWithCredentialsUseCase,

--- a/PIA VPN-tvOSTests/Login/LoginViewModelTests.swift
+++ b/PIA VPN-tvOSTests/Login/LoginViewModelTests.swift
@@ -7,19 +7,7 @@
 //
 
 import XCTest
-import PIALibrary
-import account
 @testable import PIA_VPN_tvOS
-
-/*
- - success
- - isloggin
- - failure: availability
- - failure: valid credentials
- - failure: loginusecase
- */
-
-
 
 final class LoginViewModelTests: XCTestCase {
     
@@ -37,13 +25,13 @@ final class LoginViewModelTests: XCTestCase {
                                  validateLoginCredentials: ValidateCredentialsFormat(),
                                  errorMapper: LoginPresentableErrorMapper())
         
-        XCTAssertEqual(sut.loginStatus, .none)
+        XCTAssertEqual(sut.loginStatus, LoginStatus.none)
         
         // WHEN
         await sut.login(username: "username", password: "password")
         
         // THEN
-        XCTAssertEqual(sut.loginStatus, .failed(error: .throttled(retryAfter: 20)))
+        XCTAssertEqual(sut.loginStatus, LoginStatus.failed(error: .throttled(retryAfter: 20)))
     }
     
     func test_login_fails_when_username_is_invalid() async throws {
@@ -60,13 +48,13 @@ final class LoginViewModelTests: XCTestCase {
                                  validateLoginCredentials: ValidateCredentialsFormat(),
                                  errorMapper: LoginPresentableErrorMapper())
         
-        XCTAssertEqual(sut.loginStatus, .none)
+        XCTAssertEqual(sut.loginStatus, LoginStatus.none)
         
         // WHEN
         await sut.login(username: "", password: "password")
         
         // THEN
-        XCTAssertEqual(sut.loginStatus, .failed(error: .usernameWrongFormat))
+        XCTAssertEqual(sut.loginStatus, LoginStatus.failed(error: .usernameWrongFormat))
     }
     
     func test_login_fails_when_password_is_invalid() async throws {
@@ -83,13 +71,13 @@ final class LoginViewModelTests: XCTestCase {
                                  validateLoginCredentials: ValidateCredentialsFormat(),
                                  errorMapper: LoginPresentableErrorMapper())
         
-        XCTAssertEqual(sut.loginStatus, .none)
+        XCTAssertEqual(sut.loginStatus, LoginStatus.none)
         
         // WHEN
         await sut.login(username: "username", password: "")
         
         // THEN
-        XCTAssertEqual(sut.loginStatus, .failed(error: .passwordWrongFormat))
+        XCTAssertEqual(sut.loginStatus, LoginStatus.failed(error: .passwordWrongFormat))
     }
     
     
@@ -107,7 +95,7 @@ final class LoginViewModelTests: XCTestCase {
                                  validateLoginCredentials: ValidateCredentialsFormat(),
                                  errorMapper: LoginPresentableErrorMapper())
         
-        XCTAssertEqual(sut.loginStatus, .none)
+        XCTAssertEqual(sut.loginStatus, LoginStatus.none)
         
         // WHEN
         await sut.login(username: "username", password: "password")
@@ -129,12 +117,12 @@ final class LoginViewModelTests: XCTestCase {
                                  validateLoginCredentials: ValidateCredentialsFormat(),
                                  errorMapper: LoginPresentableErrorMapper())
         
-        XCTAssertEqual(sut.loginStatus, .none)
+        XCTAssertEqual(sut.loginStatus, LoginStatus.none)
         
         // WHEN
         await sut.login(username: "username", password: "password")
         
         // THEN
-        XCTAssertEqual(sut.loginStatus, .failed(error: .unauthorized))
+        XCTAssertEqual(sut.loginStatus, LoginStatus.failed(error: .unauthorized))
     }
 }

--- a/PIA VPN-tvOSTests/Login/LoginViewModelTests.swift
+++ b/PIA VPN-tvOSTests/Login/LoginViewModelTests.swift
@@ -1,0 +1,140 @@
+//
+//  LoginViewModelTests.swift
+//  PIA VPN-tvOSTests
+//
+//  Created by Said Rehouni on 23/11/23.
+//  Copyright © 2023 Private Internet Access Inc. All rights reserved.
+//
+
+import XCTest
+import PIALibrary
+import account
+@testable import PIA_VPN_tvOS
+
+/*
+ - success
+ - isloggin
+ - failure: availability
+ - failure: valid credentials
+ - failure: loginusecase
+ */
+
+
+
+final class LoginViewModelTests: XCTestCase {
+    
+    func test_login_fails_when_checkAvailability_returns_failure() async throws {
+        // GIVEN
+        let userAccount = UserAccount.makeStub()
+        let resultLoginUseCase: Result<UserAccount, LoginError> = .success(userAccount)
+        let loginWithCredentialsUseCaseMock = LoginWithCredentialsUseCaseMock(result: resultLoginUseCase)
+        
+        let resultCheckLoginAvailability: Result<Void, LoginError> = .failure(.throttled(retryAfter: 20))
+        let checkLoginAvailabilityMock = CheckLoginAvailabilityMock(result: resultCheckLoginAvailability)
+        
+        let sut = LoginViewModel(loginWithCredentialsUseCase: loginWithCredentialsUseCaseMock,
+                                 checkLoginAvailability: checkLoginAvailabilityMock,
+                                 validateLoginCredentials: ValidateCredentialsFormat(),
+                                 errorMapper: LoginPresentableErrorMapper())
+        
+        XCTAssertEqual(sut.loginStatus, .none)
+        
+        // WHEN
+        await sut.login(username: "username", password: "password")
+        
+        // THEN
+        XCTAssertEqual(sut.loginStatus, .failed(error: .throttled(retryAfter: 20)))
+    }
+    
+    func test_login_fails_when_username_is_invalid() async throws {
+        // GIVEN
+        let userAccount = UserAccount.makeStub()
+        let resultLoginUseCase: Result<UserAccount, LoginError> = .success(userAccount)
+        let loginWithCredentialsUseCaseMock = LoginWithCredentialsUseCaseMock(result: resultLoginUseCase)
+        
+        let resultCheckLoginAvailability: Result<Void, LoginError> = .success(())
+        let checkLoginAvailabilityMock = CheckLoginAvailabilityMock(result: resultCheckLoginAvailability)
+        
+        let sut = LoginViewModel(loginWithCredentialsUseCase: loginWithCredentialsUseCaseMock,
+                                 checkLoginAvailability: checkLoginAvailabilityMock,
+                                 validateLoginCredentials: ValidateCredentialsFormat(),
+                                 errorMapper: LoginPresentableErrorMapper())
+        
+        XCTAssertEqual(sut.loginStatus, .none)
+        
+        // WHEN
+        await sut.login(username: "", password: "password")
+        
+        // THEN
+        XCTAssertEqual(sut.loginStatus, .failed(error: .usernameWrongFormat))
+    }
+    
+    func test_login_fails_when_password_is_invalid() async throws {
+        // GIVEN
+        let userAccount = UserAccount.makeStub()
+        let resultLoginUseCase: Result<UserAccount, LoginError> = .success(userAccount)
+        let loginWithCredentialsUseCaseMock = LoginWithCredentialsUseCaseMock(result: resultLoginUseCase)
+        
+        let resultCheckLoginAvailability: Result<Void, LoginError> = .success(())
+        let checkLoginAvailabilityMock = CheckLoginAvailabilityMock(result: resultCheckLoginAvailability)
+        
+        let sut = LoginViewModel(loginWithCredentialsUseCase: loginWithCredentialsUseCaseMock,
+                                 checkLoginAvailability: checkLoginAvailabilityMock,
+                                 validateLoginCredentials: ValidateCredentialsFormat(),
+                                 errorMapper: LoginPresentableErrorMapper())
+        
+        XCTAssertEqual(sut.loginStatus, .none)
+        
+        // WHEN
+        await sut.login(username: "username", password: "")
+        
+        // THEN
+        XCTAssertEqual(sut.loginStatus, .failed(error: .passwordWrongFormat))
+    }
+    
+    
+    func test_login_succeeds_when_loginUseCase_completes_with_success() async throws {
+        // GIVEN
+        let userAccount = UserAccount.makeStub()
+        let resultLoginUseCase: Result<UserAccount, LoginError> = .success(userAccount)
+        let loginWithCredentialsUseCaseMock = LoginWithCredentialsUseCaseMock(result: resultLoginUseCase)
+        
+        let resultCheckLoginAvailability: Result<Void, LoginError> = .success(())
+        let checkLoginAvailabilityMock = CheckLoginAvailabilityMock(result: resultCheckLoginAvailability)
+        
+        let sut = LoginViewModel(loginWithCredentialsUseCase: loginWithCredentialsUseCaseMock,
+                                 checkLoginAvailability: checkLoginAvailabilityMock,
+                                 validateLoginCredentials: ValidateCredentialsFormat(),
+                                 errorMapper: LoginPresentableErrorMapper())
+        
+        XCTAssertEqual(sut.loginStatus, .none)
+        
+        // WHEN
+        await sut.login(username: "username", password: "password")
+        
+        // THEN
+        XCTAssertEqual(sut.loginStatus, LoginStatus.succeeded(userAccount: userAccount))
+    }
+    
+    func test_login_fails_when_loginUseCase_completes_with_failure() async throws {
+        // GIVEN
+        let resultLoginUseCase: Result<UserAccount, LoginError> = .failure(.unauthorized)
+        let loginWithCredentialsUseCaseMock = LoginWithCredentialsUseCaseMock(result: resultLoginUseCase)
+        
+        let resultCheckLoginAvailability: Result<Void, LoginError> = .success(())
+        let checkLoginAvailabilityMock = CheckLoginAvailabilityMock(result: resultCheckLoginAvailability)
+        
+        let sut = LoginViewModel(loginWithCredentialsUseCase: loginWithCredentialsUseCaseMock,
+                                 checkLoginAvailability: checkLoginAvailabilityMock,
+                                 validateLoginCredentials: ValidateCredentialsFormat(),
+                                 errorMapper: LoginPresentableErrorMapper())
+        
+        XCTAssertEqual(sut.loginStatus, .none)
+        
+        // WHEN
+        await sut.login(username: "username", password: "password")
+        
+        // THEN
+        XCTAssertEqual(sut.loginStatus, .failed(error: .unauthorized))
+    }
+}

--- a/PIA VPN-tvOSTests/Login/LoginWithCredentialsUseCaseTests.swift
+++ b/PIA VPN-tvOSTests/Login/LoginWithCredentialsUseCaseTests.swift
@@ -1,0 +1,104 @@
+//
+//  LoginWithCredentialsUseCaseTests.swift
+//  PIA VPN-tvOSTests
+//
+//  Created by Said Rehouni on 4/12/23.
+//  Copyright © 2023 Private Internet Access Inc. All rights reserved.
+//
+
+import XCTest
+import PIALibrary
+@testable import PIA_VPN_tvOS
+
+final class LoginWithCredentialsUseCaseTests: XCTestCase {
+
+    func test_login_succeeds_when_loginprovider_completes_with_user_and_no_error() throws {
+        // GIVEN
+        let user = UserAccount.makeStub()
+        let loginProviderMock = LoginProviderMock(userResult: user, errorResult: nil)
+        let sut = LoginWithCredentialsUseCase(loginProvider: loginProviderMock,
+                                              errorMapper: LoginDomainErrorMapper())
+        
+        var capturedResult: Result<UserAccount, LoginError>?
+        let expectation = expectation(description: "Waiting for login to finish")
+        
+        // WHEN
+        sut.execute(username: "", password: "") { result in
+            expectation.fulfill()
+            capturedResult = result
+        }
+        
+        // THEN
+        wait(for: [expectation], timeout: 1.0)
+        XCTAssertEqual(capturedResult, .success(user))
+    }
+    
+    func test_login_fails_when_loginprovider_completes_with_user_and_error() throws {
+        // GIVEN
+        let user = UserAccount.makeStub()
+        let loginProviderMock = LoginProviderMock(userResult: user, errorResult: ClientError.expired)
+        let sut = LoginWithCredentialsUseCase(loginProvider: loginProviderMock,
+                                              errorMapper: LoginDomainErrorMapper())
+        
+        var capturedResult: Result<UserAccount, LoginError>?
+        let expectation = expectation(description: "Waiting for login to finish")
+        
+        // WHEN
+        sut.execute(username: "", password: "") { result in
+            expectation.fulfill()
+            capturedResult = result
+        }
+        
+        // THEN
+        wait(for: [expectation], timeout: 1.0)
+        XCTAssertEqual(capturedResult, .failure(.expired))
+    }
+    
+    func test_login_fails_when_loginprovider_completes_with_no_user_and_error() throws {
+        // GIVEN
+        let loginProviderMock = LoginProviderMock(userResult: nil, errorResult: ClientError.expired)
+        let sut = LoginWithCredentialsUseCase(loginProvider: loginProviderMock,
+                                              errorMapper: LoginDomainErrorMapper())
+        
+        var capturedResult: Result<UserAccount, LoginError>?
+        let expectation = expectation(description: "Waiting for login to finish")
+        
+        // WHEN
+        sut.execute(username: "", password: "") { result in
+            expectation.fulfill()
+            capturedResult = result
+        }
+        
+        // THEN
+        wait(for: [expectation], timeout: 1.0)
+        XCTAssertEqual(capturedResult, .failure(.expired))
+    }
+    
+    func test_login_fails_when_loginprovider_completes_with_no_user_and_no_error() throws {
+        // GIVEN
+        let loginProviderMock = LoginProviderMock(userResult: nil, errorResult: nil)
+        let sut = LoginWithCredentialsUseCase(loginProvider: loginProviderMock,
+                                              errorMapper: LoginDomainErrorMapper())
+        
+        var capturedResult: Result<UserAccount, LoginError>?
+        let expectation = expectation(description: "Waiting for login to finish")
+        
+        // WHEN
+        sut.execute(username: "", password: "") { result in
+            expectation.fulfill()
+            capturedResult = result
+        }
+        
+        // THEN
+        wait(for: [expectation], timeout: 1.0)
+        guard case .failure(let error) = capturedResult else {
+            XCTFail("Expected failure, got success")
+            return
+        }
+        
+        guard case LoginError.generic = error else {
+            XCTFail("Expected generic error, got \(error)")
+            return
+        }
+    }
+}

--- a/PIA VPN-tvOSTests/Login/LoginWithCredentialsUseCaseTests.swift
+++ b/PIA VPN-tvOSTests/Login/LoginWithCredentialsUseCaseTests.swift
@@ -12,14 +12,14 @@ import PIALibrary
 
 final class LoginWithCredentialsUseCaseTests: XCTestCase {
 
-    func test_login_succeeds_when_loginprovider_completes_with_user_and_no_error() throws {
+    func test_login_succeeds_when_loginprovider_completes_with_success() {
         // GIVEN
-        let user = UserAccount.makeStub()
-        let loginProviderMock = LoginProviderMock(userResult: user, errorResult: nil)
+        let user = PIA_VPN_tvOS.UserAccount.makeStub()
+        let loginProviderMock = LoginProviderMock(result: .success(user))
         let sut = LoginWithCredentialsUseCase(loginProvider: loginProviderMock,
                                               errorMapper: LoginDomainErrorMapper())
         
-        var capturedResult: Result<UserAccount, LoginError>?
+        var capturedResult: Result<PIA_VPN_tvOS.UserAccount, LoginError>?
         let expectation = expectation(description: "Waiting for login to finish")
         
         // WHEN
@@ -33,14 +33,13 @@ final class LoginWithCredentialsUseCaseTests: XCTestCase {
         XCTAssertEqual(capturedResult, .success(user))
     }
     
-    func test_login_fails_when_loginprovider_completes_with_user_and_error() throws {
+    func test_login_fails_when_loginprovider_completes_with_failure() {
         // GIVEN
-        let user = UserAccount.makeStub()
-        let loginProviderMock = LoginProviderMock(userResult: user, errorResult: ClientError.expired)
+        let loginProviderMock = LoginProviderMock(result: .failure(ClientError.expired))
         let sut = LoginWithCredentialsUseCase(loginProvider: loginProviderMock,
                                               errorMapper: LoginDomainErrorMapper())
         
-        var capturedResult: Result<UserAccount, LoginError>?
+        var capturedResult: Result<PIA_VPN_tvOS.UserAccount, LoginError>?
         let expectation = expectation(description: "Waiting for login to finish")
         
         // WHEN
@@ -52,53 +51,5 @@ final class LoginWithCredentialsUseCaseTests: XCTestCase {
         // THEN
         wait(for: [expectation], timeout: 1.0)
         XCTAssertEqual(capturedResult, .failure(.expired))
-    }
-    
-    func test_login_fails_when_loginprovider_completes_with_no_user_and_error() throws {
-        // GIVEN
-        let loginProviderMock = LoginProviderMock(userResult: nil, errorResult: ClientError.expired)
-        let sut = LoginWithCredentialsUseCase(loginProvider: loginProviderMock,
-                                              errorMapper: LoginDomainErrorMapper())
-        
-        var capturedResult: Result<UserAccount, LoginError>?
-        let expectation = expectation(description: "Waiting for login to finish")
-        
-        // WHEN
-        sut.execute(username: "", password: "") { result in
-            expectation.fulfill()
-            capturedResult = result
-        }
-        
-        // THEN
-        wait(for: [expectation], timeout: 1.0)
-        XCTAssertEqual(capturedResult, .failure(.expired))
-    }
-    
-    func test_login_fails_when_loginprovider_completes_with_no_user_and_no_error() throws {
-        // GIVEN
-        let loginProviderMock = LoginProviderMock(userResult: nil, errorResult: nil)
-        let sut = LoginWithCredentialsUseCase(loginProvider: loginProviderMock,
-                                              errorMapper: LoginDomainErrorMapper())
-        
-        var capturedResult: Result<UserAccount, LoginError>?
-        let expectation = expectation(description: "Waiting for login to finish")
-        
-        // WHEN
-        sut.execute(username: "", password: "") { result in
-            expectation.fulfill()
-            capturedResult = result
-        }
-        
-        // THEN
-        wait(for: [expectation], timeout: 1.0)
-        guard case .failure(let error) = capturedResult else {
-            XCTFail("Expected failure, got success")
-            return
-        }
-        
-        guard case LoginError.generic = error else {
-            XCTFail("Expected generic error, got \(error)")
-            return
-        }
     }
 }

--- a/PIA VPN.xcodeproj/project.pbxproj
+++ b/PIA VPN.xcodeproj/project.pbxproj
@@ -527,6 +527,15 @@
 		E5AB28712B279B4000744E5F /* LoginProviderType.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5AB28702B279B4000744E5F /* LoginProviderType.swift */; };
 		E5AB28732B279B7000744E5F /* LoginProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5AB28722B279B7000744E5F /* LoginProvider.swift */; };
 		E5AB28752B279BB600744E5F /* LoginIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5AB28742B279BB600744E5F /* LoginIntegrationTests.swift */; };
+		E5AB28772B28B49A00744E5F /* UserAccount.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5AB28762B28B49A00744E5F /* UserAccount.swift */; };
+		E5AB28792B28B4B300744E5F /* AccountInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5AB28782B28B4B300744E5F /* AccountInfo.swift */; };
+		E5AB287B2B28B4C400744E5F /* Credentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5AB287A2B28B4C400744E5F /* Credentials.swift */; };
+		E5AB287D2B28E4E700744E5F /* UserAccountMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5AB287C2B28E4E700744E5F /* UserAccountMapper.swift */; };
+		E5AB287F2B28F6EF00744E5F /* Stubs.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5AB287E2B28F6EF00744E5F /* Stubs.swift */; };
+		E5AB28832B2902E200744E5F /* Stubs+PIALibrary.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5AB28822B2902E200744E5F /* Stubs+PIALibrary.swift */; };
+		E5AB28852B2902E700744E5F /* LoginProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5AB28842B2902E700744E5F /* LoginProviderTests.swift */; };
+		E5AB28872B2911C900744E5F /* AccountProviderMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5AB28862B2911C900744E5F /* AccountProviderMock.swift */; };
+		E5AB288A2B29BDED00744E5F /* Foundation+PIA.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5AB28892B29BDED00744E5F /* Foundation+PIA.swift */; };
 		E5C507682B0D609300200A6A /* PIALibrary in Frameworks */ = {isa = PBXBuildFile; productRef = E5C507672B0D609300200A6A /* PIALibrary */; };
 		E5C5076A2B0D60A500200A6A /* PIALibrary in Frameworks */ = {isa = PBXBuildFile; productRef = E5C507692B0D60A500200A6A /* PIALibrary */; };
 		E5C5076C2B0D60AD00200A6A /* PIALibrary in Frameworks */ = {isa = PBXBuildFile; productRef = E5C5076B2B0D60AD00200A6A /* PIALibrary */; };
@@ -551,7 +560,6 @@
 		E5C507B32B17E5AD00200A6A /* LoginError.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5C507B22B17E5AD00200A6A /* LoginError.swift */; };
 		E5C507B72B17E75B00200A6A /* CheckLoginAvailability.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5C507B62B17E75B00200A6A /* CheckLoginAvailability.swift */; };
 		E5C507B92B17E7A400200A6A /* ValidateCredentialsFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5C507B82B17E7A400200A6A /* ValidateCredentialsFormat.swift */; };
-		E5C507BC2B1F6F6C00200A6A /* Stubs.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5C507BB2B1F6F6C00200A6A /* Stubs.swift */; };
 		E5C507BE2B1F6FA600200A6A /* Equatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5C507BD2B1F6FA600200A6A /* Equatable.swift */; };
 		E5C507C02B1F700C00200A6A /* CheckLoginAvailabilityMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5C507BF2B1F700C00200A6A /* CheckLoginAvailabilityMock.swift */; };
 		E5C507C22B1F702700200A6A /* LoginWithCredentialsUseCaseMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5C507C12B1F702700200A6A /* LoginWithCredentialsUseCaseMock.swift */; };
@@ -1092,6 +1100,15 @@
 		E5AB28702B279B4000744E5F /* LoginProviderType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginProviderType.swift; sourceTree = "<group>"; };
 		E5AB28722B279B7000744E5F /* LoginProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginProvider.swift; sourceTree = "<group>"; };
 		E5AB28742B279BB600744E5F /* LoginIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginIntegrationTests.swift; sourceTree = "<group>"; };
+		E5AB28762B28B49A00744E5F /* UserAccount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserAccount.swift; sourceTree = "<group>"; };
+		E5AB28782B28B4B300744E5F /* AccountInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountInfo.swift; sourceTree = "<group>"; };
+		E5AB287A2B28B4C400744E5F /* Credentials.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Credentials.swift; sourceTree = "<group>"; };
+		E5AB287C2B28E4E700744E5F /* UserAccountMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserAccountMapper.swift; sourceTree = "<group>"; };
+		E5AB287E2B28F6EF00744E5F /* Stubs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Stubs.swift; sourceTree = "<group>"; };
+		E5AB28822B2902E200744E5F /* Stubs+PIALibrary.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "Stubs+PIALibrary.swift"; path = "../../../../../../../.Trash/Stubs+PIALibrary.swift"; sourceTree = "<group>"; };
+		E5AB28842B2902E700744E5F /* LoginProviderTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = LoginProviderTests.swift; path = ../../../../../../.Trash/LoginProviderTests.swift; sourceTree = "<group>"; };
+		E5AB28862B2911C900744E5F /* AccountProviderMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountProviderMock.swift; sourceTree = "<group>"; };
+		E5AB28892B29BDED00744E5F /* Foundation+PIA.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Foundation+PIA.swift"; sourceTree = "<group>"; };
 		E5C507772B0E144D00200A6A /* PIA VPN-tvOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "PIA VPN-tvOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		E5C507792B0E144E00200A6A /* PIA_VPN_tvOSApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PIA_VPN_tvOSApp.swift; sourceTree = "<group>"; };
 		E5C5077B2B0E144E00200A6A /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -1110,7 +1127,6 @@
 		E5C507B22B17E5AD00200A6A /* LoginError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginError.swift; sourceTree = "<group>"; };
 		E5C507B62B17E75B00200A6A /* CheckLoginAvailability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckLoginAvailability.swift; sourceTree = "<group>"; };
 		E5C507B82B17E7A400200A6A /* ValidateCredentialsFormat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValidateCredentialsFormat.swift; sourceTree = "<group>"; };
-		E5C507BB2B1F6F6C00200A6A /* Stubs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Stubs.swift; sourceTree = "<group>"; };
 		E5C507BD2B1F6FA600200A6A /* Equatable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Equatable.swift; sourceTree = "<group>"; };
 		E5C507BF2B1F700C00200A6A /* CheckLoginAvailabilityMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckLoginAvailabilityMock.swift; sourceTree = "<group>"; };
 		E5C507C12B1F702700200A6A /* LoginWithCredentialsUseCaseMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginWithCredentialsUseCaseMock.swift; sourceTree = "<group>"; };
@@ -2007,6 +2023,14 @@
 			path = CompositionRoot;
 			sourceTree = "<group>";
 		};
+		E5AB28882B29BDC700744E5F /* Utils */ = {
+			isa = PBXGroup;
+			children = (
+				E5AB28892B29BDED00744E5F /* Foundation+PIA.swift */,
+			);
+			path = Utils;
+			sourceTree = "<group>";
+		};
 		E5C507782B0E144E00200A6A /* PIA VPN-tvOS */ = {
 			isa = PBXGroup;
 			children = (
@@ -2048,6 +2072,7 @@
 		E5C507A32B153A1800200A6A /* Login */ = {
 			isa = PBXGroup;
 			children = (
+				E5AB28882B29BDC700744E5F /* Utils */,
 				E5AB286D2B27975E00744E5F /* CompositionRoot */,
 				E5C507C82B1FAC2B00200A6A /* Data */,
 				E5C507AF2B17E47A00200A6A /* Domain */,
@@ -2065,6 +2090,7 @@
 				E5C507C32B1F72E700200A6A /* CheckLoginAvailabilityTests.swift */,
 				E5C507CB2B1FACE000200A6A /* LoginWithCredentialsUseCaseTests.swift */,
 				E5AB28742B279BB600744E5F /* LoginIntegrationTests.swift */,
+				E5AB28842B2902E700744E5F /* LoginProviderTests.swift */,
 			);
 			path = Login;
 			sourceTree = "<group>";
@@ -2110,6 +2136,9 @@
 			isa = PBXGroup;
 			children = (
 				E5C507B22B17E5AD00200A6A /* LoginError.swift */,
+				E5AB28762B28B49A00744E5F /* UserAccount.swift */,
+				E5AB28782B28B4B300744E5F /* AccountInfo.swift */,
+				E5AB287A2B28B4C400744E5F /* Credentials.swift */,
 			);
 			path = Entities;
 			sourceTree = "<group>";
@@ -2117,11 +2146,13 @@
 		E5C507BA2B1F6F3800200A6A /* Helpers */ = {
 			isa = PBXGroup;
 			children = (
-				E5C507BB2B1F6F6C00200A6A /* Stubs.swift */,
 				E5C507BD2B1F6FA600200A6A /* Equatable.swift */,
 				E5C507BF2B1F700C00200A6A /* CheckLoginAvailabilityMock.swift */,
 				E5C507C12B1F702700200A6A /* LoginWithCredentialsUseCaseMock.swift */,
 				E5AB286B2B2796E700744E5F /* LoginProviderMock.swift */,
+				E5AB287E2B28F6EF00744E5F /* Stubs.swift */,
+				E5AB28822B2902E200744E5F /* Stubs+PIALibrary.swift */,
+				E5AB28862B2911C900744E5F /* AccountProviderMock.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -2140,6 +2171,7 @@
 			children = (
 				E5C507C92B1FAC3600200A6A /* LoginDomainErrorMapper.swift */,
 				E5AB28722B279B7000744E5F /* LoginProvider.swift */,
+				E5AB287C2B28E4E700744E5F /* UserAccountMapper.swift */,
 			);
 			path = Data;
 			sourceTree = "<group>";
@@ -3234,16 +3266,21 @@
 				E5C507A52B153A2F00200A6A /* LoginViewModel.swift in Sources */,
 				E5C507B72B17E75B00200A6A /* CheckLoginAvailability.swift in Sources */,
 				E5AB286F2B27977000744E5F /* LoginFactory.swift in Sources */,
+				E5AB288A2B29BDED00744E5F /* Foundation+PIA.swift in Sources */,
 				E5C507A22B0FE40000200A6A /* LoginView.swift in Sources */,
+				E5AB287D2B28E4E700744E5F /* UserAccountMapper.swift in Sources */,
+				E5AB28792B28B4B300744E5F /* AccountInfo.swift in Sources */,
 				E5C507B12B17E48900200A6A /* LoginWithCredentialsUseCase.swift in Sources */,
 				E5C507B92B17E7A400200A6A /* ValidateCredentialsFormat.swift in Sources */,
 				E5C507AE2B17E45800200A6A /* LoginPresentableErrorMapper.swift in Sources */,
 				E5AB28712B279B4000744E5F /* LoginProviderType.swift in Sources */,
+				E5AB287B2B28B4C400744E5F /* Credentials.swift in Sources */,
 				E5C5077C2B0E144E00200A6A /* ContentView.swift in Sources */,
 				E5C5077A2B0E144E00200A6A /* PIA_VPN_tvOSApp.swift in Sources */,
 				E5C507C72B1FABFF00200A6A /* LoginDomainErrorMapperType.swift in Sources */,
 				E5C507B32B17E5AD00200A6A /* LoginError.swift in Sources */,
 				E5C507CA2B1FAC3600200A6A /* LoginDomainErrorMapper.swift in Sources */,
+				E5AB28772B28B49A00744E5F /* UserAccount.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3252,11 +3289,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				E5C507CC2B1FACE000200A6A /* LoginWithCredentialsUseCaseTests.swift in Sources */,
-				E5C507BC2B1F6F6C00200A6A /* Stubs.swift in Sources */,
 				E5C507A82B153E6B00200A6A /* LoginViewModelTests.swift in Sources */,
 				E5AB286C2B2796E700744E5F /* LoginProviderMock.swift in Sources */,
 				E5C507BE2B1F6FA600200A6A /* Equatable.swift in Sources */,
+				E5AB28872B2911C900744E5F /* AccountProviderMock.swift in Sources */,
 				E5C5078B2B0E145100200A6A /* PIA_VPN_tvOSTests.swift in Sources */,
+				E5AB287F2B28F6EF00744E5F /* Stubs.swift in Sources */,
+				E5AB28852B2902E700744E5F /* LoginProviderTests.swift in Sources */,
+				E5AB28832B2902E200744E5F /* Stubs+PIALibrary.swift in Sources */,
 				E5AB28752B279BB600744E5F /* LoginIntegrationTests.swift in Sources */,
 				E5C507C22B1F702700200A6A /* LoginWithCredentialsUseCaseMock.swift in Sources */,
 				E5C507C42B1F72E700200A6A /* CheckLoginAvailabilityTests.swift in Sources */,

--- a/PIA VPN.xcodeproj/project.pbxproj
+++ b/PIA VPN.xcodeproj/project.pbxproj
@@ -522,6 +522,11 @@
 		E59E8FC62AEA7A81009278F5 /* TermsAndConditionsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E59E8FA72AEA7A81009278F5 /* TermsAndConditionsViewController.swift */; };
 		E59E8FC72AEA7A81009278F5 /* OptionsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E59E8FA82AEA7A81009278F5 /* OptionsViewController.swift */; };
 		E59E8FC82AEA7A81009278F5 /* OptionsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E59E8FA82AEA7A81009278F5 /* OptionsViewController.swift */; };
+		E5AB286C2B2796E700744E5F /* LoginProviderMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5AB286B2B2796E700744E5F /* LoginProviderMock.swift */; };
+		E5AB286F2B27977000744E5F /* LoginFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5AB286E2B27977000744E5F /* LoginFactory.swift */; };
+		E5AB28712B279B4000744E5F /* LoginProviderType.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5AB28702B279B4000744E5F /* LoginProviderType.swift */; };
+		E5AB28732B279B7000744E5F /* LoginProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5AB28722B279B7000744E5F /* LoginProvider.swift */; };
+		E5AB28752B279BB600744E5F /* LoginIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5AB28742B279BB600744E5F /* LoginIntegrationTests.swift */; };
 		E5C507682B0D609300200A6A /* PIALibrary in Frameworks */ = {isa = PBXBuildFile; productRef = E5C507672B0D609300200A6A /* PIALibrary */; };
 		E5C5076A2B0D60A500200A6A /* PIALibrary in Frameworks */ = {isa = PBXBuildFile; productRef = E5C507692B0D60A500200A6A /* PIALibrary */; };
 		E5C5076C2B0D60AD00200A6A /* PIALibrary in Frameworks */ = {isa = PBXBuildFile; productRef = E5C5076B2B0D60AD00200A6A /* PIALibrary */; };
@@ -537,6 +542,23 @@
 		E5C5078B2B0E145100200A6A /* PIA_VPN_tvOSTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5C5078A2B0E145100200A6A /* PIA_VPN_tvOSTests.swift */; };
 		E5C507952B0E145100200A6A /* PIA_VPN_tvOSUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5C507942B0E145100200A6A /* PIA_VPN_tvOSUITests.swift */; };
 		E5C507972B0E145100200A6A /* PIA_VPN_tvOSUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5C507962B0E145100200A6A /* PIA_VPN_tvOSUITestsLaunchTests.swift */; };
+		E5C507A22B0FE40000200A6A /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5C507A12B0FE40000200A6A /* LoginView.swift */; };
+		E5C507A52B153A2F00200A6A /* LoginViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5C507A42B153A2F00200A6A /* LoginViewModel.swift */; };
+		E5C507A82B153E6B00200A6A /* LoginViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5C507A72B153E6B00200A6A /* LoginViewModelTests.swift */; };
+		E5C507AA2B17E3F100200A6A /* PIALibrary in Frameworks */ = {isa = PBXBuildFile; productRef = E5C507A92B17E3F100200A6A /* PIALibrary */; };
+		E5C507AE2B17E45800200A6A /* LoginPresentableErrorMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5C507AD2B17E45800200A6A /* LoginPresentableErrorMapper.swift */; };
+		E5C507B12B17E48900200A6A /* LoginWithCredentialsUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5C507B02B17E48900200A6A /* LoginWithCredentialsUseCase.swift */; };
+		E5C507B32B17E5AD00200A6A /* LoginError.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5C507B22B17E5AD00200A6A /* LoginError.swift */; };
+		E5C507B72B17E75B00200A6A /* CheckLoginAvailability.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5C507B62B17E75B00200A6A /* CheckLoginAvailability.swift */; };
+		E5C507B92B17E7A400200A6A /* ValidateCredentialsFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5C507B82B17E7A400200A6A /* ValidateCredentialsFormat.swift */; };
+		E5C507BC2B1F6F6C00200A6A /* Stubs.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5C507BB2B1F6F6C00200A6A /* Stubs.swift */; };
+		E5C507BE2B1F6FA600200A6A /* Equatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5C507BD2B1F6FA600200A6A /* Equatable.swift */; };
+		E5C507C02B1F700C00200A6A /* CheckLoginAvailabilityMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5C507BF2B1F700C00200A6A /* CheckLoginAvailabilityMock.swift */; };
+		E5C507C22B1F702700200A6A /* LoginWithCredentialsUseCaseMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5C507C12B1F702700200A6A /* LoginWithCredentialsUseCaseMock.swift */; };
+		E5C507C42B1F72E700200A6A /* CheckLoginAvailabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5C507C32B1F72E700200A6A /* CheckLoginAvailabilityTests.swift */; };
+		E5C507C72B1FABFF00200A6A /* LoginDomainErrorMapperType.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5C507C62B1FABFF00200A6A /* LoginDomainErrorMapperType.swift */; };
+		E5C507CA2B1FAC3600200A6A /* LoginDomainErrorMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5C507C92B1FAC3600200A6A /* LoginDomainErrorMapper.swift */; };
+		E5C507CC2B1FACE000200A6A /* LoginWithCredentialsUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5C507CB2B1FACE000200A6A /* LoginWithCredentialsUseCaseTests.swift */; };
 		E5F52A182A8A5D5300828883 /* WifiNetworkMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5F52A172A8A5D5300828883 /* WifiNetworkMonitor.swift */; };
 		E5F52A192A8A5D5300828883 /* WifiNetworkMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5F52A172A8A5D5300828883 /* WifiNetworkMonitor.swift */; };
 		E5F52A1B2A8A5E1E00828883 /* IPv4Address.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5F52A1A2A8A5E1E00828883 /* IPv4Address.swift */; };
@@ -1065,6 +1087,11 @@
 		E59E8FA62AEA7A81009278F5 /* PurchaseViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PurchaseViewController.swift; sourceTree = "<group>"; };
 		E59E8FA72AEA7A81009278F5 /* TermsAndConditionsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TermsAndConditionsViewController.swift; sourceTree = "<group>"; };
 		E59E8FA82AEA7A81009278F5 /* OptionsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OptionsViewController.swift; sourceTree = "<group>"; };
+		E5AB286B2B2796E700744E5F /* LoginProviderMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginProviderMock.swift; sourceTree = "<group>"; };
+		E5AB286E2B27977000744E5F /* LoginFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginFactory.swift; sourceTree = "<group>"; };
+		E5AB28702B279B4000744E5F /* LoginProviderType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginProviderType.swift; sourceTree = "<group>"; };
+		E5AB28722B279B7000744E5F /* LoginProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginProvider.swift; sourceTree = "<group>"; };
+		E5AB28742B279BB600744E5F /* LoginIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginIntegrationTests.swift; sourceTree = "<group>"; };
 		E5C507772B0E144D00200A6A /* PIA VPN-tvOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "PIA VPN-tvOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		E5C507792B0E144E00200A6A /* PIA_VPN_tvOSApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PIA_VPN_tvOSApp.swift; sourceTree = "<group>"; };
 		E5C5077B2B0E144E00200A6A /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -1075,6 +1102,22 @@
 		E5C507902B0E145100200A6A /* PIA VPN-tvOSUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "PIA VPN-tvOSUITests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		E5C507942B0E145100200A6A /* PIA_VPN_tvOSUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PIA_VPN_tvOSUITests.swift; sourceTree = "<group>"; };
 		E5C507962B0E145100200A6A /* PIA_VPN_tvOSUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PIA_VPN_tvOSUITestsLaunchTests.swift; sourceTree = "<group>"; };
+		E5C507A12B0FE40000200A6A /* LoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginView.swift; sourceTree = "<group>"; };
+		E5C507A42B153A2F00200A6A /* LoginViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewModel.swift; sourceTree = "<group>"; };
+		E5C507A72B153E6B00200A6A /* LoginViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewModelTests.swift; sourceTree = "<group>"; };
+		E5C507AD2B17E45800200A6A /* LoginPresentableErrorMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginPresentableErrorMapper.swift; sourceTree = "<group>"; };
+		E5C507B02B17E48900200A6A /* LoginWithCredentialsUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginWithCredentialsUseCase.swift; sourceTree = "<group>"; };
+		E5C507B22B17E5AD00200A6A /* LoginError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginError.swift; sourceTree = "<group>"; };
+		E5C507B62B17E75B00200A6A /* CheckLoginAvailability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckLoginAvailability.swift; sourceTree = "<group>"; };
+		E5C507B82B17E7A400200A6A /* ValidateCredentialsFormat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValidateCredentialsFormat.swift; sourceTree = "<group>"; };
+		E5C507BB2B1F6F6C00200A6A /* Stubs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Stubs.swift; sourceTree = "<group>"; };
+		E5C507BD2B1F6FA600200A6A /* Equatable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Equatable.swift; sourceTree = "<group>"; };
+		E5C507BF2B1F700C00200A6A /* CheckLoginAvailabilityMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckLoginAvailabilityMock.swift; sourceTree = "<group>"; };
+		E5C507C12B1F702700200A6A /* LoginWithCredentialsUseCaseMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginWithCredentialsUseCaseMock.swift; sourceTree = "<group>"; };
+		E5C507C32B1F72E700200A6A /* CheckLoginAvailabilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckLoginAvailabilityTests.swift; sourceTree = "<group>"; };
+		E5C507C62B1FABFF00200A6A /* LoginDomainErrorMapperType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginDomainErrorMapperType.swift; sourceTree = "<group>"; };
+		E5C507C92B1FAC3600200A6A /* LoginDomainErrorMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginDomainErrorMapper.swift; sourceTree = "<group>"; };
+		E5C507CB2B1FACE000200A6A /* LoginWithCredentialsUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginWithCredentialsUseCaseTests.swift; sourceTree = "<group>"; };
 		E5F52A172A8A5D5300828883 /* WifiNetworkMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WifiNetworkMonitor.swift; sourceTree = "<group>"; };
 		E5F52A1A2A8A5E1E00828883 /* IPv4Address.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IPv4Address.swift; sourceTree = "<group>"; };
 		E5F52A1E2A8A614900828883 /* NetworkMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkMonitor.swift; sourceTree = "<group>"; };
@@ -1183,6 +1226,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E5C507AA2B17E3F100200A6A /* PIALibrary in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1955,9 +1999,18 @@
 			path = iOS;
 			sourceTree = "<group>";
 		};
+		E5AB286D2B27975E00744E5F /* CompositionRoot */ = {
+			isa = PBXGroup;
+			children = (
+				E5AB286E2B27977000744E5F /* LoginFactory.swift */,
+			);
+			path = CompositionRoot;
+			sourceTree = "<group>";
+		};
 		E5C507782B0E144E00200A6A /* PIA VPN-tvOS */ = {
 			isa = PBXGroup;
 			children = (
+				E5C507A32B153A1800200A6A /* Login */,
 				E5C507792B0E144E00200A6A /* PIA_VPN_tvOSApp.swift */,
 				E5C5077B2B0E144E00200A6A /* ContentView.swift */,
 				E5C5077D2B0E145000200A6A /* Assets.xcassets */,
@@ -1977,6 +2030,7 @@
 		E5C507892B0E145100200A6A /* PIA VPN-tvOSTests */ = {
 			isa = PBXGroup;
 			children = (
+				E5C507A62B153E4800200A6A /* Login */,
 				E5C5078A2B0E145100200A6A /* PIA_VPN_tvOSTests.swift */,
 			);
 			path = "PIA VPN-tvOSTests";
@@ -1989,6 +2043,105 @@
 				E5C507962B0E145100200A6A /* PIA_VPN_tvOSUITestsLaunchTests.swift */,
 			);
 			path = "PIA VPN-tvOSUITests";
+			sourceTree = "<group>";
+		};
+		E5C507A32B153A1800200A6A /* Login */ = {
+			isa = PBXGroup;
+			children = (
+				E5AB286D2B27975E00744E5F /* CompositionRoot */,
+				E5C507C82B1FAC2B00200A6A /* Data */,
+				E5C507AF2B17E47A00200A6A /* Domain */,
+				E5C507AC2B17E44400200A6A /* UI */,
+				E5C507AB2B17E43400200A6A /* Presentation */,
+			);
+			path = Login;
+			sourceTree = "<group>";
+		};
+		E5C507A62B153E4800200A6A /* Login */ = {
+			isa = PBXGroup;
+			children = (
+				E5C507BA2B1F6F3800200A6A /* Helpers */,
+				E5C507A72B153E6B00200A6A /* LoginViewModelTests.swift */,
+				E5C507C32B1F72E700200A6A /* CheckLoginAvailabilityTests.swift */,
+				E5C507CB2B1FACE000200A6A /* LoginWithCredentialsUseCaseTests.swift */,
+				E5AB28742B279BB600744E5F /* LoginIntegrationTests.swift */,
+			);
+			path = Login;
+			sourceTree = "<group>";
+		};
+		E5C507AB2B17E43400200A6A /* Presentation */ = {
+			isa = PBXGroup;
+			children = (
+				E5C507B62B17E75B00200A6A /* CheckLoginAvailability.swift */,
+				E5C507A42B153A2F00200A6A /* LoginViewModel.swift */,
+				E5C507AD2B17E45800200A6A /* LoginPresentableErrorMapper.swift */,
+				E5C507B82B17E7A400200A6A /* ValidateCredentialsFormat.swift */,
+			);
+			path = Presentation;
+			sourceTree = "<group>";
+		};
+		E5C507AC2B17E44400200A6A /* UI */ = {
+			isa = PBXGroup;
+			children = (
+				E5C507A12B0FE40000200A6A /* LoginView.swift */,
+			);
+			path = UI;
+			sourceTree = "<group>";
+		};
+		E5C507AF2B17E47A00200A6A /* Domain */ = {
+			isa = PBXGroup;
+			children = (
+				E5C507C52B1FABEB00200A6A /* Interfaces */,
+				E5C507B52B17E5BB00200A6A /* Entities */,
+				E5C507B42B17E5B400200A6A /* Use cases */,
+			);
+			path = Domain;
+			sourceTree = "<group>";
+		};
+		E5C507B42B17E5B400200A6A /* Use cases */ = {
+			isa = PBXGroup;
+			children = (
+				E5C507B02B17E48900200A6A /* LoginWithCredentialsUseCase.swift */,
+			);
+			path = "Use cases";
+			sourceTree = "<group>";
+		};
+		E5C507B52B17E5BB00200A6A /* Entities */ = {
+			isa = PBXGroup;
+			children = (
+				E5C507B22B17E5AD00200A6A /* LoginError.swift */,
+			);
+			path = Entities;
+			sourceTree = "<group>";
+		};
+		E5C507BA2B1F6F3800200A6A /* Helpers */ = {
+			isa = PBXGroup;
+			children = (
+				E5C507BB2B1F6F6C00200A6A /* Stubs.swift */,
+				E5C507BD2B1F6FA600200A6A /* Equatable.swift */,
+				E5C507BF2B1F700C00200A6A /* CheckLoginAvailabilityMock.swift */,
+				E5C507C12B1F702700200A6A /* LoginWithCredentialsUseCaseMock.swift */,
+				E5AB286B2B2796E700744E5F /* LoginProviderMock.swift */,
+			);
+			path = Helpers;
+			sourceTree = "<group>";
+		};
+		E5C507C52B1FABEB00200A6A /* Interfaces */ = {
+			isa = PBXGroup;
+			children = (
+				E5C507C62B1FABFF00200A6A /* LoginDomainErrorMapperType.swift */,
+				E5AB28702B279B4000744E5F /* LoginProviderType.swift */,
+			);
+			path = Interfaces;
+			sourceTree = "<group>";
+		};
+		E5C507C82B1FAC2B00200A6A /* Data */ = {
+			isa = PBXGroup;
+			children = (
+				E5C507C92B1FAC3600200A6A /* LoginDomainErrorMapper.swift */,
+				E5AB28722B279B7000744E5F /* LoginProvider.swift */,
+			);
+			path = Data;
 			sourceTree = "<group>";
 		};
 		E5F52A162A8A5D3800828883 /* Wifi */ = {
@@ -2207,6 +2360,9 @@
 			dependencies = (
 			);
 			name = "PIA VPN-tvOS";
+			packageProductDependencies = (
+				E5C507A92B17E3F100200A6A /* PIALibrary */,
+			);
 			productName = "PIA VPN-tvOS";
 			productReference = E5C507772B0E144D00200A6A /* PIA VPN-tvOS.app */;
 			productType = "com.apple.product-type.application";
@@ -3074,8 +3230,20 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E5AB28732B279B7000744E5F /* LoginProvider.swift in Sources */,
+				E5C507A52B153A2F00200A6A /* LoginViewModel.swift in Sources */,
+				E5C507B72B17E75B00200A6A /* CheckLoginAvailability.swift in Sources */,
+				E5AB286F2B27977000744E5F /* LoginFactory.swift in Sources */,
+				E5C507A22B0FE40000200A6A /* LoginView.swift in Sources */,
+				E5C507B12B17E48900200A6A /* LoginWithCredentialsUseCase.swift in Sources */,
+				E5C507B92B17E7A400200A6A /* ValidateCredentialsFormat.swift in Sources */,
+				E5C507AE2B17E45800200A6A /* LoginPresentableErrorMapper.swift in Sources */,
+				E5AB28712B279B4000744E5F /* LoginProviderType.swift in Sources */,
 				E5C5077C2B0E144E00200A6A /* ContentView.swift in Sources */,
 				E5C5077A2B0E144E00200A6A /* PIA_VPN_tvOSApp.swift in Sources */,
+				E5C507C72B1FABFF00200A6A /* LoginDomainErrorMapperType.swift in Sources */,
+				E5C507B32B17E5AD00200A6A /* LoginError.swift in Sources */,
+				E5C507CA2B1FAC3600200A6A /* LoginDomainErrorMapper.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3083,7 +3251,16 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E5C507CC2B1FACE000200A6A /* LoginWithCredentialsUseCaseTests.swift in Sources */,
+				E5C507BC2B1F6F6C00200A6A /* Stubs.swift in Sources */,
+				E5C507A82B153E6B00200A6A /* LoginViewModelTests.swift in Sources */,
+				E5AB286C2B2796E700744E5F /* LoginProviderMock.swift in Sources */,
+				E5C507BE2B1F6FA600200A6A /* Equatable.swift in Sources */,
 				E5C5078B2B0E145100200A6A /* PIA_VPN_tvOSTests.swift in Sources */,
+				E5AB28752B279BB600744E5F /* LoginIntegrationTests.swift in Sources */,
+				E5C507C22B1F702700200A6A /* LoginWithCredentialsUseCaseMock.swift in Sources */,
+				E5C507C42B1F72E700200A6A /* CheckLoginAvailabilityTests.swift in Sources */,
+				E5C507C02B1F700C00200A6A /* CheckLoginAvailabilityMock.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -4536,6 +4713,11 @@
 			productName = PIALibrary;
 		};
 		E5C5076D2B0D60B300200A6A /* PIALibrary */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = E5C507662B0D609300200A6A /* XCRemoteSwiftPackageReference "mobile-ios-library" */;
+			productName = PIALibrary;
+		};
+		E5C507A92B17E3F100200A6A /* PIALibrary */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = E5C507662B0D609300200A6A /* XCRemoteSwiftPackageReference "mobile-ios-library" */;
 			productName = PIALibrary;


### PR DESCRIPTION
### Summary
This PR adds the Login screen to PIA tvOS. It includes all the different layers involved:
- UI
- Data
- Presentation
- Domain/App logic
- Composition Root

`LoginViewModel` exposes a status property in order to validate the logic when unit testing since the screen does not navigate when the operations was successful. This property will be taken care of once we tackle the navigation to the next screen. 

Tests are composed mainly by unit tests. There are also a couple of integration tests that are mocking the login provider which is a bridge to PIALibrary's `DefaultAccountProvider`. These tests are responsible of testing the integration between the all the different components on presentation and domain layers.

Error handling and proper design will be tackled in a different PR.

### Architecture

![Screenshot 2023-12-11 at 22 23 30](https://github.com/pia-foss/mobile-ios/assets/109279805/d08956bf-a91b-42ca-8c46-4eedfd40877b)
