### PR TITLE
PIA-1443: Split CI workflows [WIP]

### DIFF
--- a/.github/workflows/pull_request_all_unit_tests.yml
+++ b/.github/workflows/pull_request_all_unit_tests.yml
@@ -1,9 +1,9 @@
-name: build_and_test
+name: build_and_test_all_unit_tests
 on:
   pull_request:
   workflow_dispatch:
 concurrency:
-  group: "${{ github.ref }}"
+  group: "${{ github.run_id }}"
   cancel-in-progress: true
 jobs:
   build:
@@ -33,13 +33,5 @@ jobs:
 
     - name: Run iOS unit tests
       run: bundle exec fastlane tests
-    
-    - name: Run tvOS e2e tests
-      run: bundle exec fastlane tvos_e2e_tests
-      timeout-minutes: 45
-
-    - name: Run iOS e2e tests
-      run: bundle exec fastlane ios_e2e_tests
-      timeout-minutes: 45
 
       

--- a/.github/workflows/pull_request_ios_e2e_tests.yml
+++ b/.github/workflows/pull_request_ios_e2e_tests.yml
@@ -1,0 +1,35 @@
+name: build_and_test_ios_e2e
+on:
+  pull_request:
+  workflow_dispatch:
+concurrency:
+  group: "${{ github.run_id }}"
+  cancel-in-progress: true
+jobs:
+  build:
+    runs-on: macos-14
+    env:
+      TEST_RUNNER_PIA_TEST_USER: ${{ secrets.PIA_ACCOUNT_USERNAME}}
+      TEST_RUNNER_PIA_TEST_PASSWORD: ${{ secrets.PIA_ACCOUNT_PASSWORD }}
+      TEST_RUNNER_PIA_TEST_DEDICATEDIP: ${{ secrets.PIA_TEST_DEDICATEDIP }}
+
+    steps:
+    - name: Setup Git credentials
+      run: |
+        git config --global url."https://${{ secrets.ORG_GITHUB_USERNAME }}:${{ secrets.ORG_GITHUB_TOKEN }}@github.com/".insteadOf "git@github.com:"
+
+    - uses: actions/checkout@v3
+    
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.0.2
+
+    - name: Install Fastlane
+      run: gem install fastlane
+
+    - name: Run iOS e2e tests
+      run: bundle exec fastlane ios_e2e_tests
+      timeout-minutes: 35
+
+      

--- a/.github/workflows/pull_request_tvos_e2e_tests.yml
+++ b/.github/workflows/pull_request_tvos_e2e_tests.yml
@@ -1,0 +1,36 @@
+name: build_and_test_tvos_e2e
+on:
+  pull_request:
+  workflow_dispatch:
+concurrency:
+  group: "${{ github.run_id }}"
+  cancel-in-progress: true
+jobs:
+  build:
+    runs-on: macos-14
+    env:
+      TEST_RUNNER_PIA_TEST_USER: ${{ secrets.PIA_ACCOUNT_USERNAME}}
+      TEST_RUNNER_PIA_TEST_PASSWORD: ${{ secrets.PIA_ACCOUNT_PASSWORD }}
+      TEST_RUNNER_PIA_TEST_DEDICATEDIP: ${{ secrets.PIA_TEST_DEDICATEDIP }}
+
+    steps:
+    - name: Setup Git credentials
+      run: |
+        git config --global url."https://${{ secrets.ORG_GITHUB_USERNAME }}:${{ secrets.ORG_GITHUB_TOKEN }}@github.com/".insteadOf "git@github.com:"
+
+    - uses: actions/checkout@v3
+    
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.0.2
+
+    - name: Install Fastlane
+      run: gem install fastlane
+    
+    - name: Run tvOS e2e tests
+      run: bundle exec fastlane tvos_e2e_tests
+      timeout-minutes: 40
+
+
+      

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -15,22 +15,59 @@ platform :ios do
   end
 
   lane :ios_e2e_tests do
+    # build_app(
+    #   scheme: "PIA VPN dev", 
+    #   skip_archive: true,
+    #   configuration: "Debug",
+    #   export_method: "development",
+    #   skip_package_ipa: true,
+    #   skip_codesigning: true,
+    #   derived_data_path: "derived_data",
+    #   skip_package_dependencies_resolution: true
+    #   )
+    
+    scan(
+      scheme: "PIA VPN dev", 
+      skip_build: false,
+      build_for_testing: true,
+      derived_data_path: "derived_data"
+      )
     run_tests(
       scheme: "PIA VPN dev",
       testplan: "PIA-VPN-e2e-simulator",
       devices: ["iPhone 14"],
       prelaunch_simulator: true,
-      test_without_building: true
+      test_without_building: true,
+      derived_data_path: "derived_data"
     )
   end
 
   lane :tvos_e2e_tests do
+    # build_app(
+    #   scheme: "PIA VPN-tvOS", 
+    #   skip_archive: true,
+    #   skip_codesigning: true,
+    #   configuration: "Debug",
+    #   export_method: "development",
+    #   skip_package_ipa: true,
+    #   xcargs: "'platform=tvOS Simulator,name=Apple TV'",
+      
+    #   )
+
+    scan(
+      scheme: "PIA VPN-tvOS", 
+      skip_build: false,
+      build_for_testing: true,
+      derived_data_path: "derived_data"
+      )
+    
     run_tests(
       scheme: "PIA VPN-tvOS",
       testplan: "PIA VPN-tvOS_E2E_Tests",
       test_without_building: true,
       prelaunch_simulator: true,
-      device: "Apple TV"
+      device: "Apple TV",
+      derived_data_path: "derived_data"
     )
   end
 


### PR DESCRIPTION
This PR splits the CI workflows that run on every pull request into 3 workflows:
- 1 workflow to build and run the unit tests on iOS and tvOS
- 1 workflow to build and run the e2e tests on iOS
- 1 workflow to build and run the e2e tests on tvOS