### PR TITLE
PIA-1547: Handle default focus when Settings and Options appear

### DIFF
--- a/PIA VPN-tvOS/Dashboard/UI/DashboardView.swift
+++ b/PIA VPN-tvOS/Dashboard/UI/DashboardView.swift
@@ -10,10 +10,10 @@ struct DashboardView: View {
             ConnectionStateBar(tintColor: viewModel.connectionTintColor.connectionBarTint)
             Spacer()
             DashboardConnectionButtonSection()
-                .padding(.bottom, 80)
+                .padding(.bottom, 60)
             
             SelectedServerSection()
-                .padding(.bottom, 40)
+                .frame(minHeight: Spacing.selectedServerViewMinHeight)
             
             QuickConnectSection()
                 .frame(width: Spacing.dashboardViewWidth)

--- a/PIA VPN-tvOS/Dashboard/UI/SelectedServerView.swift
+++ b/PIA VPN-tvOS/Dashboard/UI/SelectedServerView.swift
@@ -19,9 +19,11 @@ struct SelectedServerView: View {
                 Text(viewModel.selectedServerSubtitle)
                     .font(.system(size: 31, weight: .bold))
                     .foregroundColor(isButtonFocused ? .pia_on_primary : .pia_on_surface)
-                    .lineLimit(nil)
+                    .lineLimit(2)
+                    .minimumScaleFactor(0.9)
             }
             .padding(.leading, 22)
+            .fixedSize(horizontal: false, vertical: true) // it resizes vertically to allow more than 1 line on the name of the server
             
             Spacer()
             
@@ -39,7 +41,7 @@ struct SelectedServerView: View {
             Button {
                 viewModel.selectedServerSectionWasTapped()
             } label: {
-                HStack {
+                HStack(alignment: .top) {
                     Spacer()
                     buttonView()
                         .frame(width: Spacing.dashboardViewWidth)

--- a/PIA VPN-tvOS/Help/UI/HelpOptionsView.swift
+++ b/PIA VPN-tvOS/Help/UI/HelpOptionsView.swift
@@ -10,6 +10,8 @@ import SwiftUI
 
 struct HelpOptionsView: View {
     @ObservedObject var viewModel: HelpOptionsViewModel
+    @FocusState var focusedSection: HelpOptionsViewModel.Sections?
+    
     var body: some View {
         HStack {
             VStack(spacing: 20) {
@@ -22,6 +24,9 @@ struct HelpOptionsView: View {
                 .aspectRatio(contentMode: .fit)
         }
         .padding(.top, Spacing.screenTopPadding)
+        .onAppear {
+            setFocusToDefault()
+        }
     }
     
     
@@ -44,6 +49,7 @@ struct HelpOptionsView: View {
             SettingsButtonView(title: viewModel.aboutSectionTitle, style: .rightChevron) {
                 viewModel.aboutOptionsButtonWasTapped()
             }
+            .focused($focusedSection, equals: .about)
             
             SettingsButtonView(
                 title: viewModel.helpImproveSectionContent.title ,
@@ -51,6 +57,7 @@ struct HelpOptionsView: View {
                 style: .rightText(content: viewModel.helpImproveSectionContent.value)) {
                 viewModel.toggleHelpImprove()
             }
+            .focused($focusedSection, equals: .helpImprove)
         }
     }
 
@@ -70,4 +77,12 @@ struct HelpOptionsView: View {
         }
     }
     
+}
+
+// MARK: - Default focus
+
+extension HelpOptionsView {
+    private func setFocusToDefault() {
+        focusedSection = .about
+    }
 }

--- a/PIA VPN-tvOS/RegionsSelection/UI/RegionsContainerView.swift
+++ b/PIA VPN-tvOS/RegionsSelection/UI/RegionsContainerView.swift
@@ -74,9 +74,19 @@ struct RegionsContainerView: View {
                 guard let focusedMenuItem = newValue else { return }
                 viewModel.selectedSection = focusedMenuItem
             }
+            .onAppear {
+                setFocusToDefault()
+            }
         }
 
     }
 }
 
 
+// MARK: - Default focus
+
+extension RegionsContainerView {
+    private func setFocusToDefault() {
+        focusedFilter = .all
+    }
+}

--- a/PIA VPN-tvOS/Settings/UI/AvailableSettingsView.swift
+++ b/PIA VPN-tvOS/Settings/UI/AvailableSettingsView.swift
@@ -11,8 +11,8 @@ import SwiftUI
 struct AvailableSettingsView: View {
     @ObservedObject var viewModel: AvailableSettingsViewModel
     
-    // TODO: check how to reset the default focus on appear. Atm this property is not used
     @FocusState var focusedSection: AvailableSettingsViewModel.Sections?
+    
     
     var body: some View {
         HStack {
@@ -34,6 +34,7 @@ struct AvailableSettingsView: View {
                 SettingsButtonView(title: section.title, style: .rightChevron) {
                     viewModel.navigate(to: section)
                 }
+                .focused($focusedSection, equals: section)
             }
         }
         

--- a/PIA VPN-tvOS/Shared/UI/PIAStyles.swift
+++ b/PIA VPN-tvOS/Shared/UI/PIAStyles.swift
@@ -22,5 +22,6 @@ struct Spacing {
     static let settingsButtonHorizontalPadding: CGFloat = 20
     static let settingsHorizontalBigPadding: CGFloat = settingsButtonHorizontalPadding * 2
     static let contentViewMaxWidth: CGFloat = 861
+    static let selectedServerViewMinHeight: CGFloat = 170
 }
 

--- a/PIA VPN-tvOS/Shared/UseCases/RefreshServersLatencyUseCase.swift
+++ b/PIA VPN-tvOS/Shared/UseCases/RefreshServersLatencyUseCase.swift
@@ -65,6 +65,10 @@ class RefreshServersLatencyUseCase: RefreshServersLatencyUseCaseType {
     }
     
     func stop() {
+        cancellables.forEach { anyCancellable in
+            anyCancellable.cancel()
+        }
+        cancellables.removeAll()
         self.timer = nil
         self.state = .none
     }


### PR DESCRIPTION
- Set the focus to the first item of the Settings Screen when the screen appears (previously the focus was sometimes on the VPN button from the top navigation bar when the Settings and Options screens appear).
- Set the focus to the first item of the Options screen when the view appears.
- Fix a UI issue on the selected region section of the dashboard where the long names of servers appear truncated. 