### PR TITLE
PIA-1388: Disconnect and remove favourite when deleting DIP

### DIFF
--- a/PIA VPN-tvOS/DedicatedIp/CompositionRoot/DedicatedIPFactory.swift
+++ b/PIA VPN-tvOS/DedicatedIp/CompositionRoot/DedicatedIPFactory.swift
@@ -30,8 +30,11 @@ class DedicatedIPFactory {
     }
     
     private static func makeRemoveDIPUseCase() -> RemoveDIPUseCaseType {
-        RemoveDIPUseCase(serverProvider: makeDefaultServerProvider(),
-                         dedicatedIpProvider: makeDedicatedIPProvider())
+        RemoveDIPUseCase(dedicatedIpProvider: makeDedicatedIPProvider(),
+                         favoriteRegionsUseCase: RegionsSelectionFactory.makeFavoriteRegionUseCase,
+                         getDedicatedIP: makeGetDedicatedIpUseCase(), 
+                         vpnCpnnectionUseCase: VpnConnectionFactory.makeVpnConnectionUseCase,
+                         selectedServer: RegionsSelectionFactory.makeClientPreferences)
     }
     
     private static func makeDedicatedIPProvider() -> DedicatedIPProviderType {

--- a/PIA VPN-tvOSTests/DedicatedIp/DedicatedIPViewModelTests.swift
+++ b/PIA VPN-tvOSTests/DedicatedIp/DedicatedIPViewModelTests.swift
@@ -146,7 +146,7 @@ final class DedicatedIPViewModelTests: XCTestCase {
     }
 }
 
-private struct ServerTypeStub: ServerType {
+struct ServerTypeStub: ServerType {
     var name: String
     var identifier: String
     var regionIdentifier: String
@@ -173,7 +173,7 @@ private struct ServerTypeStub: ServerType {
     
     static func makeNonValidServerTypeStub() -> ServerType {
         ServerTypeStub(name: "name",
-                       identifier: "identifier",
+                       identifier: "identifier2",
                        regionIdentifier: "regionIdentifier",
                        country: "country",
                        geo: false,

--- a/PIA VPN-tvOSTests/DedicatedIp/Mocks/ClientPreferencesMock.swift
+++ b/PIA VPN-tvOSTests/DedicatedIp/Mocks/ClientPreferencesMock.swift
@@ -1,0 +1,26 @@
+//
+//  ClientPreferencesMock.swift
+//  PIA VPN-tvOSTests
+//
+//  Created by Said Rehouni on 22/2/24.
+//  Copyright © 2024 Private Internet Access Inc. All rights reserved.
+//
+
+import Foundation
+@testable import PIA_VPN_tvOS
+import Combine
+
+class ClientPreferencesMock: ClientPreferencesType {
+    var selectedServer: ServerType
+    
+    private var selectedServerPublisher: CurrentValueSubject<ServerType, Never>
+    
+    init(selectedServer: ServerType) {
+        self.selectedServer = selectedServer
+        self.selectedServerPublisher = CurrentValueSubject(selectedServer)
+    }
+    
+    func getSelectedServer() -> AnyPublisher<ServerType, Never> {
+        return selectedServerPublisher.eraseToAnyPublisher()
+    }
+}

--- a/PIA VPN-tvOSTests/DedicatedIp/Mocks/DedicatedIPProviderMock.swift
+++ b/PIA VPN-tvOSTests/DedicatedIp/Mocks/DedicatedIPProviderMock.swift
@@ -10,17 +10,30 @@ import Foundation
 @testable import PIA_VPN_tvOS
 
 class DedicatedIPProviderMock: DedicatedIPProviderType {
+    enum Request {
+        case activateDIPToken
+        case removeDIPToken
+        case renewDIPToken
+        case getDIPTokens
+    }
+    
     private let result: Result<Void, DedicatedIPError>
+    var requests: [Request] = []
     
     init(result: Result<Void, DedicatedIPError>) {
         self.result = result
     }
     
     func activateDIPToken(_ token: String, completion: @escaping (Result<Void, DedicatedIPError>) -> Void) {
+        requests.append(.activateDIPToken)
         completion(result)
     }
     
-    func removeDIPToken(_ token: String) {}
-    func renewDIPToken(_ token: String) {}
-    func getDIPTokens() -> [String] { [] }
+    func removeDIPToken(_ token: String) { requests.append(.removeDIPToken) }
+    func renewDIPToken(_ token: String) { requests.append(.renewDIPToken) }
+    
+    func getDIPTokens() -> [String] {
+        requests.append(.getDIPTokens)
+        return []
+    }
 }

--- a/PIA VPN-tvOSTests/DedicatedIp/RemoveDIPUseCaseTests.swift
+++ b/PIA VPN-tvOSTests/DedicatedIp/RemoveDIPUseCaseTests.swift
@@ -1,0 +1,123 @@
+//
+//  RemoveDIPUseCaseTests.swift
+//  PIA VPN-tvOSTests
+//
+//  Created by Said Rehouni on 22/2/24.
+//  Copyright © 2024 Private Internet Access Inc. All rights reserved.
+//
+
+import XCTest
+@testable import PIA_VPN_tvOS
+
+final class RemoveDIPUseCaseTests: XCTestCase {
+    class Fixture {
+        var dipServerProviderMock = DedicatedIPProviderMock(result: .success(()))
+        var favoriteRegionsUseCaseMock = FavoriteRegionUseCaseMock()
+        var getDedicatedIPUseCaseMock: GetDedicatedIpUseCaseMock!
+        var vpnConnectionUseCaseMock = VpnConnectionUseCaseMock()
+        var clientPreferencesMock: ClientPreferencesMock!
+    }
+    
+    var fixture: Fixture!
+    var sut: RemoveDIPUseCase!
+    
+    func instantiateSut(result: ServerType?, selectedServer: ServerType) {
+        fixture.getDedicatedIPUseCaseMock = GetDedicatedIpUseCaseMock(result: result)
+        fixture.clientPreferencesMock = ClientPreferencesMock(selectedServer: selectedServer)
+        sut = RemoveDIPUseCase(dedicatedIpProvider: fixture.dipServerProviderMock,
+                               favoriteRegionsUseCase: fixture.favoriteRegionsUseCaseMock,
+                               getDedicatedIP: fixture.getDedicatedIPUseCaseMock,
+                               vpnCpnnectionUseCase: fixture.vpnConnectionUseCaseMock,
+                               selectedServer: fixture.clientPreferencesMock)
+    }
+
+    override func setUp() {
+        fixture = Fixture()
+    }
+
+    override func tearDown() {
+        fixture = nil
+        sut = nil
+    }
+
+    func test_removeDIPToken_complets_successfully_when_dedicatedIp_was_found_and_connected() {
+        // GIVEN
+        let server = ServerTypeStub.makesServer1()
+        instantiateSut(result: server, selectedServer: server)
+        
+        let expectation = expectation(description: "Waiting for vpnConnectionUseCaseMock to be called")
+        fixture.vpnConnectionUseCaseMock.disconnectionAction = {
+            expectation.fulfill()
+        }
+        // WHEN
+        sut()
+        
+        // THEN
+        wait(for: [expectation], timeout: 1.0)
+        XCTAssertEqual(fixture.dipServerProviderMock.requests, [.removeDIPToken])
+        XCTAssertEqual(fixture.favoriteRegionsUseCaseMock.removeFromFavoritesCalledAttempt, 1)
+        XCTAssertEqual(fixture.vpnConnectionUseCaseMock.disconnectCalledAttempt, 1)
+    }
+    
+    func test_removeDIPToken_complets_successfully_when_dedicatedIp_was_found_and_not_connected() {
+        // GIVEN
+        let server = ServerTypeStub.makesServer1()
+        let selectedServer = ServerTypeStub.makesServer2()
+        instantiateSut(result: server, selectedServer: selectedServer)
+        
+        fixture.vpnConnectionUseCaseMock.disconnectionAction = {
+            XCTFail("Unexpected call to vpnConnectionUseCaseMock")
+        }
+        // WHEN
+        sut()
+        
+        // THEN
+        XCTAssertEqual(fixture.dipServerProviderMock.requests, [.removeDIPToken])
+        XCTAssertEqual(fixture.favoriteRegionsUseCaseMock.removeFromFavoritesCalledAttempt, 1)
+        XCTAssertEqual(fixture.vpnConnectionUseCaseMock.disconnectCalledAttempt, 0)
+    }
+    
+    func test_activatesDIPToken_complets_with_failure_when_DedicatedIPProvider_complets_with_failure() {
+        // GIVEN
+        instantiateSut(result: nil, selectedServer: ServerTypeStub.makeValidServerTypeStub())
+        fixture.vpnConnectionUseCaseMock.disconnectionAction = {
+            XCTFail("Unexpected call to vpnConnectionUseCaseMock")
+        }
+        
+        // WHEN
+        sut()
+        
+        // THEN
+        XCTAssertEqual(fixture.dipServerProviderMock.requests, [])
+        XCTAssertEqual(fixture.favoriteRegionsUseCaseMock.removeFromFavoritesCalledAttempt, 0)
+        XCTAssertEqual(fixture.vpnConnectionUseCaseMock.disconnectCalledAttempt, 0)
+    }
+}
+
+extension ServerTypeStub {
+    static func makesServer1() -> ServerType {
+        ServerTypeStub(name: "name",
+                       identifier: "identifier",
+                       regionIdentifier: "regionIdentifier",
+                       country: "country",
+                       geo: false,
+                       pingTime: 0,
+                       isAutomatic: true,
+                       dipToken: "dipToken",
+                       dipIKEv2IP: "dipIKEv2IP",
+                       dipStatusString: "dipStatusString")
+    }
+
+    static func makesServer2() -> ServerType {
+        ServerTypeStub(name: "name2",
+                       identifier: "identifier2",
+                       regionIdentifier: "regionIdentifier2",
+                       country: "country2",
+                       geo: false,
+                       pingTime: 0,
+                       isAutomatic: true,
+                       dipToken: "dipToken",
+                       dipIKEv2IP: "dipIKEv2IP2",
+                       dipStatusString: "dipStatusString")
+    }
+}

--- a/PIA VPN.xcodeproj/project.pbxproj
+++ b/PIA VPN.xcodeproj/project.pbxproj
@@ -655,6 +655,8 @@
 		E574D9FF2B854A4B000FADAF /* ActivateDIPTokenUseCaseMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = E574D9FA2B853662000FADAF /* ActivateDIPTokenUseCaseMock.swift */; };
 		E574DA002B854A52000FADAF /* RemoveDIPUseCaseMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = E574D9FC2B853677000FADAF /* RemoveDIPUseCaseMock.swift */; };
 		E574DA072B8610CF000FADAF /* Regions.json in Resources */ = {isa = PBXBuildFile; fileRef = E574DA062B8610CF000FADAF /* Regions.json */; };
+		E574DA092B875C4A000FADAF /* RemoveDIPUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E574DA082B875C49000FADAF /* RemoveDIPUseCaseTests.swift */; };
+		E574DA0B2B879BAE000FADAF /* ClientPreferencesMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = E574DA0A2B879BAE000FADAF /* ClientPreferencesMock.swift */; };
 		E59D1A152B7E2D4B00A2FBFB /* NetworkExtension.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DD606AB921C7A17900E0781D /* NetworkExtension.framework */; };
 		E59D1A182B7E2D4B00A2FBFB /* PacketTunnelProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = E59D1A172B7E2D4B00A2FBFB /* PacketTunnelProvider.swift */; };
 		E59D1A1D2B7E2D4B00A2FBFB /* PIA tvOS Tunnel.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = E59D1A142B7E2D4B00A2FBFB /* PIA tvOS Tunnel.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
@@ -1429,6 +1431,8 @@
 		E574D9FA2B853662000FADAF /* ActivateDIPTokenUseCaseMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivateDIPTokenUseCaseMock.swift; sourceTree = "<group>"; };
 		E574D9FC2B853677000FADAF /* RemoveDIPUseCaseMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoveDIPUseCaseMock.swift; sourceTree = "<group>"; };
 		E574DA062B8610CF000FADAF /* Regions.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = Regions.json; sourceTree = "<group>"; };
+		E574DA082B875C49000FADAF /* RemoveDIPUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoveDIPUseCaseTests.swift; sourceTree = "<group>"; };
+		E574DA0A2B879BAE000FADAF /* ClientPreferencesMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientPreferencesMock.swift; sourceTree = "<group>"; };
 		E59D1A142B7E2D4B00A2FBFB /* PIA tvOS Tunnel.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = "PIA tvOS Tunnel.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
 		E59D1A172B7E2D4B00A2FBFB /* PacketTunnelProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PacketTunnelProvider.swift; sourceTree = "<group>"; };
 		E59D1A192B7E2D4B00A2FBFB /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -3030,6 +3034,7 @@
 				E574D9E42B83F3D2000FADAF /* DedicatedIPProviderTests.swift */,
 				E574D9E52B83F3D2000FADAF /* ActivateDIPTokenUseCaseTests.swift */,
 				E574D9F62B851C16000FADAF /* DedicatedIPViewModelTests.swift */,
+				E574DA082B875C49000FADAF /* RemoveDIPUseCaseTests.swift */,
 			);
 			path = DedicatedIp;
 			sourceTree = "<group>";
@@ -3042,6 +3047,7 @@
 				E574D9F82B85364C000FADAF /* GetDedicatedIpUseCaseMock.swift */,
 				E574D9FA2B853662000FADAF /* ActivateDIPTokenUseCaseMock.swift */,
 				E574D9FC2B853677000FADAF /* RemoveDIPUseCaseMock.swift */,
+				E574DA0A2B879BAE000FADAF /* ClientPreferencesMock.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -4670,6 +4676,7 @@
 				69194BBB2B7BE59600691775 /* VpnConnectionUseCaseTests.swift in Sources */,
 				6953E5532B7B748800D685B4 /* ConnectionStateMonitorMock.swift in Sources */,
 				690FC4842B3C5B0500F6DCC8 /* QuickConnectButtonViewModelDelegateMock.swift in Sources */,
+				E574DA092B875C4A000FADAF /* RemoveDIPUseCaseTests.swift in Sources */,
 				6944B16E2B8536B8008E3B70 /* OptimalLocationUseCaseTests.swift in Sources */,
 				693474C82B6B8BDD0061F788 /* KeychainTypeMock.swift in Sources */,
 				693B9A442B7622B600757A41 /* RegionsDisplayNameUseCaseTests.swift in Sources */,
@@ -4690,6 +4697,7 @@
 				E5AB28E12B4C107F00744E5F /* VpnConfigurationProviderTypeMock.swift in Sources */,
 				E5C507C42B1F72E700200A6A /* CheckLoginAvailabilityTests.swift in Sources */,
 				692DE7DC2B73AE32000A2F1A /* TopNavigationViewModelTests.swift in Sources */,
+				E574DA0B2B879BAE000FADAF /* ClientPreferencesMock.swift in Sources */,
 				E574D9E92B83F3D2000FADAF /* ActivateDIPTokenUseCaseTests.swift in Sources */,
 				69793DA12B59B96B000CB845 /* RegionsListViewModelTests.swift in Sources */,
 				692DE7DA2B739AF8000A2F1A /* AppRouterTests.swift in Sources */,


### PR DESCRIPTION
**Summary**
This PR does the following when a DIP is deleted:
-  Removes DIP from favourite 
-  Disconnects VPN if DIP is selected server