### PR TITLE
PIA-1377: Cache the last connected location

### DIFF
--- a/PIA VPN-tvOS/Dashboard/CompositionRoot/DashboardFactory.swift
+++ b/PIA VPN-tvOS/Dashboard/CompositionRoot/DashboardFactory.swift
@@ -28,13 +28,13 @@ extension DashboardFactory {
     }
     
 
-    static func makeSelectedServerUserCase() -> SelectedServerUseCaseType {
+    static var makeSelectedServerUserCase: SelectedServerUseCaseType = {
         return SelectedServerUseCase(serverProvider: VpnConnectionFactory.makeServerProvider(), clientPreferences: RegionsSelectionFactory.makeClientPreferences)
-    }
+    }()
     
     private static func makeSelectedServerViewModel() -> SelectedServerViewModel {
         return SelectedServerViewModel(
-            useCase: makeSelectedServerUserCase(),
+            useCase: makeSelectedServerUserCase,
             optimalLocationUseCase: RegionsSelectionFactory.makeOptimalLocationUseCase,
             regionsDisplayNameUseCase: RegionsSelectionFactory.makeRegionsDisplayNameUseCase(),
             routerAction: .navigate(router: AppRouterFactory.makeAppRouter(), destination: RegionsDestinations.serversList))
@@ -59,7 +59,7 @@ extension DashboardFactory {
     }
     
     static internal func makeQuickConnectViewModel() -> QuickConnectViewModel {
-        QuickConnectViewModel(selectedServerUseCase: makeSelectedServerUserCase(), regionsUseCase: RegionsSelectionFactory.makeRegionsListUseCase())
+        QuickConnectViewModel(selectedServerUseCase: makeSelectedServerUserCase, regionsUseCase: RegionsSelectionFactory.makeRegionsListUseCase())
     }
     
     static func makeQuickConnectView() -> QuickConnectView {

--- a/PIA VPN-tvOS/RegionsSelection/CompositionRoot/RegionsSelectionFactory.swift
+++ b/PIA VPN-tvOS/RegionsSelection/CompositionRoot/RegionsSelectionFactory.swift
@@ -84,7 +84,7 @@ class RegionsSelectionFactory {
     }()
     
     static var makeOptimalLocationUseCase: OptimalLocationUseCaseType = {
-        return OptimalLocationUseCase(serverProvider: VpnConnectionFactory.makeServerProvider(), vpnStatusMonitor: StateMonitorsFactory.makeVPNStatusMonitor, selectedServerUseCase: DashboardFactory.makeSelectedServerUserCase())
+        return OptimalLocationUseCase(serverProvider: VpnConnectionFactory.makeServerProvider(), vpnStatusMonitor: StateMonitorsFactory.makeVPNStatusMonitor, selectedServerUseCase: DashboardFactory.makeSelectedServerUserCase)
     }()
     
     static func makeGetDedicatedIpUseCase() -> GetDedicatedIpUseCaseType {

--- a/PIA VPN-tvOS/Shared/CompositionRoot/VpnConnectionFactory.swift
+++ b/PIA VPN-tvOS/Shared/CompositionRoot/VpnConnectionFactory.swift
@@ -11,7 +11,7 @@ import PIALibrary
 
 class VpnConnectionFactory {
     static var makeVpnConnectionUseCase: VpnConnectionUseCaseType = {
-        return VpnConnectionUseCase(serverProvider: makeServerProvider(), vpnProvider: makeVpnProvider(), vpnStatusMonitor: StateMonitorsFactory.makeVPNStatusMonitor)
+        return VpnConnectionUseCase(serverProvider: makeServerProvider(), vpnProvider: makeVpnProvider(), vpnStatusMonitor: StateMonitorsFactory.makeVPNStatusMonitor, clientPreferences: RegionsSelectionFactory.makeClientPreferences)
     }()
     
     static func makeServerProvider() -> ServerProviderType {

--- a/PIA VPN-tvOS/Shared/StateMonitors/UserAuthenticationStatusMonitor.swift
+++ b/PIA VPN-tvOS/Shared/StateMonitors/UserAuthenticationStatusMonitor.swift
@@ -44,10 +44,7 @@ class UserAuthenticationStatusMonitor: UserAuthenticationStatusMonitorType {
     }
     
     @objc func handleAccountDidLogout() {
-        if status.value != .loggedOut {
-            status.send(.loggedOut)
-        }
-        
+        status.send(.loggedOut)
     }
     
     func getStatus() -> AnyPublisher<UserAuthenticationStatus, Never> {

--- a/PIA VPN-tvOS/Shared/Utils/PIALibrary+Protocols/ClientPreferences+Protocols.swift
+++ b/PIA VPN-tvOS/Shared/Utils/PIALibrary+Protocols/ClientPreferences+Protocols.swift
@@ -12,10 +12,12 @@ import Combine
 
 protocol ClientPreferencesType {
     var selectedServer: ServerType { get set }
+    var lastConnectedServer: ServerType? { get set }
     func getSelectedServer() -> AnyPublisher<ServerType, Never>
 }
 
 class ClientPreferences: ClientPreferencesType {
+    
     private let clientPrefs: Client.Preferences
     
     var selectedServer: ServerType {
@@ -33,6 +35,18 @@ class ClientPreferences: ClientPreferencesType {
             pendingPreferences.commit()
         }
     }
+    
+    var lastConnectedServer: ServerType? {
+        get {
+            clientPrefs.lastConnectedRegion
+        }
+        set {
+            let ed = clientPrefs.editable()
+            ed.lastConnectedRegion = newValue as? Server
+            ed.commit()
+        }
+    }
+    
     
     private var selectedServerPublisher: CurrentValueSubject<ServerType, Never>
     

--- a/PIA VPN-tvOSTests/Common/Mocks/ClientPreferencesMock.swift
+++ b/PIA VPN-tvOSTests/Common/Mocks/ClientPreferencesMock.swift
@@ -1,0 +1,28 @@
+//
+//  ClientPreferencesMock.swift
+//  PIA VPN-tvOSTests
+//
+//  Created by Laura S on 2/23/24.
+//  Copyright © 2024 Private Internet Access Inc. All rights reserved.
+//
+
+import Foundation
+import Combine
+@testable import PIA_VPN_tvOS
+
+class ClientPreferencesMock: ClientPreferencesType {
+    
+    var selectedServer: ServerType = ServerMock()
+    
+    var lastConnectedServer: ServerType?
+    
+    
+    var selectedServerPublisher: CurrentValueSubject<ServerType, Never> = CurrentValueSubject(ServerMock())
+    var getSelectedServerCalled = false
+    func getSelectedServer() -> AnyPublisher<ServerType, Never> {
+        getSelectedServerCalled = true
+        return selectedServerPublisher.eraseToAnyPublisher()
+    }
+    
+    
+}

--- a/PIA VPN.xcodeproj/project.pbxproj
+++ b/PIA VPN.xcodeproj/project.pbxproj
@@ -262,6 +262,7 @@
 		69B70ABE2ACC2CFE0072A09D /* AccessibilityId.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69B70ABD2ACC2CFE0072A09D /* AccessibilityId.swift */; };
 		69B70ABF2ACC2CFE0072A09D /* AccessibilityId.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69B70ABD2ACC2CFE0072A09D /* AccessibilityId.swift */; };
 		69B70AC02ACC2CFE0072A09D /* AccessibilityId.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69B70ABD2ACC2CFE0072A09D /* AccessibilityId.swift */; };
+		69C4C31A2B88D1B00019A8C6 /* ClientPreferencesMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69C4C3192B88D1B00019A8C6 /* ClientPreferencesMock.swift */; };
 		69C587FD2AD00C6300B95EF9 /* PIAExampleWithAuthenticatedAppTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69C587FC2AD00C6300B95EF9 /* PIAExampleWithAuthenticatedAppTest.swift */; };
 		69C5E7CC2B72945F00FE3126 /* TopNavigationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69C5E7CB2B72945F00FE3126 /* TopNavigationView.swift */; };
 		69C5E7CE2B72949000FE3126 /* TopNavigationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69C5E7CD2B72949000FE3126 /* TopNavigationViewModel.swift */; };
@@ -1134,6 +1135,7 @@
 		69B70AB02ACBF51C0072A09D /* PIA-VPN_E2E_Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "PIA-VPN_E2E_Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		69B70AB42ACBF51C0072A09D /* LoginScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginScreen.swift; sourceTree = "<group>"; };
 		69B70ABD2ACC2CFE0072A09D /* AccessibilityId.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityId.swift; sourceTree = "<group>"; };
+		69C4C3192B88D1B00019A8C6 /* ClientPreferencesMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientPreferencesMock.swift; sourceTree = "<group>"; };
 		69C587FC2AD00C6300B95EF9 /* PIAExampleWithAuthenticatedAppTest.swift */ = {isa = PBXFileReference; indentWidth = 2; lastKnownFileType = sourcecode.swift; path = PIAExampleWithAuthenticatedAppTest.swift; sourceTree = "<group>"; tabWidth = 2; };
 		69C5E7CB2B72945F00FE3126 /* TopNavigationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopNavigationView.swift; sourceTree = "<group>"; };
 		69C5E7CD2B72949000FE3126 /* TopNavigationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopNavigationViewModel.swift; sourceTree = "<group>"; };
@@ -2119,6 +2121,7 @@
 				690FC4852B3C5F7300F6DCC8 /* SelectedServerUseCaseMock.swift */,
 				E52E68FF2B56ABE400471913 /* AppRouterSpy.swift */,
 				6953E5522B7B748800D685B4 /* ConnectionStateMonitorMock.swift */,
+				69C4C3192B88D1B00019A8C6 /* ClientPreferencesMock.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -4648,6 +4651,7 @@
 				693B9A422B7615C700757A41 /* RegionsDisplayNameUseCaseMock.swift in Sources */,
 				E5AB286C2B2796E700744E5F /* LoginProviderMock.swift in Sources */,
 				6944B16C2B853505008E3B70 /* OptimalLocationUseCaseMock.swift in Sources */,
+				69C4C31A2B88D1B00019A8C6 /* ClientPreferencesMock.swift in Sources */,
 				693474CD2B6BC84C0061F788 /* FavoriteRegionsUseCaseTests.swift in Sources */,
 				E5AB28872B2911C900744E5F /* AccountProviderMock.swift in Sources */,
 				696E8F102B31AC690080BB31 /* RootContainerViewModelTests.swift in Sources */,


### PR DESCRIPTION
The problem this PR is solving:
- When connected to the Optimal Location and the app is killed, after opening back again the app, the location displayed as the connected one under the Optimal Location was always AU - Adelaide (the first location from the locations list), which was incorrect. The root cause was that once that the VPN connection succeeds we were not storing the current connected location as the `lastConnectedRegion` under the Client Preferences.

- Other glitch solved (in the 2nd commit of the PR):
- After signing out, the app still remained in the Account Settings screen. This was due to the Authentication State not being published under `handleAccountDidLogout` method 