### PR TITLE
PIA-1502: Fix duplicated dip on regions list when removing Dip server

### DIFF
--- a/PIA VPN-tvOS/Help/UI/AcknowledgementsView.swift
+++ b/PIA VPN-tvOS/Help/UI/AcknowledgementsView.swift
@@ -23,9 +23,10 @@ struct AcknowledgementsView: View {
                         .font(.system(size: 29, weight: .medium))
                         .foregroundColor(.pia_on_background)
                 }
+                .frame(width: Spacing.contentViewMaxWidth)
                 .focusable()
                 Divider()
-                    .frame(height: 1)
+                    .frame(width: Spacing.contentViewMaxWidth, height: 1)
                     .background(Color.pia_on_background)
                     .padding()
                 
@@ -43,7 +44,8 @@ struct AcknowledgementsView: View {
                         .padding()
                     
                 }
-            }.frame(width: Spacing.contentViewMaxWidth)
+                .frame(width: Spacing.contentViewMaxWidth)
+            }
             
         }
         .padding(.top, 80)

--- a/PIA VPN-tvOS/RegionsSelection/UseCases/RegionsFilterUseCase.swift
+++ b/PIA VPN-tvOS/RegionsSelection/UseCases/RegionsFilterUseCase.swift
@@ -125,7 +125,10 @@ extension RegionsFilterUseCase {
     }
     
     private func getServersWithoutDip(from servers: [ServerType]) -> [ServerType] {
-        return servers.filter { self.getDedicatedIpUseCase.isDedicatedIp($0) == false }
+        return servers.filter {
+            self.getDedicatedIpUseCase.isDedicatedIp($0) == false
+            && $0.dipToken == nil
+        }
     }
     
     private func getFavorites(from servers: [ServerType]) -> [ServerType] {


### PR DESCRIPTION
- Filter out all the servers with a dip token from the regions 'all' servers (since the dip servers are displayed separately on the top section of the regions list next to the Optimal Location servers).
- Also fix a UI glitch that sometimes made not possible to scroll on the Acknowledgementes screen when moving the focus from any button on the top navigation bar to the Acknowledgments scroll view.