### PR TITLE
PIA-1443: Split CI workflows by platform

### DIFF
--- a/.github/workflows/ios_pull_request.yml
+++ b/.github/workflows/ios_pull_request.yml
@@ -1,0 +1,38 @@
+name: ios_build_and_test
+on:
+  pull_request:
+  workflow_dispatch:
+concurrency:
+  group: "${{ github.run_id }}"
+  cancel-in-progress: true
+jobs:
+  build:
+    runs-on: macos-14
+    env:
+      TEST_RUNNER_PIA_TEST_USER: ${{ secrets.PIA_ACCOUNT_USERNAME}}
+      TEST_RUNNER_PIA_TEST_PASSWORD: ${{ secrets.PIA_ACCOUNT_PASSWORD }}
+      TEST_RUNNER_PIA_TEST_DEDICATEDIP: ${{ secrets.PIA_TEST_DEDICATEDIP }}
+
+    steps:
+    - name: Setup Git credentials
+      run: |
+        git config --global url."https://${{ secrets.ORG_GITHUB_USERNAME }}:${{ secrets.ORG_GITHUB_TOKEN }}@github.com/".insteadOf "git@github.com:"
+
+    - uses: actions/checkout@v3
+    
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.0.2
+
+    - name: Install Fastlane
+      run: gem install fastlane
+
+    - name: Run iOS unit tests
+      run: bundle exec fastlane tests
+
+    - name: Run iOS e2e tests
+      run: bundle exec fastlane ios_e2e_tests
+      timeout-minutes: 45
+
+      

--- a/.github/workflows/tvos_pull_request.yml
+++ b/.github/workflows/tvos_pull_request.yml
@@ -1,9 +1,9 @@
-name: build_and_test
+name: tvos_build_and_test
 on:
   pull_request:
   workflow_dispatch:
 concurrency:
-  group: "${{ github.ref }}"
+  group: "${{ github.run_id }}"
   cancel-in-progress: true
 jobs:
   build:
@@ -30,16 +30,10 @@ jobs:
 
     - name: Run tvOS unit tests
       run: bundle exec fastlane tvOStests
-
-    - name: Run iOS unit tests
-      run: bundle exec fastlane tests
     
     - name: Run tvOS e2e tests
       run: bundle exec fastlane tvos_e2e_tests
       timeout-minutes: 45
 
-    - name: Run iOS e2e tests
-      run: bundle exec fastlane ios_e2e_tests
-      timeout-minutes: 45
 
       


### PR DESCRIPTION
Split pull request CI Workflow into 2, one per each platform (1 for tvOS and 1 for iOS):
- 1 workflow that builds the iOS app and runs the iOS Unit Test and the iOS e2eTests
- 1 workflow that builds the tvOS app and runs the tvOS Unit Test and the tvOS e2eTests

Note: there is also another [draft PR](https://github.com/pia-foss/mobile-ios/pull/110) that splits the workflows into 3 (instead of 2). But that PR consumes more time on CI because it has to build the iOS and the tvOS target twice. 
If we put all the tests for iOS on the same workflow and we run firs the Unit Tests, then running the e2e tests is actually 8minutes faster because it does not have to download the swift packages and compile the iOS target again since it uses the same derived data. And the same happens when we group the Unit Tests + e2e tests for tvOS on the same workflow.