### PR TITLE
PIA-1476: Handle empty Favorites list when the selected filter is favorites

### DIFF
--- a/PIA VPN-tvOS/RegionsSelection/Presentation/RegionsContainerViewModel.swift
+++ b/PIA VPN-tvOS/RegionsSelection/Presentation/RegionsContainerViewModel.swift
@@ -87,9 +87,13 @@ extension RegionsContainerViewModel {
     private func subscribeToFavoritesUpdates() {
         favoritesUseCase.favoriteIdentifiersPublisher
             .receive(on: RunLoop.main)
-            .sink { newFavorites in
+            .sink {[weak self] newFavorites in
+                guard let self else { return }
                 if newFavorites.isEmpty {
                     self.sideMenuItems = [.all, .search]
+                    if selectedSection == .favorites {
+                        selectedSection = .all
+                    }
                 } else {
                     self.sideMenuItems = [.favorites, .all, .search]
                 }

--- a/PIA VPN-tvOSTests/RegionsList/Mocks/FavoriteRegionUseCaseMock.swift
+++ b/PIA VPN-tvOSTests/RegionsList/Mocks/FavoriteRegionUseCaseMock.swift
@@ -20,7 +20,7 @@ class FavoriteRegionUseCaseMock: FavoriteRegionUseCaseType {
     }
     
     var favoriteIdentifiers: [String] = []
-    @Published private var favorites: [String] = []
+    @Published internal var favorites: [String] = []
     var favoriteIdentifiersPublisher: Published<[String]>.Publisher {
         $favorites
     }


### PR DESCRIPTION
This PR fixes the following bug:
- Bug where the regions list remains unusable and in an empty state when removing all the favorites items and the selected filter is Favorite.

Solution:
- When the selected filter is Favorites and all the favorite locations get removed from the list, then the selected section becomes the 'All' servers due to the Favorites section being removed from he left side menu.