### PR TITLE
PIA-1444: Handle storing and displaying dip server on favorites

### DIFF
--- a/PIA VPN-tvOS/Dashboard/CompositionRoot/DashboardFactory.swift
+++ b/PIA VPN-tvOS/Dashboard/CompositionRoot/DashboardFactory.swift
@@ -36,7 +36,7 @@ extension DashboardFactory {
         return SelectedServerViewModel(
             useCase: makeSelectedServerUserCase,
             optimalLocationUseCase: RegionsSelectionFactory.makeOptimalLocationUseCase,
-            regionsDisplayNameUseCase: RegionsSelectionFactory.makeRegionsDisplayNameUseCase(),
+            regionsDisplayNameUseCase: RegionsSelectionFactory.makeRegionsDisplayNameUseCase(), getDedicatedIpUseCase: DedicatedIPFactory.makeGetDedicatedIpUseCase(),
             routerAction: .navigate(router: AppRouterFactory.makeAppRouter(), destination: RegionsDestinations.serversList))
     }
     

--- a/PIA VPN-tvOS/Dashboard/Presentation/SelectedServerViewModel.swift
+++ b/PIA VPN-tvOS/Dashboard/Presentation/SelectedServerViewModel.swift
@@ -9,6 +9,7 @@ class SelectedServerViewModel: ObservableObject {
     private let useCase: SelectedServerUseCaseType
     private let optimalLocationUseCase: OptimalLocationUseCaseType
     private let regionsDisplayNameUseCase: RegionsDisplayNameUseCaseType
+    private let getDedicatedIpUseCase: GetDedicatedIpUseCaseType
     
     let routerAction: AppRouter.Actions
     @Published var selectedServer: ServerType?
@@ -28,11 +29,12 @@ class SelectedServerViewModel: ObservableObject {
     
     @Published var selectedServerSubtitle = ""
     
-    init(useCase: SelectedServerUseCaseType, optimalLocationUseCase: OptimalLocationUseCaseType, regionsDisplayNameUseCase: RegionsDisplayNameUseCaseType,
+    init(useCase: SelectedServerUseCaseType, optimalLocationUseCase: OptimalLocationUseCaseType, regionsDisplayNameUseCase: RegionsDisplayNameUseCaseType, getDedicatedIpUseCase: GetDedicatedIpUseCaseType,
          routerAction: AppRouter.Actions) {
         self.useCase = useCase
         self.optimalLocationUseCase = optimalLocationUseCase
         self.regionsDisplayNameUseCase = regionsDisplayNameUseCase
+        self.getDedicatedIpUseCase = getDedicatedIpUseCase
         self.routerAction = routerAction
         updateState()
     }
@@ -47,6 +49,11 @@ class SelectedServerViewModel: ObservableObject {
     
     func iconImageNameFor(focused: Bool) -> String {
         guard let currentServer = selectedServer else { return "" }
+        
+        if getDedicatedIpUseCase.isDedicatedIp(currentServer) {
+            return .icon_dip_location
+        }
+        
         if currentServer.isAutomatic {
           let autoIcon =  focused ? focusedAutomaticServerIconName : unfocusedAutomaticServerIconName
             return autoIcon

--- a/PIA VPN-tvOS/DedicatedIp/Domain/Use cases/GetDedicatedIpUseCase.swift
+++ b/PIA VPN-tvOS/DedicatedIp/Domain/Use cases/GetDedicatedIpUseCase.swift
@@ -10,6 +10,7 @@ import Foundation
 
 protocol GetDedicatedIpUseCaseType {
     func callAsFunction() -> ServerType?
+    func isDedicatedIp(_ server: ServerType) -> Bool
 }
 
 class GetDedicatedIpUseCase: GetDedicatedIpUseCaseType {
@@ -26,5 +27,11 @@ class GetDedicatedIpUseCase: GetDedicatedIpUseCaseType {
         return serverProvider.currentServersType
             .filter({ $0.dipToken != nil && dipTokens.contains($0.dipToken!) })
             .first
+    }
+    
+    func isDedicatedIp(_ server: ServerType) -> Bool {
+        guard let currentDipServer = callAsFunction() else { return false }
+        return server.dipToken != nil &&
+        server.identifier == currentDipServer.identifier
     }
 }

--- a/PIA VPN-tvOS/DedicatedIp/Domain/Use cases/RemoveDIPUseCase.swift
+++ b/PIA VPN-tvOS/DedicatedIp/Domain/Use cases/RemoveDIPUseCase.swift
@@ -34,7 +34,7 @@ class RemoveDIPUseCase: RemoveDIPUseCaseType {
         }
         
         dedicatedIpProvider.removeDIPToken(dipToken)
-        _ = try? favoriteRegionsUseCase.removeFromFavorites(dedicatedIPServer.identifier)
+        _ = try? favoriteRegionsUseCase.removeFromFavorites(dedicatedIPServer.identifier, isDipServer: true)
         
         let selectedServer = selectedServer.selectedServer
         if selectedServer.identifier == dedicatedIPServer.identifier {

--- a/PIA VPN-tvOS/RegionsSelection/CompositionRoot/RegionsSelectionFactory.swift
+++ b/PIA VPN-tvOS/RegionsSelection/CompositionRoot/RegionsSelectionFactory.swift
@@ -21,7 +21,7 @@ class RegionsSelectionFactory {
     }
     
     static func makeRegionsDisplayNameUseCase() -> RegionsDisplayNameUseCaseType {
-        return RegionsDisplayNameUseCase()
+        return RegionsDisplayNameUseCase(getDedicatedIpUseCase: DedicatedIPFactory.makeGetDedicatedIpUseCase())
     }
     
 
@@ -38,7 +38,7 @@ class RegionsSelectionFactory {
     }
     
     static func makeRegionsFilterUseCase() -> RegionsFilterUseCaseType {
-        return RegionsFilterUseCase(serversUseCase: makeRegionsListUseCase(), favoritesUseCase: makeFavoriteRegionUseCase, searchedRegionsAvailability: makeSearchedRegionsAvailability())
+        return RegionsFilterUseCase(serversUseCase: makeRegionsListUseCase(), favoritesUseCase: makeFavoriteRegionUseCase, searchedRegionsAvailability: makeSearchedRegionsAvailability(), getDedicatedIpUseCase: DedicatedIPFactory.makeGetDedicatedIpUseCase())
     }
     
     static func makeSearchedRegionsAvailability() -> SearchedRegionsAvailabilityType {

--- a/PIA VPN-tvOS/RegionsSelection/Presentation/RegionsListViewModel.swift
+++ b/PIA VPN-tvOS/RegionsSelection/Presentation/RegionsListViewModel.swift
@@ -62,6 +62,12 @@ class RegionsListViewModel: ObservableObject {
     }
     
     func getIconImageName(for server: ServerType) -> (unfocused: String, focused: String) {
+        let isDedicatedIpServer = getDedicatedIpUseCase.isDedicatedIp(server)
+        
+        if isDedicatedIpServer {
+            return (unfocused: .icon_dip_location, focused: .icon_dip_location)
+        }
+        
         if server.isAutomatic {
             return (unfocused: .smart_location_icon_name, focused: .smart_location_icon_highlighted_name)
         } else {
@@ -200,14 +206,17 @@ extension RegionsListViewModel {
     }
     
     private func isFavorite(server: ServerType) -> Bool {
-        let favoritesIds = favoriteUseCase.favoriteIdentifiers
-        return favoritesIds.contains(server.identifier)
+        let isServerDipServer = getDedicatedIpUseCase.isDedicatedIp(server)
+        let isServerFavorite = favoriteUseCase.isFavoriteServerWith(identifier: server.identifier, isDipServer: isServerDipServer)
+        
+        return isServerFavorite
     }
     
     private func addToFavorites(_ server: ServerType) {
         favoriteToggleError = nil
+        let isDipServer = getDedicatedIpUseCase.isDedicatedIp(server)
         do {
-            try  favoriteUseCase.addToFavorites(server.identifier)
+            try favoriteUseCase.addToFavorites(server.identifier, isDipServer: isDipServer)
             refreshRegionsList()
             favoriteToggleError = nil
         } catch {
@@ -217,8 +226,9 @@ extension RegionsListViewModel {
     
     private func removeFromFavorites(_ server: ServerType) {
         favoriteToggleError = nil
+        let isDipServer = getDedicatedIpUseCase.isDedicatedIp(server)
         do {
-            try  favoriteUseCase.removeFromFavorites(server.identifier)
+            try favoriteUseCase.removeFromFavorites(server.identifier, isDipServer: isDipServer)
             refreshRegionsList()
             favoriteToggleError = nil
         } catch {

--- a/PIA VPN-tvOS/RegionsSelection/UI/RegionsListView.swift
+++ b/PIA VPN-tvOS/RegionsSelection/UI/RegionsListView.swift
@@ -21,29 +21,29 @@ struct RegionsListView: View {
             label: RegionsListItemButton.ContextMenuLabel(title: viewModel.favoriteContextMenuTitle(for: server), iconName: viewModel.favoriteIconName(for: server)),
             action: {
                 viewModel.toggleFavorite(server: server)
-        })
+            })
     }
     
     var body: some View {
-        VStack(alignment: .leading) {
-            if !viewModel.optimalAndDIPServers.isEmpty {
-                optimalLocationAndDIPLocationSection
-            }
-            
-            if let title = viewModel.regionsListTitle {
-                Text(title)
-                    .font(.headline)
-                    .fontWeight(.regular)
-                    .foregroundColor(Color.pia_on_surface_container_secondary)
-            }
-            ScrollView(.vertical) {
+        ScrollView(.vertical) {
+            VStack(alignment: .leading) {
+                if !viewModel.optimalAndDIPServers.isEmpty {
+                    optimalLocationAndDIPLocationSection
+                }
+                
+                if let title = viewModel.regionsListTitle {
+                    Text(title)
+                        .font(.headline)
+                        .fontWeight(.regular)
+                        .foregroundColor(Color.pia_on_surface_container_secondary)
+                }
                 
                 LazyVGrid(columns: columns, alignment: .leading, spacing: 40) {
-                    ForEach(viewModel.servers, id: \.identifier) { server in
+                    ForEach(viewModel.servers, id: \.id) { server in
                         RegionsListItemButton(
                             onRegionItemSelected: {
-                            viewModel.didSelectRegionServer(server)
-                        },
+                                viewModel.didSelectRegionServer(server)
+                            },
                             iconName: viewModel.getIconImageName(for: server).unfocused,
                             highlightedIconName: viewModel.getIconImageName(for: server).focused,
                             title: viewModel.getDisplayName(for: server).title,
@@ -51,14 +51,16 @@ struct RegionsListView: View {
                             favoriteIconName: viewModel.favoriteIconName(for: server),
                             contextMenuItem: contextMenuItem(for: server)
                         )
-
+                        
                     }
                 }
+                
+            }.onAppear {
+                viewModel.viewDidAppear()
             }
             
-        }.onAppear {
-            viewModel.viewDidAppear()
         }
+        
     }
 }
 
@@ -80,8 +82,8 @@ extension RegionsListView {
                 ForEach(viewModel.optimalAndDIPServers, id: \.identifier) { server in
                     RegionsListItemButton(
                         onRegionItemSelected: {
-                        viewModel.didSelectRegionServer(server)
-                    },
+                            viewModel.didSelectRegionServer(server)
+                        },
                         iconName: server.dipToken == nil ? .smart_location_icon_name : .icon_dip_location,
                         highlightedIconName: server.dipToken == nil ? .smart_location_icon_highlighted_name : .icon_dip_location,
                         title: viewModel.getDisplayName(for: server).title,
@@ -89,12 +91,12 @@ extension RegionsListView {
                         favoriteIconName: viewModel.favoriteIconName(for: server),
                         contextMenuItem: contextMenuItem(for: server)
                     )
-
+                    
                 }
             }
         }
         
-
+        
     }
     
 }

--- a/PIA VPN-tvOS/RegionsSelection/UseCases/FavoriteRegionUseCase.swift
+++ b/PIA VPN-tvOS/RegionsSelection/UseCases/FavoriteRegionUseCase.swift
@@ -13,13 +13,15 @@ protocol FavoriteRegionUseCaseType {
     var favoriteIdentifiers: [String] { get }
     var favoriteIdentifiersPublisher: Published<[String]>.Publisher { get }
     @discardableResult
-    func addToFavorites(_ id: String) throws -> [String]
+    func addToFavorites(_ id: String, isDipServer: Bool) throws -> [String]
     @discardableResult
-    func removeFromFavorites(_ id: String) throws -> [String]
+    func removeFromFavorites(_ id: String, isDipServer: Bool) throws -> [String]
+    func getFavoriteDIPServerId() -> String?
+    func isFavoriteServerWith(identifier: String, isDipServer: Bool) -> Bool
 }
 
 class FavoriteRegionUseCase: FavoriteRegionUseCaseType {
-    
+    static let favDipIdPreffix = "favDIP:"
     
     private let keychain: KeychainType
     
@@ -44,21 +46,45 @@ class FavoriteRegionUseCase: FavoriteRegionUseCaseType {
     }
     
     @discardableResult
-    func addToFavorites(_ id: String) throws -> [String] {
+    func addToFavorites(_ id: String, isDipServer: Bool) throws -> [String] {
         var newFavorites = favoriteIdentifiers
-        newFavorites.append(id)
+        let newFavoriteId = isDipServer ? calculateServerIdForDipServer(id) : id
+        newFavorites.append(newFavoriteId)
         try keychain.set(favorites: newFavorites)
         favorites = newFavorites
         return newFavorites
     }
     
     @discardableResult
-    func removeFromFavorites(_ id: String) throws -> [String] {
-        var newFavorites = favoriteIdentifiers.filter { id != $0 }
+    func removeFromFavorites(_ id: String, isDipServer: Bool) throws -> [String] {
+        let storedFavoriteId = isDipServer ? calculateServerIdForDipServer(id) : id
+        let newFavorites = favoriteIdentifiers.filter { storedFavoriteId != $0 }
         try keychain.set(favorites: newFavorites)
         favorites = newFavorites
         return newFavorites
     }
     
+    private func calculateServerIdForDipServer(_ id: String) -> String {
+        return "\(Self.favDipIdPreffix)\(id)"
+    }
     
+    func getFavoriteDIPServerId() -> String? {
+        guard let storedFavIdWithPreffix = favoriteIdentifiers.filter { $0.hasPrefix(Self.favDipIdPreffix) }.first else {
+            return nil
+        }
+        
+        let dipServerIdWithoutPreffix = String(storedFavIdWithPreffix.dropFirst(Self.favDipIdPreffix.count))
+        
+        return dipServerIdWithoutPreffix
+    }
+    
+    func isFavoriteServerWith(identifier: String, isDipServer: Bool) -> Bool {
+        if isDipServer {
+            guard let savedFavoriteDipServerId = getFavoriteDIPServerId() else { return false }
+            return savedFavoriteDipServerId == identifier
+        } else {
+            return favoriteIdentifiers.contains(identifier)
+        }
+        
+    }
 }

--- a/PIA VPN-tvOS/RegionsSelection/UseCases/RegionsDisplayNameUseCase.swift
+++ b/PIA VPN-tvOS/RegionsSelection/UseCases/RegionsDisplayNameUseCase.swift
@@ -17,18 +17,24 @@ protocol RegionsDisplayNameUseCaseType {
     func getDisplayNameForOptimalLocation(with targetLocation: ServerType?) -> (title: String, subtitle: String)
 }
 
-
 class RegionsDisplayNameUseCase: RegionsDisplayNameUseCaseType {
+    let getDedicatedIpUseCase: GetDedicatedIpUseCaseType
+    
+    init(getDedicatedIpUseCase: GetDedicatedIpUseCaseType) {
+        self.getDedicatedIpUseCase = getDedicatedIpUseCase
+    }
     
     func getDisplayName(for server: ServerType, amongst servers: [ServerType]) -> (title: String, subtitle: String) {
-
-        guard !servers.isEmpty else {
-            return (title: server.country, subtitle: server.name)
+        
+        if getDedicatedIpUseCase.isDedicatedIp(server) {
+            return getDisplayNameForDedicatedIpServer(server)
         }
         
-        if server.dipToken != nil {
-            return (title: L10n.Localizable.Settings.Dedicatedip.Stats.dedicatedip, subtitle: server.name)
-        } else if isTheDefaultServer(server, amongst: servers) {
+        if servers.isEmpty {
+            return (title: server.country, subtitle: server.name)
+        }
+
+        if isTheDefaultServer(server, amongst: servers) {
             return (title: server.name, subtitle: L10n.Localizable.Regions.ListItem.Default.title)
         } else {
             return (title: server.country, subtitle: getDisplaySubtitleForNonDefault(server: server))
@@ -46,6 +52,10 @@ class RegionsDisplayNameUseCase: RegionsDisplayNameUseCaseType {
             return (title: L10n.Localizable.LocationSelection.OptimalLocation.title, subtitle: L10n.Localizable.Global.automatic)
         }
         
+    }
+    
+    private func getDisplayNameForDedicatedIpServer(_ server: ServerType) -> (title: String, subtitle: String) {
+        return (title: L10n.Localizable.Settings.Dedicatedip.Stats.dedicatedip, subtitle: server.name)
     }
     
 }

--- a/PIA VPN-tvOS/Shared/Utils/PIALibrary+Protocols/PIALibrary+Protocols.swift
+++ b/PIA VPN-tvOS/Shared/Utils/PIALibrary+Protocols/PIALibrary+Protocols.swift
@@ -13,6 +13,7 @@ protocol AccountProviderType {
 extension DefaultAccountProvider: AccountProviderType { }
 
 protocol ServerType {
+    var id: ObjectIdentifier { get }
     var name: String { get }
     var identifier: String { get }
     var regionIdentifier: String { get }
@@ -26,6 +27,11 @@ protocol ServerType {
 }
 
 extension Server: ServerType {
+    
+    public var id: ObjectIdentifier {
+        return ObjectIdentifier(self)
+    }
+    
     var dipStatusString: String? {
         dipStatus?.getStatus()
     }

--- a/PIA VPN-tvOSTests/Common/Mocks/ServerMock.swift
+++ b/PIA VPN-tvOSTests/Common/Mocks/ServerMock.swift
@@ -3,6 +3,9 @@ import Foundation
 @testable import PIA_VPN_tvOS
 
 class ServerMock: ServerType {
+    
+    var id: ObjectIdentifier { return ObjectIdentifier(self) }
+    
     var isAutomatic: Bool
     
     var pingTime: Int?
@@ -23,7 +26,7 @@ class ServerMock: ServerType {
     
     var dipStatusString: String?
     
-    init(name: String, identifier: String, regionIdentifier: String, country: String, geo: Bool, pingTime: Int? = nil, isAutomatic: Bool = false) {
+    init(name: String = "", identifier: String = "" , regionIdentifier: String = "", country: String = "", geo: Bool = false, pingTime: Int? = nil, isAutomatic: Bool = false) {
         self.name = name
         self.identifier = identifier
         self.regionIdentifier = regionIdentifier

--- a/PIA VPN-tvOSTests/Dashboard/SelectedServerViewModelTests.swift
+++ b/PIA VPN-tvOSTests/Dashboard/SelectedServerViewModelTests.swift
@@ -1,0 +1,132 @@
+//
+//  SelectedServerViewModelTests.swift
+//  PIA VPN-tvOSTests
+//
+//  Created by Laura S on 3/1/24.
+//  Copyright © 2024 Private Internet Access Inc. All rights reserved.
+//
+
+import Foundation
+import XCTest
+import Combine
+
+@testable import PIA_VPN_tvOS
+
+class SelectedServerViewModelTests: XCTestCase {
+    class Fixture {
+        let selectedServerUseCaseMock = SelectedServerUseCaseMock()
+        let optimalLocationUseCaseMock = OptimalLocationUseCaseMock()
+        let regionsDisplayNameUseCaseMock = RegionsDisplayNameUseCaseMock()
+        var getDedicatedIpUseCaseMock = GetDedicatedIpUseCaseMock(result: nil)
+        let routerSpy = AppRouterSpy()
+        var routerActionMock: AppRouter.Actions!
+        
+        static let barcelona = ServerMock(name: "Barcelona-1", identifier: "es-server-barcelona", regionIdentifier: "es-region", country: "ES", geo: false, pingTime: 25)
+        
+        static let optimaLocation = ServerMock(isAutomatic: true)
+        
+        static let dipServer = ServerMock(name: "US New York", identifier: "us-ny", regionIdentifier: "us", country: "us", geo: false)
+        
+        init() {
+            self.routerActionMock = .goBackToRoot(router: self.routerSpy)
+        }
+        
+        func stubGetDedicatedIpServer(_ server: ServerType) {
+            self.getDedicatedIpUseCaseMock = GetDedicatedIpUseCaseMock(result: server)
+        }
+    }
+    
+    var fixture: Fixture!
+    var sut: SelectedServerViewModel!
+    
+    override func setUp() {
+        fixture = Fixture()
+    }
+    
+    override func tearDown() {
+        fixture = nil
+        sut = nil
+    }
+    
+    private func instantiateSut() {
+        sut = SelectedServerViewModel(useCase: fixture.selectedServerUseCaseMock, 
+                                      optimalLocationUseCase: fixture.optimalLocationUseCaseMock,
+                                      regionsDisplayNameUseCase: fixture.regionsDisplayNameUseCaseMock,
+                                      getDedicatedIpUseCase: fixture.getDedicatedIpUseCaseMock,
+                                      routerAction: fixture.routerActionMock)
+        
+    }
+    
+    
+    func test_selectedServerTitle_forOptimalLocation() {
+        // GIVEN that the selected location is the Optimal Location
+        instantiateSut()
+        sut.selectedServer = Fixture.optimaLocation
+        
+        // THEN the selected server titl is "Optimal Location"
+        XCTAssertEqual(sut.selectedSeverTitle, "Optimal Location")
+    }
+    
+    func test_selectedServerTitle_forNonOptimalLocation() {
+        // GIVEN that the selected location is Barcelona
+        instantiateSut()
+        sut.selectedServer = Fixture.barcelona
+        
+        // THEN the selected server titl is "Selected Location"
+        XCTAssertEqual(sut.selectedSeverTitle, "Selected Location")
+    }
+    
+    
+    func test_iconImageForOptimalLocation() {
+        // GIVEN that the selected location is the Optimal Location
+        instantiateSut()
+        sut.selectedServer = Fixture.optimaLocation
+        
+        let iconImageNameWhenFocused = sut.iconImageNameFor(focused: true)
+        
+        // THEN the icon image for focused state name is
+        XCTAssertEqual(iconImageNameWhenFocused, .smart_location_icon_highlighted_name)
+        
+        let iconImageNameWhenNotFocused = sut.iconImageNameFor(focused: false)
+        
+        // AND the icon image for not focused state name is
+        XCTAssertEqual(iconImageNameWhenNotFocused, .smart_location_icon_name)
+        
+    }
+    
+    func test_iconImageForDipLocation() {
+        // GIVEN that the selected location is the dip location
+        fixture.stubGetDedicatedIpServer(Fixture.dipServer)
+        instantiateSut()
+        sut.selectedServer = Fixture.dipServer
+        
+        let iconImageNameWhenFocused = sut.iconImageNameFor(focused: true)
+        
+        // THEN the icon image for focused state name is
+        XCTAssertEqual(iconImageNameWhenFocused, .icon_dip_location)
+        
+        let iconImageNameWhenNotFocused = sut.iconImageNameFor(focused: false)
+        
+        // AND the icon image for not focused state name is
+        XCTAssertEqual(iconImageNameWhenNotFocused, .icon_dip_location)
+        
+    }
+    
+    func test_iconImageForNonOptimalAndNonDipLocation() {
+        // GIVEN that the selected location is Barcelona and is Not the Optimal Location or a dip location
+        instantiateSut()
+        sut.selectedServer = Fixture.barcelona
+        
+        let iconImageNameWhenFocused = sut.iconImageNameFor(focused: true)
+        
+        // THEN the icon image for focused state name is
+        XCTAssertEqual(iconImageNameWhenFocused, "flag-es")
+        
+        let iconImageNameWhenNotFocused = sut.iconImageNameFor(focused: false)
+        
+        // AND the icon image for not focused state name is
+        XCTAssertEqual(iconImageNameWhenNotFocused, "flag-es")
+        
+    }
+    
+}

--- a/PIA VPN-tvOSTests/DedicatedIp/DedicatedIPViewModelTests.swift
+++ b/PIA VPN-tvOSTests/DedicatedIp/DedicatedIPViewModelTests.swift
@@ -147,6 +147,9 @@ final class DedicatedIPViewModelTests: XCTestCase {
 }
 
 struct ServerTypeStub: ServerType {
+    
+    var id: ObjectIdentifier { return ObjectIdentifier(ServerMock()) }
+    
     var name: String
     var identifier: String
     var regionIdentifier: String

--- a/PIA VPN-tvOSTests/DedicatedIp/Mocks/GetDedicatedIpUseCaseMock.swift
+++ b/PIA VPN-tvOSTests/DedicatedIp/Mocks/GetDedicatedIpUseCaseMock.swift
@@ -10,13 +10,26 @@ import Foundation
 @testable import PIA_VPN_tvOS
 
 class GetDedicatedIpUseCaseMock: GetDedicatedIpUseCaseType {
+    
     private let result: ServerType?
     
     init(result: ServerType?) {
         self.result = result
     }
     
+    var callAsFunctionCalled = false
+    var callAsFunctionCalledAttempt = 0
     func callAsFunction() -> ServerType? {
-        result
+        callAsFunctionCalled = true
+        callAsFunctionCalledAttempt += 1
+        return result
+    }
+    
+    var isDedicatedIpCalled = false
+    var isDedicatedIpCalledAttempt = 0
+    func isDedicatedIp(_ server: ServerType) -> Bool {
+        isDedicatedIpCalled = true
+        isDedicatedIpCalledAttempt += 1
+        return result?.identifier == server.identifier
     }
 }

--- a/PIA VPN-tvOSTests/RegionsList/FavoriteRegionsUseCaseTests.swift
+++ b/PIA VPN-tvOSTests/RegionsList/FavoriteRegionsUseCaseTests.swift
@@ -8,6 +8,8 @@
 
 import Foundation
 import XCTest
+import Combine
+
 @testable import PIA_VPN_tvOS
 import PIALibrary
 
@@ -18,13 +20,14 @@ class FavoriteRegionsUseCaseTests: XCTestCase {
     
     var fixture: Fixture!
     var sut: FavoriteRegionUseCase!
+    var favoritesPublishedValues: [String] = []
+    var cancellables = Set<AnyCancellable>()
     
-    func instantiateSut() {
-        sut = FavoriteRegionUseCase(keychain: fixture.keychainMock)
-    }
     
     override func setUp() {
         fixture = Fixture()
+        favoritesPublishedValues = []
+        cancellables = Set<AnyCancellable>()
     }
     
     override func tearDown() {
@@ -32,24 +35,40 @@ class FavoriteRegionsUseCaseTests: XCTestCase {
         sut = nil
     }
     
+    private func instantiateSut() {
+        sut = FavoriteRegionUseCase(keychain: fixture.keychainMock)
+    }
     
-    func test_addToFavorites_whenKeychainSucceeds() throws {
+    private func subscribeToPublishedFavorites() {
+        sut.favoriteIdentifiersPublisher
+            .sink { [weak self] newFavs in
+                self?.favoritesPublishedValues = newFavs
+            }.store(in: &cancellables)
+    }
+    
+    
+    func test_addToFavorites_NoDipServer_whenKeychainSucceeds() throws {
         // GIVEN that there is one item saved to favorites
         fixture.keychainMock.getFavoritesResultSuccess = ["server-id-one"]
         
         // AND GIVEN that no error is thrown when trying to save a favorite into the Keychain
         fixture.keychainMock.setFavoritesResultError = nil
         instantiateSut()
+        subscribeToPublishedFavorites()
+        // The initial value of the published favorites contains one item
+        XCTAssertEqual(favoritesPublishedValues.count, 1)
         
-        // WHEN adding a new item to the favorites list
-        let newFavorites = try sut.addToFavorites("server-id-two")
+        // WHEN adding a new item that is not a DIP server to the favorites list
+        let newFavorites = try sut.addToFavorites("server-id-two", isDipServer: false)
 
+        // THEN the new item id is added to the list of favorites
         XCTAssertEqual(newFavorites.count, 2)
         XCTAssertEqual(["server-id-one", "server-id-two"], newFavorites)
-        
+        // AND the new value is also publised on the favorites publisher
+        XCTAssertEqual(favoritesPublishedValues.count, 2)
     }
     
-    func test_addToFavorites_whenKeychainFails() {
+    func test_addToFavorites_NoDipServer_whenKeychainFails() {
         // GIVEN that there is one item saved to favorites
         fixture.keychainMock.getFavoritesResultSuccess = ["server-id-one"]
         
@@ -57,30 +76,35 @@ class FavoriteRegionsUseCaseTests: XCTestCase {
         fixture.keychainMock.setFavoritesResultError = KeychainError.add
         instantiateSut()
         
-        // WHEN adding a new item to the favorites list
+        // WHEN adding a new item that is not a DIP server to the favorites list
         // THEN an error is thrown
-        XCTAssertThrowsError(try sut.addToFavorites("server-id-two"))
+        XCTAssertThrowsError(try sut.addToFavorites("server-id-two", isDipServer: false))
 
     }
     
     
-    func test_removeFavorites_whenKeychainSucceeds() throws {
+    func test_removeFavorites_NoDipServer_whenKeychainSucceeds() throws {
         // GIVEN that there is one item saved to favorites
         fixture.keychainMock.getFavoritesResultSuccess = ["server-id-one"]
         
         // AND GIVEN that no error is thrown when trying to set the favorites into the Keychain
         fixture.keychainMock.setFavoritesResultError = nil
         instantiateSut()
+        subscribeToPublishedFavorites()
+        // The initial value of the published favorites contains one item
+        XCTAssertEqual(favoritesPublishedValues.count, 1)
         
         // WHEN removing the item from the favorites list
-        let newFavorites = try sut.removeFromFavorites("server-id-one")
+        let newFavorites = try sut.removeFromFavorites("server-id-one", isDipServer: false)
         // THEN the item is removed from the favorites list
         XCTAssertEqual(newFavorites.count, 0)
         XCTAssertEqual([], newFavorites)
+        // AND the favorites publisher is also updated with the empty list of favorites
+        XCTAssertEqual(favoritesPublishedValues.count, 0)
         
     }
     
-    func test_removeFromFavorites_whenKeychainFails() {
+    func test_removeFromFavorites_NoDipServer_whenKeychainFails() {
         // GIVEN that there is one item saved to favorites
         fixture.keychainMock.getFavoritesResultSuccess = ["server-id-one"]
         
@@ -90,7 +114,165 @@ class FavoriteRegionsUseCaseTests: XCTestCase {
         
         // WHEN removing the item from the favorites list
         // THEN an error is thrown
-        XCTAssertThrowsError(try sut.removeFromFavorites("server-id-one"))
+        XCTAssertThrowsError(try sut.removeFromFavorites("server-id-one", isDipServer: false))
 
     }
+    
+    func test_addToFavorites_DipServer_whenKeychainSucceeds() throws {
+        // GIVEN that there is one item saved to favorites
+        fixture.keychainMock.getFavoritesResultSuccess = ["server-id-one"]
+        
+        // AND GIVEN that no error is thrown when trying to save a favorite into the Keychain
+        fixture.keychainMock.setFavoritesResultError = nil
+        instantiateSut()
+        
+        // WHEN adding a new item that is a DIP server to the favorites list
+        let newFavorites = try sut.addToFavorites("server-id-two", isDipServer: true)
+
+        // THEN the new item id with the DIP preffix is added to the list of favorites
+        XCTAssertEqual(newFavorites.count, 2)
+        XCTAssertEqual(["server-id-one", "favDIP:server-id-two"], newFavorites)
+        
+    }
+    
+    func test_addToFavorites_DipServer_whenKeychainFails() {
+        // GIVEN that there is one item saved to favorites
+        fixture.keychainMock.getFavoritesResultSuccess = ["server-id-one"]
+        
+        // AND GIVEN that AN error is thrown when trying to save a favorite into the Keychain
+        fixture.keychainMock.setFavoritesResultError = KeychainError.add
+        instantiateSut()
+        
+        // WHEN adding a new item that is a DIP server to the favorites list
+        // THEN an error is thrown
+        XCTAssertThrowsError(try sut.addToFavorites("server-id-two", isDipServer: true))
+
+    }
+    
+    func test_removeFavorites_DipServer_whenKeychainSucceeds() throws {
+        // GIVEN that "server-id-one" is saved to favorites as a favorite DIP server
+        fixture.keychainMock.getFavoritesResultSuccess = ["favDIP:server-id-one"]
+        
+        // AND GIVEN that no error is thrown when trying to set the favorites into the Keychain
+        fixture.keychainMock.setFavoritesResultError = nil
+        instantiateSut()
+        
+        // WHEN calling to remove "server-id-one" as a dip server from the favorites list
+        let newFavorites = try sut.removeFromFavorites("server-id-one", isDipServer: true)
+        // THEN the item is removed from the favorites list
+        XCTAssertEqual(newFavorites.count, 0)
+        XCTAssertEqual([], newFavorites)
+        
+    }
+    
+    func test_removeFromFavorites_DipServer_whenKeychainFails() {
+        // GIVEN that "server-id-one" is saved to favorites as a favorite DIP server
+        fixture.keychainMock.getFavoritesResultSuccess = ["favDIP:server-id-one"]
+        
+        // AND GIVEN that AN error is thrown when trying to set the favorites into the Keychain
+        fixture.keychainMock.setFavoritesResultError = KeychainError.add
+        instantiateSut()
+        
+        // WHEN calling to remove "server-id-one" as a dip server from the favorites list
+        // THEN an error is thrown
+        XCTAssertThrowsError(try sut.removeFromFavorites("server-id-one", isDipServer: true))
+    }
+    
+    func test_addToFavorites_sameServer_withDIP() throws {
+        // GIVEN that there is one item saved to favorites that is NOT a DIP Server
+        fixture.keychainMock.getFavoritesResultSuccess = ["server-id-one"]
+        
+        // AND GIVEN that no error is thrown when trying to set the favorites into the Keychain
+        fixture.keychainMock.setFavoritesResultError = nil
+        instantiateSut()
+        
+        // WHEN trying to add the same item id, but as a DIP server to the list
+        let newFavorites = try sut.addToFavorites("server-id-one", isDipServer: true)
+
+        // THEN the new item id with the DIP preffix is added to the list of favorites
+        XCTAssertEqual(newFavorites.count, 2)
+        XCTAssertEqual(["server-id-one", "favDIP:server-id-one"], newFavorites)
+    }
+    
+    func test_removeFromFavorites_sameServer_withDIP() throws {
+        // GIVEN that there is one item saved to favorites that is NOT a DIP Server
+        fixture.keychainMock.getFavoritesResultSuccess = ["server-id-one"]
+        
+        // AND GIVEN that no error is thrown when trying to set the favorites into the Keychain
+        fixture.keychainMock.setFavoritesResultError = nil
+        instantiateSut()
+        
+        // WHEN trying to remove the same item id, but as a DIP server to the list
+        let newFavorites = try sut.removeFromFavorites("server-id-one", isDipServer: true)
+
+        // THEN nothing gets removed and the favorites list remains with 1 item
+        XCTAssertEqual(newFavorites.count, 1)
+        XCTAssertEqual(["server-id-one"], newFavorites)
+    }
+    
+    func test_getFavoriteDIPServerId_when_DipIsFavorite() {
+        // GIVEN that there is one item saved to favorites that is NOT a DIP Server, and one that is a DIP server
+        fixture.keychainMock.getFavoritesResultSuccess = ["server-id-one", "favDIP:server-id-two"]
+        
+        instantiateSut()
+        
+        // WHEN getting the id of the favorite DIP server
+        let favoriteDIPServerId = sut.getFavoriteDIPServerId()
+        
+        // THEN the server id is returned without the fav DIP preffix
+        XCTAssertEqual(favoriteDIPServerId, "server-id-two")
+        
+    }
+    
+    func test_getFavoriteDIPServerId_when_DipIsNotFavorite() {
+        // GIVEN that no DIP item is stored in the favorites
+        fixture.keychainMock.getFavoritesResultSuccess = ["server-id-one", "server-id-two"]
+        
+        instantiateSut()
+        
+        // WHEN getting the id of the favorite DIP server
+        let favoriteDIPServerId = sut.getFavoriteDIPServerId()
+        
+        // THEN the returned value is nil
+        XCTAssertNil(favoriteDIPServerId)
+        
+    }
+    
+    
+    func test_isFavorite_whenNoDipServerIsSaved() {
+        // GIVEN that no DIP item is stored in the favorites
+        fixture.keychainMock.getFavoritesResultSuccess = ["server-id-one", "server-id-two"]
+        
+        instantiateSut()
+        
+        // WHEN calculating if "server-id-two" is favorite as a No Dip Server
+        let isServerTwoFavoriteAsNoDip = sut.isFavoriteServerWith(identifier: "server-id-two", isDipServer: false)
+        // THEN the result is true
+        XCTAssertTrue(isServerTwoFavoriteAsNoDip)
+        
+        // WHEN calculating if "server-id-two" is favorite as a Dip Server
+        let isServerTwoFavoriteAsDip = sut.isFavoriteServerWith(identifier: "server-id-two", isDipServer: true)
+        // THEN the result is false
+        XCTAssertFalse(isServerTwoFavoriteAsDip)
+        
+    }
+    
+    func test_isFavorite_whenADipServerIsSaved() {
+        // GIVEN that a DIP item is stored in the favorites
+        fixture.keychainMock.getFavoritesResultSuccess = ["server-id-one", "favDIP:server-id-two"]
+        
+        instantiateSut()
+        
+        // WHEN calculating if "server-id-two" is favorite as a No Dip Server
+        let isServerTwoFavoriteAsNoDip = sut.isFavoriteServerWith(identifier: "server-id-two", isDipServer: false)
+        // THEN the result is false
+        XCTAssertFalse(isServerTwoFavoriteAsNoDip)
+        
+        // WHEN calculating if "server-id-two" is favorite as a Dip Server
+        let isServerTwoFavoriteAsDip = sut.isFavoriteServerWith(identifier: "server-id-two", isDipServer: true)
+        // THEN the result is true
+        XCTAssertTrue(isServerTwoFavoriteAsDip)
+        
+    }
+    
 }

--- a/PIA VPN-tvOSTests/RegionsList/Mocks/FavoriteRegionUseCaseMock.swift
+++ b/PIA VPN-tvOSTests/RegionsList/Mocks/FavoriteRegionUseCaseMock.swift
@@ -12,7 +12,6 @@ import Combine
 
 class FavoriteRegionUseCaseMock: FavoriteRegionUseCaseType {
     
-    
     var favoriteIdentifiers: [String] = []
     @Published private var favorites: [String] = []
     var favoriteIdentifiersPublisher: Published<[String]>.Publisher {
@@ -21,12 +20,12 @@ class FavoriteRegionUseCaseMock: FavoriteRegionUseCaseType {
     
     var addToFavoritesCalled = false
     var addToFavoritesCalledAttempt = 0
-    var addToFavoritesCalledWithArgument: String = ""
+    var addToFavoritesCalledWithArguments: (serverId: String, isDipServer: Bool) = (serverId: "", isDipServer: false)
     var addToFavoritesCalledErrorThrown: Error?
-    func addToFavorites(_ id: String) throws -> [String] {
+    func addToFavorites(_ id: String, isDipServer: Bool) throws -> [String] {
         addToFavoritesCalled = true
         addToFavoritesCalledAttempt += 1
-        addToFavoritesCalledWithArgument = id
+        addToFavoritesCalledWithArguments = (serverId: id, isDipServer: isDipServer)
         if let error = addToFavoritesCalledErrorThrown {
             throw error
         } else {
@@ -36,12 +35,12 @@ class FavoriteRegionUseCaseMock: FavoriteRegionUseCaseType {
     
     var removeFromFavoritesCalled = false
     var removeFromFavoritesCalledAttempt = 0
-    var removeFromFavoritesCalledWithArgument = ""
+    var removeFromFavoritesCalledWithArguments: (serverId: String, isDipServer: Bool) = (serverId: "", isDipServer: false)
     var removeFromFavoritesCalledErrorThrown: Error?
-    func removeFromFavorites(_ id: String) throws -> [String] {
+    func removeFromFavorites(_ id: String, isDipServer: Bool) throws -> [String] {
         removeFromFavoritesCalled = true
         removeFromFavoritesCalledAttempt += 1
-        removeFromFavoritesCalledWithArgument = id
+        removeFromFavoritesCalledWithArguments = (serverId: id, isDipServer: isDipServer)
         
         if let error = removeFromFavoritesCalledErrorThrown {
             throw error
@@ -50,5 +49,25 @@ class FavoriteRegionUseCaseMock: FavoriteRegionUseCaseType {
         }
     }
     
+    
+    var getFavoriteDIPServerIdCalled = false
+    var getFavoriteDIPServerIdCalledAttempt = 0
+    var getFavoriteDIPServerIdResult: String?
+    func getFavoriteDIPServerId() -> String? {
+        getFavoriteDIPServerIdCalled = true
+        getFavoriteDIPServerIdCalledAttempt += 1
+        return getFavoriteDIPServerIdResult
+    }
+    
+    var isFavoriteServerWithCalled = false
+    var isFavoriteServerWithCalledAttepmt = 0
+    var isFavoriteServerWithArguments: (identifier: String, isDipServer: Bool)!
+    var isFavoriteServerWithIdentifierResult: Bool = false
+    func isFavoriteServerWith(identifier: String, isDipServer: Bool) -> Bool {
+        isFavoriteServerWithCalled = true
+        isFavoriteServerWithCalledAttepmt += 1
+        isFavoriteServerWithArguments = (identifier: identifier, isDipServer: isDipServer)
+        return isFavoriteServerWithIdentifierResult
+    }
     
 }

--- a/PIA VPN-tvOSTests/RegionsList/RegionsDisplayNameUseCaseTests.swift
+++ b/PIA VPN-tvOSTests/RegionsList/RegionsDisplayNameUseCaseTests.swift
@@ -12,6 +12,8 @@ import XCTest
 
 class RegionsDisplayNameUseCaseTests: XCTestCase {
     class Fixture {
+        var getDedicatedIpUseCaseMock = GetDedicatedIpUseCaseMock(result: nil)
+        
         static let barcelona = ServerMock(name: "Barcelona-1", identifier: "es-server-barcelona", regionIdentifier: "es-region", country: "ES", geo: false, pingTime: 25)
         static let madrid = ServerMock(name: "Madrid", identifier: "es-server-madrid", regionIdentifier: "es-region2", country: "ES", geo: false, pingTime: 12)
         static let toronto = ServerMock(name: "CA Toronto", identifier: "ca-server", regionIdentifier: "canada", country: "CA", geo: false, pingTime: 30)
@@ -26,13 +28,17 @@ class RegionsDisplayNameUseCaseTests: XCTestCase {
             france
         ]
         
+        func stubGetDedicatedIpServer(with server: ServerType) {
+            self.getDedicatedIpUseCaseMock = GetDedicatedIpUseCaseMock(result: server)
+        }
+        
     }
     
     var fixture: Fixture!
     var sut: RegionsDisplayNameUseCase!
     
     func instantiateSut() {
-        sut = RegionsDisplayNameUseCase()
+        sut = RegionsDisplayNameUseCase(getDedicatedIpUseCase: fixture.getDedicatedIpUseCaseMock)
     }
     
     override func setUp() {
@@ -107,6 +113,22 @@ class RegionsDisplayNameUseCaseTests: XCTestCase {
         XCTAssertEqual(displayName.title, "Optimal Location")
         // AND the display name subtitle is "Barcelona-1"
         XCTAssertEqual(displayName.subtitle, "Barcelona-1")
+    }
+    
+    func test_displayNameForDipServer() {
+        // GIVEN that France is a DIP server
+        fixture.stubGetDedicatedIpServer(with: Fixture.france)
+        
+        instantiateSut()
+        
+        // WHEN getting the display name for France
+        let displayNameForFrance = sut.getDisplayName(for: Fixture.france)
+        
+        // THEN the display name title is "Dedicated IP"
+        XCTAssertEqual(displayNameForFrance.title, "Dedicated IP")
+        // AND the display name subtitle is "France"
+        XCTAssertEqual(displayNameForFrance.subtitle, "France")
+        
     }
     
 }

--- a/PIA VPN.xcodeproj/project.pbxproj
+++ b/PIA VPN.xcodeproj/project.pbxproj
@@ -316,6 +316,7 @@
 		69FA73DD2B7D50B2002300B3 /* AvailableSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69FA73DC2B7D50B2002300B3 /* AvailableSettingsView.swift */; };
 		69FA73E02B7D50D7002300B3 /* AvailableSettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69FA73DF2B7D50D7002300B3 /* AvailableSettingsViewModel.swift */; };
 		69FA73E22B7D5576002300B3 /* Routes+Settings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69FA73E12B7D5576002300B3 /* Routes+Settings.swift */; };
+		69FF063C2B91FAE6006063DF /* SelectedServerViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69FF063B2B91FAE6006063DF /* SelectedServerViewModelTests.swift */; };
 		69FF0B042B3AD1D40074AA04 /* SelectedServerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69FF0B032B3AD1D40074AA04 /* SelectedServerView.swift */; };
 		69FF0B062B3AD2860074AA04 /* QuickConnectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69FF0B052B3AD2860074AA04 /* QuickConnectView.swift */; };
 		69FF0B082B3AD3E60074AA04 /* SelectedServerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69FF0B072B3AD3E60074AA04 /* SelectedServerViewModel.swift */; };
@@ -1231,6 +1232,7 @@
 		69FA73DC2B7D50B2002300B3 /* AvailableSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AvailableSettingsView.swift; sourceTree = "<group>"; };
 		69FA73DF2B7D50D7002300B3 /* AvailableSettingsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AvailableSettingsViewModel.swift; sourceTree = "<group>"; };
 		69FA73E12B7D5576002300B3 /* Routes+Settings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Routes+Settings.swift"; sourceTree = "<group>"; };
+		69FF063B2B91FAE6006063DF /* SelectedServerViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectedServerViewModelTests.swift; sourceTree = "<group>"; };
 		69FF0B032B3AD1D40074AA04 /* SelectedServerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectedServerView.swift; sourceTree = "<group>"; };
 		69FF0B052B3AD2860074AA04 /* QuickConnectView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickConnectView.swift; sourceTree = "<group>"; };
 		69FF0B072B3AD3E60074AA04 /* SelectedServerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectedServerViewModel.swift; sourceTree = "<group>"; };
@@ -2352,6 +2354,7 @@
 				690FC47F2B3C59AF00F6DCC8 /* QuickConnectButtonViewModelTests.swift */,
 				690FC4872B3C60F500F6DCC8 /* QuickConnectViewModelTests.swift */,
 				69E61DF02B56990E00085648 /* DashboardViewModelTests.swift */,
+				69FF063B2B91FAE6006063DF /* SelectedServerViewModelTests.swift */,
 			);
 			path = Dashboard;
 			sourceTree = "<group>";
@@ -4972,6 +4975,7 @@
 				6963465B2B70F6A80051F8BC /* RegionsFilterUseCaseMock.swift in Sources */,
 				E52E69112B5D696E00471913 /* UserAuthenticationStatusMonitorTests.swift in Sources */,
 				E5AB28D12B4B39F000744E5F /* VPNConfigurationInstallingViewModelTests.swift in Sources */,
+				69FF063C2B91FAE6006063DF /* SelectedServerViewModelTests.swift in Sources */,
 				E5C5078B2B0E145100200A6A /* PIA_VPN_tvOSTests.swift in Sources */,
 				E574D9FF2B854A4B000FADAF /* ActivateDIPTokenUseCaseMock.swift in Sources */,
 				E55EDCF82B769416007010DB /* ConnectionStatsPermissonMock.swift in Sources */,


### PR DESCRIPTION
The root of the problem was:
- The identifier of  a given server that contains a dip can be the same as the identifier of a server for a given location


Solution:
- When storing a favorite server id with a DIP, add a prefix in front of the server identifier
- Update the functions on the FavoriteRegionUseCase to add/remove a favorite so that they accept an extra parameter to determine whether the server to add or remove is a DIP server or not and take the prefix into account
