### PR TITLE
PIA-000: Add workflow to archive a development build

### DIFF
--- a/.github/workflows/development_build.yml
+++ b/.github/workflows/development_build.yml
@@ -1,0 +1,56 @@
+name: development_build
+on:
+  push:
+    branches: 
+      - master
+
+  workflow_dispatch:
+concurrency:
+  group: "${{ github.ref }}"
+  cancel-in-progress: true
+jobs:
+  build:
+    runs-on: macos-13
+    env:
+      CERTIFICATE_PASSWORD: ${{ secrets.DEVELOPER_CERTIFICATE_PASSWORD }}
+      KEYCHAIN_NAME: ${{ secrets.KEYCHAIN_NAME }}
+      KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+      APP_STORE_CONNECT_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
+      APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+      APP_STORE_CONNECT_KEY: ${{ secrets.APP_STORE_CONNECT_KEY }}
+
+    steps:
+    - name: Setup Git credentials
+      run: |
+        git config --global url."https://${{ secrets.ORG_GITHUB_USERNAME }}:${{ secrets.ORG_GITHUB_TOKEN }}@github.com/".insteadOf "git@github.com:"
+
+    - uses: actions/checkout@v3
+
+    - name: Select XCode version
+      run: sudo xcode-select -s /Applications/Xcode_14.3.1.app
+    
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.0.2
+
+    - name: Install Fastlane
+      run: gem install fastlane
+
+    - name: Decode Developer Certificates
+      run: echo "${{ secrets.DEVELOPER_IOS_CERTIFICATE }}" | base64 --decode > ./fastlane/Certificate.p12
+
+    - name: Set up development certificates and profiles
+      run: bundle exec fastlane get_development_profiles > /dev/null 2>&1
+    
+    - name: Create artifacts dir
+      run: mkdir artifacts
+      
+    - name: Archive development build
+      run: bundle exec fastlane development_build
+
+    - name: Upload development ipa file
+      uses: actions/upload-artifact@v4
+      with:
+        path: artifacts/
+      

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -21,7 +21,7 @@ platform :ios do
   end
 
   desc "This line is for settin up the certificates and provisioning profiles"
-  lane :get_profiles do
+  lane :get_profiles do |options|
     api_key = app_store_connect_api_key(
       key_id: key_id,
       issuer_id: issuer_id,
@@ -29,32 +29,43 @@ platform :ios do
     )
 
     certificates
+    development_profiles = options[:development] || false
 
     get_provisioning_profile(
+      development: development_profiles,
       api_key: api_key,
       app_identifier: "com.privateinternetaccess.ios.PIA-VPN"
     )
 
     get_provisioning_profile(
+      development: development_profiles,
       api_key: api_key,
       app_identifier: "com.privateinternetaccess.ios.PIA-VPN.Tunnel"
     )
 
     get_provisioning_profile(
+      development: development_profiles,
       api_key: api_key,
       app_identifier: "com.privateinternetaccess.ios.PIA-VPN.WG-Tunnel"
     )
 
     get_provisioning_profile(
+      development: development_profiles,
       api_key: api_key,
       app_identifier: "com.privateinternetaccess.ios.PIA-VPN.PIAWidget"
     )
 
     get_provisioning_profile(
+      development: development_profiles,
       api_key: api_key,
       app_identifier: "com.privateinternetaccess.ios.PIA-VPN.AdBlocker"
     )
 
+  end
+
+  desc "This line is for setting up the certificates and provisioning profiles for development builds"
+  lane :get_development_profiles do
+    get_profiles(development: true)
   end
 
   desc "This line is for creating testflight build"
@@ -92,6 +103,38 @@ platform :ios do
   lane :certificates do
     import_certificates
   end
+
+  desc "This line is for creating a developer build"
+  lane :development_build do
+
+    current_branch = git_branch()
+    commit_hash = last_git_commit()
+    short_hash = commit_hash[:abbreviated_commit_hash]
+    archive_path = "PIA_VPN_iOS.#{current_branch}_#{short_hash}"
+    archive_zip_name = "#{archive_path}.zip"
+
+    build_app(scheme: "PIA VPN",
+      export_method: "development",
+      clean: true,
+      configuration: "Debug",
+      build_path: "build/#{archive_path}",
+      output_name: "#{archive_path}.ipa",
+      export_options: {
+        provisioningProfiles: { 
+          "com.privateinternetaccess.ios.PIA-VPN" => "match Development com.privateinternetaccess.ios.PIA-VPN",
+          "com.privateinternetaccess.ios.PIA-VPN.Tunnel" => "match Development com.privateinternetaccess.ios.PIA-VPN.Tunnel",
+          "com.privateinternetaccess.ios.PIA-VPN.WG-Tunnel" => "match Development com.privateinternetaccess.ios.PIA-VPN.WG-Tunnel",
+          "com.privateinternetaccess.ios.PIA-VPN.PIAWidget" => "match Development com.privateinternetaccess.ios.PIA-VPN.PIAWidget",
+          "com.privateinternetaccess.ios.PIA-VPN.AdBlocker" => "match Development com.privateinternetaccess.ios.PIA-VPN.AdBlocker"
+        }
+      }
+    )
+
+    zip(output_path: archive_zip_name, path: "#{archive_path}.ipa")
+    sh "mv ../#{archive_zip_name} ../artifacts/#{archive_zip_name}"
+
+  end
+
 
   desc "Increase build number for TestFlight"
   private_lane :increment_build_number_testflight do 


### PR DESCRIPTION
- This PR sets up a CI workflow to build an `ipa` artifact with Development credentials every time we merge to `master`
- The Development build can only be installed on devices that are authorized on our Apple Developer portal