### PR TITLE
PIA-1224: Integrate VPN status monitor into connection button

### DIFF
--- a/PIA VPN-tvOS/Dashboard/CompositionRoot/DashboardFactory.swift
+++ b/PIA VPN-tvOS/Dashboard/CompositionRoot/DashboardFactory.swift
@@ -29,7 +29,8 @@ class DashboardFactory {
 
 extension DashboardFactory {
     private static func makePIAConnectionButtonViewModel() -> PIAConnectionButtonViewModel {
-        return PIAConnectionButtonViewModel(useCase: makeVpnConnectionUseCase())
+        return PIAConnectionButtonViewModel(useCase: makeVpnConnectionUseCase(), 
+                                            vpnStatusMonitor: StateMonitorsFactory.makeVPNStatusMonitor())
     }
     
     private static func makeVpnConnectionUseCase() -> VpnConnectionUseCaseType {

--- a/PIA VPN-tvOS/Shared/StateMonitors/VPNStatusMonitor.swift
+++ b/PIA VPN-tvOS/Shared/StateMonitors/VPNStatusMonitor.swift
@@ -23,6 +23,8 @@ class VPNStatusMonitor: VPNStatusMonitorType {
         self.vpnStatusProvider = vpnStatusProvider
         self.notificationCenter = notificationCenter
         self.status = CurrentValueSubject<VPNStatus, Never>(vpnStatusProvider.vpnStatus)
+        
+        addObservers()
     }
     
     private func addObservers() {

--- a/PIA VPN-tvOSTests/Common/Mocks/VpnConnectionUseCaseMock.swift
+++ b/PIA VPN-tvOSTests/Common/Mocks/VpnConnectionUseCaseMock.swift
@@ -15,10 +15,14 @@ class VpnConnectionUseCaseMock: VpnConnectionUseCaseType {
     var connectCalledToServerAttempt: Int = 0
     var connectToServerCalledWithArgument: ServerType?
     
+    var connectionAction: (() -> Void)?
+    var disconnectionAction: (() -> Void)?
+    
     func connect(to server: ServerType) {
         connectToServerCalled = true
         connectCalledToServerAttempt += 1
         connectToServerCalledWithArgument = server
+        connectionAction?()
     }
     
     var connectCalled: Bool = false
@@ -27,6 +31,7 @@ class VpnConnectionUseCaseMock: VpnConnectionUseCaseType {
     func connect() {
         connectCalled = true
         connectCalledAttempt += 1
+        connectionAction?()
     }
     
     var disconnectCalled: Bool = false
@@ -35,6 +40,7 @@ class VpnConnectionUseCaseMock: VpnConnectionUseCaseType {
     func disconnect() {
         disconnectCalled = true
         disconnectCalledAttempt += 1
+        disconnectionAction?()
     }
     
     

--- a/PIA VPN-tvOSTests/Shared/Mocks/VPNStatusMonitorMock.swift
+++ b/PIA VPN-tvOSTests/Shared/Mocks/VPNStatusMonitorMock.swift
@@ -1,0 +1,20 @@
+//
+//  VPNStatusMonitorMock.swift
+//  PIA VPN-tvOSTests
+//
+//  Created by Said Rehouni on 22/1/24.
+//  Copyright © 2024 Private Internet Access Inc. All rights reserved.
+//
+
+import Foundation
+import Combine
+import PIALibrary
+@testable import PIA_VPN_tvOS
+
+class VPNStatusMonitorMock: VPNStatusMonitorType {
+    var status = PassthroughSubject<VPNStatus, Never>()
+    
+    func getStatus() -> AnyPublisher<VPNStatus, Never> {
+        return status.eraseToAnyPublisher()
+    }
+}

--- a/PIA VPN.xcodeproj/project.pbxproj
+++ b/PIA VPN.xcodeproj/project.pbxproj
@@ -571,6 +571,7 @@
 		E52E691D2B5DC2B200471913 /* StateMonitorsFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = E52E691C2B5DC2B200471913 /* StateMonitorsFactory.swift */; };
 		E52E691F2B5DCEA500471913 /* UserAuthenticationStatusMonitorMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = E52E691E2B5DCEA500471913 /* UserAuthenticationStatusMonitorMock.swift */; };
 		E52E69222B5DCF1F00471913 /* VPNStatusProviderMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = E52E69212B5DCF1F00471913 /* VPNStatusProviderMock.swift */; };
+		E52E69252B5E92CC00471913 /* VPNStatusMonitorMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = E52E69242B5E92CC00471913 /* VPNStatusMonitorMock.swift */; };
 		E59E8F942AEA7A29009278F5 /* ActivityButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = E59E8F932AEA7A29009278F5 /* ActivityButton.swift */; };
 		E59E8F952AEA7A29009278F5 /* ActivityButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = E59E8F932AEA7A29009278F5 /* ActivityButton.swift */; };
 		E59E8F972AEA7A5A009278F5 /* AutolayoutViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E59E8F962AEA7A5A009278F5 /* AutolayoutViewController.swift */; };
@@ -1263,6 +1264,7 @@
 		E52E691C2B5DC2B200471913 /* StateMonitorsFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StateMonitorsFactory.swift; sourceTree = "<group>"; };
 		E52E691E2B5DCEA500471913 /* UserAuthenticationStatusMonitorMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserAuthenticationStatusMonitorMock.swift; sourceTree = "<group>"; };
 		E52E69212B5DCF1F00471913 /* VPNStatusProviderMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VPNStatusProviderMock.swift; sourceTree = "<group>"; };
+		E52E69242B5E92CC00471913 /* VPNStatusMonitorMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VPNStatusMonitorMock.swift; sourceTree = "<group>"; };
 		E59E8F932AEA7A29009278F5 /* ActivityButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActivityButton.swift; sourceTree = "<group>"; };
 		E59E8F962AEA7A5A009278F5 /* AutolayoutViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AutolayoutViewController.swift; sourceTree = "<group>"; };
 		E59E8F992AEA7A7F009278F5 /* SignupInternetUnreachableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SignupInternetUnreachableViewController.swift; sourceTree = "<group>"; };
@@ -2567,6 +2569,7 @@
 			isa = PBXGroup;
 			children = (
 				E52E69212B5DCF1F00471913 /* VPNStatusProviderMock.swift */,
+				E52E69242B5E92CC00471913 /* VPNStatusMonitorMock.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -4069,6 +4072,7 @@
 				698C3B492B2B33650012D527 /* VpnConnectionUseCaseMock.swift in Sources */,
 				69CA26B22B59668700E78894 /* RegionsListUseCaseMock.swift in Sources */,
 				E5C507CC2B1FACE000200A6A /* LoginWithCredentialsUseCaseTests.swift in Sources */,
+				E52E69252B5E92CC00471913 /* VPNStatusMonitorMock.swift in Sources */,
 				696E8F0D2B31A8760080BB31 /* NotificationCenterMock.swift in Sources */,
 				E5C507A82B153E6B00200A6A /* LoginViewModelTests.swift in Sources */,
 				E5AB286C2B2796E700744E5F /* LoginProviderMock.swift in Sources */,


### PR DESCRIPTION
**Summary**
This PR integrates the VPN status monitor to update the connection button in Home with the received vpn state.
Unit tests have been also updated.
