### PR TITLE
PIA-1108: Hide dynamic island on logout

### DIFF
--- a/PIA VPN/DashboardViewController.swift
+++ b/PIA VPN/DashboardViewController.swift
@@ -558,6 +558,9 @@ class DashboardViewController: AutolayoutViewController {
     @objc private func accountDidLogout(notification: Notification) {
         AppPreferences.shared.todayWidgetVpnStatus = nil
         AppPreferences.shared.todayWidgetButtonTitle = L10n.Localizable.Today.Widget.login
+        if #available(iOS 16.2, *) {
+            stopConnectionLiveActivity()
+        }
         presentLogin()
     }
     
@@ -1251,5 +1254,12 @@ extension DashboardViewController {
         let liveActivityManager = appDelegate.liveActivityManager else { return }
         let connState = makeLiveActivityStateForCurrentConnection()
         liveActivityManager.startLiveActivity(with: connState)
+    }
+
+    @available(iOS 16.2, *)
+    private func stopConnectionLiveActivity() {
+       guard let appDelegate = UIApplication.shared.delegate as? AppDelegate,
+        let liveActivityManager = appDelegate.liveActivityManager else { return }
+        liveActivityManager.endLiveActivities()
     }
 }


### PR DESCRIPTION
## Summary

It fixes an issue where the dynamic island was still visible in the latest know state after the user have logged out of the application.

## Sanity Tests

- [x] Login. Confirm dynamic island visible on lock screen.
- [x] After the above. Connect. Confirm dynamic island connected on lock screen.
- [x] After the above. Logout. Confirm dynamic island is no longer visible on lock screen.
- [x] After the above. Login. Confirm dynamic island visible on lock screen.
- [x] After the above. Logout. Confirm dynamic island is no longer visible on lock screen.