### PR TITLE
PIA-000: Separate tvOS e2e tests execution from tvOS Unit Tests

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -33,9 +33,13 @@ jobs:
 
     - name: Run iOS unit tests
       run: bundle exec fastlane tests
+    
+    - name: Run tvOS e2e tests
+      run: bundle exec fastlane tvos_e2e_tests
+      timeout-minutes: 45
 
     - name: Run iOS e2e tests
-      run: bundle exec fastlane e2e_tests
+      run: bundle exec fastlane ios_e2e_tests
       timeout-minutes: 45
 
       

--- a/PIA VPN-tvOS.xctestplan
+++ b/PIA VPN-tvOS.xctestplan
@@ -1,0 +1,47 @@
+{
+  "configurations" : [
+    {
+      "id" : "29215987-92F9-408B-A171-72ED6320AD78",
+      "name" : "Test Scheme Action",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "targetForVariableExpansion" : {
+      "containerPath" : "container:PIA VPN.xcodeproj",
+      "identifier" : "E5C507762B0E144D00200A6A",
+      "name" : "PIA VPN-tvOS"
+    }
+  },
+  "testTargets" : [
+    {
+      "parallelizable" : true,
+      "target" : {
+        "containerPath" : "container:PIA VPN.xcodeproj",
+        "identifier" : "E5C507852B0E145100200A6A",
+        "name" : "PIA VPN-tvOSTests"
+      }
+    },
+    {
+      "enabled" : false,
+      "parallelizable" : true,
+      "target" : {
+        "containerPath" : "container:PIA VPN.xcodeproj",
+        "identifier" : "E5C5078F2B0E145100200A6A",
+        "name" : "PIA VPN-tvOSUITests"
+      }
+    },
+    {
+      "enabled" : false,
+      "parallelizable" : true,
+      "target" : {
+        "containerPath" : "container:PIA VPN.xcodeproj",
+        "identifier" : "35E8E6572B870AD200A3A3DB",
+        "name" : "PIA-VPN_tvOS_E2E_Tests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/PIA VPN-tvOS_E2E_Tests.xctestplan
+++ b/PIA VPN-tvOS_E2E_Tests.xctestplan
@@ -1,0 +1,37 @@
+{
+  "configurations" : [
+    {
+      "id" : "EC1EF781-61B8-484C-BB72-58B0B8656D3B",
+      "name" : "Configuration 1",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "environmentVariableEntries" : [
+      {
+        "key" : "PIA_TEST_USER",
+        "value" : "xxx"
+      },
+      {
+        "key" : "PIA_TEST_DEDICATEDIP",
+        "value" : "xxx"
+      },
+      {
+        "key" : "PIA_TEST_PASSWORD",
+        "value" : "xxx"
+      }
+    ]
+  },
+  "testTargets" : [
+    {
+      "target" : {
+        "containerPath" : "container:PIA VPN.xcodeproj",
+        "identifier" : "35E8E6572B870AD200A3A3DB",
+        "name" : "PIA-VPN_tvOS_E2E_Tests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/PIA VPN.xcodeproj/project.pbxproj
+++ b/PIA VPN.xcodeproj/project.pbxproj
@@ -1177,6 +1177,7 @@
 		69C5E7CD2B72949000FE3126 /* TopNavigationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopNavigationViewModel.swift; sourceTree = "<group>"; };
 		69C5E7CF2B72962700FE3126 /* TopNavigationFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopNavigationFactory.swift; sourceTree = "<group>"; };
 		69CA26B12B59668700E78894 /* RegionsListUseCaseMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegionsListUseCaseMock.swift; sourceTree = "<group>"; };
+		69E192422B8E14DF00A97286 /* PIA VPN-tvOS.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = "PIA VPN-tvOS.xctestplan"; sourceTree = "<group>"; };
 		69E61DE72B55643500085648 /* RegionsListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegionsListView.swift; sourceTree = "<group>"; };
 		69E61DE92B55644900085648 /* RegionsListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegionsListViewModel.swift; sourceTree = "<group>"; };
 		69E61DEB2B5564C600085648 /* RegionsSelectionFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegionsSelectionFactory.swift; sourceTree = "<group>"; };
@@ -1898,6 +1899,7 @@
 		291C6373183EBC210039EC03 = {
 			isa = PBXGroup;
 			children = (
+				69E192422B8E14DF00A97286 /* PIA VPN-tvOS.xctestplan */,
 				8269A6ED251CB5ED000B4DBF /* PIAWidgetExtension.entitlements */,
 				291C6385183EBC210039EC03 /* PIA VPN */,
 				0EFB6071203D7A2C0095398C /* PIA VPN AdBlocker */,

--- a/PIA VPN.xcodeproj/project.pbxproj
+++ b/PIA VPN.xcodeproj/project.pbxproj
@@ -1178,6 +1178,8 @@
 		69C5E7CF2B72962700FE3126 /* TopNavigationFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopNavigationFactory.swift; sourceTree = "<group>"; };
 		69CA26B12B59668700E78894 /* RegionsListUseCaseMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegionsListUseCaseMock.swift; sourceTree = "<group>"; };
 		69E192422B8E14DF00A97286 /* PIA VPN-tvOS.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = "PIA VPN-tvOS.xctestplan"; sourceTree = "<group>"; };
+		69E192432B8E22FC00A97286 /* PIA-VPN_E2E_Tests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = "PIA-VPN_E2E_Tests.xctestplan"; sourceTree = "<group>"; };
+		69E192442B8E274500A97286 /* PIA VPN-tvOS_E2E_Tests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = "PIA VPN-tvOS_E2E_Tests.xctestplan"; sourceTree = "<group>"; };
 		69E61DE72B55643500085648 /* RegionsListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegionsListView.swift; sourceTree = "<group>"; };
 		69E61DE92B55644900085648 /* RegionsListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegionsListViewModel.swift; sourceTree = "<group>"; };
 		69E61DEB2B5564C600085648 /* RegionsSelectionFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegionsSelectionFactory.swift; sourceTree = "<group>"; };
@@ -1899,6 +1901,8 @@
 		291C6373183EBC210039EC03 = {
 			isa = PBXGroup;
 			children = (
+				69E192442B8E274500A97286 /* PIA VPN-tvOS_E2E_Tests.xctestplan */,
+				69E192432B8E22FC00A97286 /* PIA-VPN_E2E_Tests.xctestplan */,
 				69E192422B8E14DF00A97286 /* PIA VPN-tvOS.xctestplan */,
 				8269A6ED251CB5ED000B4DBF /* PIAWidgetExtension.entitlements */,
 				291C6385183EBC210039EC03 /* PIA VPN */,

--- a/PIA VPN.xcodeproj/xcshareddata/xcschemes/PIA VPN-tvOS.xcscheme
+++ b/PIA VPN.xcodeproj/xcshareddata/xcschemes/PIA VPN-tvOS.xcscheme
@@ -32,6 +32,9 @@
             reference = "container:PIA VPN-tvOS.xctestplan"
             default = "YES">
          </TestPlanReference>
+         <TestPlanReference
+            reference = "container:PIA VPN-tvOS_E2E_Tests.xctestplan">
+         </TestPlanReference>
       </TestPlans>
       <Testables>
          <TestableReference

--- a/PIA VPN.xcodeproj/xcshareddata/xcschemes/PIA VPN-tvOS.xcscheme
+++ b/PIA VPN.xcodeproj/xcshareddata/xcschemes/PIA VPN-tvOS.xcscheme
@@ -26,8 +26,13 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      shouldAutocreateTestPlan = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:PIA VPN-tvOS.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+      </TestPlans>
       <Testables>
          <TestableReference
             skipped = "NO"
@@ -52,7 +57,7 @@
             </BuildableReference>
          </TestableReference>
          <TestableReference
-            skipped = "NO"
+            skipped = "YES"
             parallelizable = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"

--- a/PIA VPN.xcodeproj/xcshareddata/xcschemes/PIA-VPN_E2E_Tests.xcscheme
+++ b/PIA VPN.xcodeproj/xcshareddata/xcschemes/PIA-VPN_E2E_Tests.xcscheme
@@ -21,12 +21,16 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      shouldAutocreateTestPlan = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:PIA-VPN_E2E_Tests.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+      </TestPlans>
       <Testables>
          <TestableReference
-            skipped = "NO"
-            parallelizable = "YES">
+            skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "69B70AAF2ACBF51C0072A09D"

--- a/PIA VPN.xcodeproj/xcshareddata/xcschemes/PIA-VPN_tvOS_E2E_Tests.xcscheme
+++ b/PIA VPN.xcodeproj/xcshareddata/xcschemes/PIA-VPN_tvOS_E2E_Tests.xcscheme
@@ -47,6 +47,11 @@
             value = "xxx"
             isEnabled = "YES">
          </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "PIA_TEST_DEDICATEDIP"
+            value = "xxx"
+            isEnabled = "YES">
+         </EnvironmentVariable>
       </EnvironmentVariables>
    </LaunchAction>
    <ProfileAction

--- a/PIA-VPN_E2E_Tests.xctestplan
+++ b/PIA-VPN_E2E_Tests.xctestplan
@@ -1,0 +1,37 @@
+{
+  "configurations" : [
+    {
+      "id" : "8843AFD5-2776-4814-805F-FB03DFFEB24E",
+      "name" : "Test Scheme Action",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "environmentVariableEntries" : [
+      {
+        "key" : "PIA_TEST_USER",
+        "value" : "xxx"
+      },
+      {
+        "key" : "PIA_TEST_PASSWORD",
+        "value" : "xxx"
+      },
+      {
+        "key" : "PIA_TEST_DEDICATEDIP",
+        "value" : "xxx"
+      }
+    ]
+  },
+  "testTargets" : [
+    {
+      "target" : {
+        "containerPath" : "container:PIA VPN.xcodeproj",
+        "identifier" : "69B70AAF2ACBF51C0072A09D",
+        "name" : "PIA-VPN_E2E_Tests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -14,13 +14,19 @@ platform :ios do
     run_tests(scheme: "PIA VPN-tvOS")
   end
 
-  lane :e2e_tests do
+  lane :ios_e2e_tests do
     run_tests(
       scheme: "PIA VPN dev",
       testplan: "PIA-VPN-e2e-simulator",
       devices: ["iPhone 14"],
       prelaunch_simulator: true,
       test_without_building: true
+    )
+  end
+
+  lane :tvos_e2e_tests do
+    run_tests(
+      scheme: "PIA-VPN_tvOS_E2E_Tests"
     )
   end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -26,7 +26,11 @@ platform :ios do
 
   lane :tvos_e2e_tests do
     run_tests(
-      scheme: "PIA-VPN_tvOS_E2E_Tests"
+      scheme: "PIA VPN-tvOS",
+      testplan: "PIA VPN-tvOS_E2E_Tests",
+      test_without_building: true,
+      prelaunch_simulator: true,
+      device: "Apple TV"
     )
   end
 


### PR DESCRIPTION
- Remove tvOS e2e tests suite from the tvOS unit test test plan in order to keep the execution of these tests suites separate.
- Add a job in CI to run the tvOS e2e tests independently from the tvOS unit tests