### PR TITLE
PIA-922: Handle unauthorized user

### DIFF
--- a/PIA VPN-tvOS/Login/Utils/Foundation+PIA.swift
+++ b/PIA VPN-tvOS/Login/Utils/Foundation+PIA.swift
@@ -15,4 +15,11 @@ extension TimeInterval {
         let now = Date().timeIntervalSince1970
         return now > self ? nil : self - now
     }
+    
+    /// Returns time in seconds between now & the receiver
+    /// and a nil if the receiver has already gone ahead of now.
+    public func timeUntilNow() -> Double? {
+        let now = Date().timeIntervalSince1970
+        return now < self ? nil : now - self
+    }
 }

--- a/PIA VPN-tvOS/Shared/Utils/Foundation+Protocols.swift
+++ b/PIA VPN-tvOS/Shared/Utils/Foundation+Protocols.swift
@@ -15,6 +15,8 @@ protocol NotificationCenterType {
     
     func removeObserver(_ observer: Any)
     
+    func post(name aName: NSNotification.Name, object anObject: Any?)
+    
     @available(iOS 13.0, *)
     func publisher(for name: Notification.Name, object: AnyObject?) -> NotificationCenter.Publisher
     

--- a/PIA VPN-tvOS/Shared/Utils/PIALibrary+Protocols/PIALibrary+Protocols.swift
+++ b/PIA VPN-tvOS/Shared/Utils/PIALibrary+Protocols/PIALibrary+Protocols.swift
@@ -10,6 +10,7 @@ protocol AccountProviderType {
     var currentUser: PIALibrary.UserAccount? { get set }
     func logout(_ callback: ((Error?) -> Void)?)
     func login(with linkToken: String, _ callback: ((PIALibrary.UserAccount?, Error?) -> Void)?)
+    func accountInformation(_ callback: ((PIALibrary.AccountInfo?, Error?) -> Void)?)
 }
 
 extension DefaultAccountProvider: AccountProviderType {
@@ -100,5 +101,4 @@ extension DefaultVPNProvider: VPNStatusProviderType {}
 
 extension MockVPNProvider: VPNStatusProviderType {}
 
-extension DefaultAccountProvider: ProductsProviderType {}
-extension Client.Configuration: ProductConfigurationType {}
+

--- a/PIA VPN-tvOS/Signup/CompositionRool/SignupFactory.swift
+++ b/PIA VPN-tvOS/Signup/CompositionRool/SignupFactory.swift
@@ -42,3 +42,6 @@ class SignUpFactory {
                                   productConfiguration: Client.configuration)
     }
 }
+
+extension DefaultAccountProvider: ProductsProviderType {}
+extension Client.Configuration: ProductConfigurationType {}

--- a/PIA VPN-tvOSTests/Common/Mocks/AccountProviderTypeMock.swift
+++ b/PIA VPN-tvOSTests/Common/Mocks/AccountProviderTypeMock.swift
@@ -7,10 +7,21 @@
 //
 
 import Foundation
-@testable import PIA_VPN_tvOS
 import PIALibrary
+import XCTest
+
+#if canImport(PIA_VPN_tvOS)
+@testable import PIA_VPN_tvOS
+#endif
+
+#if canImport(PIA_VPN)
+@testable import PIA_VPN
+#endif
+
 
 class AccountProviderTypeMock: AccountProviderType {
+    
+    
     var publicUsername: String? = nil
     
     var currentUser: PIALibrary.UserAccount? = nil
@@ -28,5 +39,14 @@ class AccountProviderTypeMock: AccountProviderType {
     
     func login(with linkToken: String, _ callback: ((PIALibrary.UserAccount?, Error?) -> Void)?) {
         loginWithTokenCalledAttempt += 1
+    }
+    
+    private(set) var accountInformationCalledAttempt = 0
+    var accountInformationResult: PIALibrary.AccountInfo?
+    var accountInformationError: Error?
+    func accountInformation(_ callback: ((PIALibrary.AccountInfo?, Error?) -> Void)?) {
+        accountInformationCalledAttempt += 1
+        callback?(accountInformationResult, accountInformationError)
+
     }
 }

--- a/PIA VPN-tvOSTests/Common/Mocks/NotificationCenterMock.swift
+++ b/PIA VPN-tvOSTests/Common/Mocks/NotificationCenterMock.swift
@@ -1,8 +1,15 @@
 
 import Foundation
 import Combine
+#if canImport(PIA_VPN_tvOS)
 @testable import PIA_VPN_tvOS
+#endif
 
+#if canImport(PIA_VPN)
+@testable import PIA_VPN
+#endif
+
+@available(iOS 13.0, *)
 class NotificationCenterMock: NotificationCenterType {
     var notificationPublisher: NotificationCenter.Publisher!
     func publisher(for name: Notification.Name, object: AnyObject?) -> NotificationCenter.Publisher {
@@ -24,6 +31,13 @@ class NotificationCenterMock: NotificationCenterType {
     func removeObserver(_ observer: Any) {
         removeObserverCalled = true
         remoververCalledAttempt += 1
+    }
+    
+    private(set) var postNotificationCalledAttempt = 0
+    private(set) var postNotificationCalledWithName: NSNotification.Name?
+    func post(name aName: NSNotification.Name, object anObject: Any?) {
+        postNotificationCalledAttempt += 1
+        postNotificationCalledWithName = aName
     }
     
 }

--- a/PIA VPN.xcodeproj/project.pbxproj
+++ b/PIA VPN.xcodeproj/project.pbxproj
@@ -234,6 +234,8 @@
 		6944B16C2B853505008E3B70 /* OptimalLocationUseCaseMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6944B16B2B853505008E3B70 /* OptimalLocationUseCaseMock.swift */; };
 		6944B16E2B8536B8008E3B70 /* OptimalLocationUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6944B16D2B8536B8008E3B70 /* OptimalLocationUseCaseTests.swift */; };
 		694AC74E2B17AB9C007E7B56 /* DashboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 694AC74D2B17AB9C007E7B56 /* DashboardView.swift */; };
+		6951D8D42BDBB404000F7B28 /* AccountInformationAvailabilityFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6951D8D32BDBB404000F7B28 /* AccountInformationAvailabilityFactory.swift */; };
+		6951D8D52BDBB404000F7B28 /* AccountInformationAvailabilityFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6951D8D32BDBB404000F7B28 /* AccountInformationAvailabilityFactory.swift */; };
 		6953E54B2B7A8FDC00D685B4 /* ButtonStyleModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6953E54A2B7A8FDC00D685B4 /* ButtonStyleModifier.swift */; };
 		6953E54D2B7A907A00D685B4 /* View+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6953E54C2B7A907A00D685B4 /* View+Extensions.swift */; };
 		6953E54F2B7AA69800D685B4 /* ConnectionStateMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6953E54E2B7AA69800D685B4 /* ConnectionStateMonitor.swift */; };
@@ -294,6 +296,18 @@
 		69B70ABE2ACC2CFE0072A09D /* AccessibilityId.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69B70ABD2ACC2CFE0072A09D /* AccessibilityId.swift */; };
 		69B70ABF2ACC2CFE0072A09D /* AccessibilityId.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69B70ABD2ACC2CFE0072A09D /* AccessibilityId.swift */; };
 		69B70AC02ACC2CFE0072A09D /* AccessibilityId.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69B70ABD2ACC2CFE0072A09D /* AccessibilityId.swift */; };
+		69B82EAB2BDA5084004A12DD /* AccountInformationAvailabilityVerifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69B82EAA2BDA5084004A12DD /* AccountInformationAvailabilityVerifier.swift */; };
+		69B82EAC2BDA58CA004A12DD /* PIALibrary+Protocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6913179E2B32E4D4009B4E85 /* PIALibrary+Protocols.swift */; };
+		69B82EAD2BDA58CB004A12DD /* PIALibrary+Protocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6913179E2B32E4D4009B4E85 /* PIALibrary+Protocols.swift */; };
+		69B82EB52BDA5F72004A12DD /* UserDefaultsType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69B82EB42BDA5F72004A12DD /* UserDefaultsType.swift */; };
+		69B82EB62BDA5F72004A12DD /* UserDefaultsType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69B82EB42BDA5F72004A12DD /* UserDefaultsType.swift */; };
+		69B82EB72BDA5F90004A12DD /* AccountInformationAvailabilityVerifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69B82EAA2BDA5084004A12DD /* AccountInformationAvailabilityVerifier.swift */; };
+		69B82EBB2BDA614F004A12DD /* AccountInformationAvailabilityVerifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69B82EBA2BDA614F004A12DD /* AccountInformationAvailabilityVerifierTests.swift */; };
+		69B82EBD2BDA6242004A12DD /* NotificationCenterMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 696E8F0C2B31A8760080BB31 /* NotificationCenterMock.swift */; };
+		69B82EBE2BDA63D1004A12DD /* AccountProviderTypeMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 691317A02B32ED76009B4E85 /* AccountProviderTypeMock.swift */; };
+		69B82EC02BDA6857004A12DD /* UserDefaultsMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69B82EBF2BDA6857004A12DD /* UserDefaultsMock.swift */; };
+		69B82EC12BDA6B97004A12DD /* Foundation+PIA.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5AB28892B29BDED00744E5F /* Foundation+PIA.swift */; };
+		69B82EC22BDA6B98004A12DD /* Foundation+PIA.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5AB28892B29BDED00744E5F /* Foundation+PIA.swift */; };
 		69C4C31A2B88D1B00019A8C6 /* ClientPreferencesMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69C4C3192B88D1B00019A8C6 /* ClientPreferencesMock.swift */; };
 		69C587FD2AD00C6300B95EF9 /* PIAExampleWithAuthenticatedAppTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69C587FC2AD00C6300B95EF9 /* PIAExampleWithAuthenticatedAppTest.swift */; };
 		69C5E7CC2B72945F00FE3126 /* TopNavigationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69C5E7CB2B72945F00FE3126 /* TopNavigationView.swift */; };
@@ -1258,6 +1272,7 @@
 		6944B16D2B8536B8008E3B70 /* OptimalLocationUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptimalLocationUseCaseTests.swift; sourceTree = "<group>"; };
 		6947AADB2ACDC8AE001BCC66 /* PIA-VPN-e2e-simulator.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = "PIA-VPN-e2e-simulator.xctestplan"; sourceTree = "<group>"; };
 		694AC74D2B17AB9C007E7B56 /* DashboardView.swift */ = {isa = PBXFileReference; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = DashboardView.swift; sourceTree = "<group>"; tabWidth = 4; };
+		6951D8D32BDBB404000F7B28 /* AccountInformationAvailabilityFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountInformationAvailabilityFactory.swift; sourceTree = "<group>"; };
 		6953E54A2B7A8FDC00D685B4 /* ButtonStyleModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonStyleModifier.swift; sourceTree = "<group>"; };
 		6953E54C2B7A907A00D685B4 /* View+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+Extensions.swift"; sourceTree = "<group>"; };
 		6953E54E2B7AA69800D685B4 /* ConnectionStateMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionStateMonitor.swift; sourceTree = "<group>"; };
@@ -1308,6 +1323,10 @@
 		69B70AB02ACBF51C0072A09D /* PIA-VPN_E2E_Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "PIA-VPN_E2E_Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		69B70AB42ACBF51C0072A09D /* LoginScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginScreen.swift; sourceTree = "<group>"; };
 		69B70ABD2ACC2CFE0072A09D /* AccessibilityId.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityId.swift; sourceTree = "<group>"; };
+		69B82EAA2BDA5084004A12DD /* AccountInformationAvailabilityVerifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountInformationAvailabilityVerifier.swift; sourceTree = "<group>"; };
+		69B82EB42BDA5F72004A12DD /* UserDefaultsType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsType.swift; sourceTree = "<group>"; };
+		69B82EBA2BDA614F004A12DD /* AccountInformationAvailabilityVerifierTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountInformationAvailabilityVerifierTests.swift; sourceTree = "<group>"; };
+		69B82EBF2BDA6857004A12DD /* UserDefaultsMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsMock.swift; sourceTree = "<group>"; };
 		69C4C3192B88D1B00019A8C6 /* ClientPreferencesMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientPreferencesMock.swift; sourceTree = "<group>"; };
 		69C587FC2AD00C6300B95EF9 /* PIAExampleWithAuthenticatedAppTest.swift */ = {isa = PBXFileReference; indentWidth = 2; lastKnownFileType = sourcecode.swift; path = PIAExampleWithAuthenticatedAppTest.swift; sourceTree = "<group>"; tabWidth = 2; };
 		69C5E7CB2B72945F00FE3126 /* TopNavigationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopNavigationView.swift; sourceTree = "<group>"; };
@@ -2084,6 +2103,8 @@
 		0EEE1BE81E4F6EF400397DE2 /* PIA VPNTests */ = {
 			isa = PBXGroup;
 			children = (
+				69B82EB92BDA6134004A12DD /* Mocks */,
+				69B82EB82BDA60B2004A12DD /* AccountInformationAvailability */,
 				DD606AC221C9251F00E0781D /* Core */,
 				0EC932861F502762002EB42C /* Supporting files */,
 				DD606AC721C9344100E0781D /* AppTests.swift */,
@@ -2189,6 +2210,8 @@
 		291C6385183EBC210039EC03 /* PIA VPN */ = {
 			isa = PBXGroup;
 			children = (
+				69B82EB22BDA5F4C004A12DD /* Shared */,
+				69B82EAF2BDA5930004A12DD /* AccountInformationAvailability */,
 				E58A456C2BAA285F002A0704 /* ValidateQRLogin */,
 				0E047DD81C6BDAF00026F9A7 /* Global */,
 				0E9160551DA6F7EC00A13AA7 /* Core */,
@@ -2668,6 +2691,55 @@
 				69D12D152ACC75140053A81B /* Util */,
 			);
 			path = "PIA-VPN_E2E_Tests";
+			sourceTree = "<group>";
+		};
+		69B82EAF2BDA5930004A12DD /* AccountInformationAvailability */ = {
+			isa = PBXGroup;
+			children = (
+				69B82EB02BDA5991004A12DD /* CompositionRoot */,
+				69B82EAA2BDA5084004A12DD /* AccountInformationAvailabilityVerifier.swift */,
+			);
+			name = AccountInformationAvailability;
+			sourceTree = "<group>";
+		};
+		69B82EB02BDA5991004A12DD /* CompositionRoot */ = {
+			isa = PBXGroup;
+			children = (
+				6951D8D32BDBB404000F7B28 /* AccountInformationAvailabilityFactory.swift */,
+			);
+			name = CompositionRoot;
+			sourceTree = "<group>";
+		};
+		69B82EB22BDA5F4C004A12DD /* Shared */ = {
+			isa = PBXGroup;
+			children = (
+				69B82EB32BDA5F59004A12DD /* Foundation+Protocols */,
+			);
+			name = Shared;
+			sourceTree = "<group>";
+		};
+		69B82EB32BDA5F59004A12DD /* Foundation+Protocols */ = {
+			isa = PBXGroup;
+			children = (
+				69B82EB42BDA5F72004A12DD /* UserDefaultsType.swift */,
+			);
+			name = "Foundation+Protocols";
+			sourceTree = "<group>";
+		};
+		69B82EB82BDA60B2004A12DD /* AccountInformationAvailability */ = {
+			isa = PBXGroup;
+			children = (
+				69B82EBA2BDA614F004A12DD /* AccountInformationAvailabilityVerifierTests.swift */,
+			);
+			path = AccountInformationAvailability;
+			sourceTree = "<group>";
+		};
+		69B82EB92BDA6134004A12DD /* Mocks */ = {
+			isa = PBXGroup;
+			children = (
+				69B82EBF2BDA6857004A12DD /* UserDefaultsMock.swift */,
+			);
+			path = Mocks;
 			sourceTree = "<group>";
 		};
 		69C5E7C92B7293F700FE3126 /* UI */ = {
@@ -4903,6 +4975,7 @@
 				DD9706AC224262E000630220 /* QuickSettingsTileCollectionViewCell.swift in Sources */,
 				82CAB87B255AEA3500BB08EF /* MessagesManager.swift in Sources */,
 				0E1F318720176A6300FC1000 /* Theme+DarkPalette.swift in Sources */,
+				69B82EAD2BDA58CB004A12DD /* PIALibrary+Protocols.swift in Sources */,
 				E59E8FC62AEA7A81009278F5 /* TermsAndConditionsViewController.swift in Sources */,
 				8272C6312657D42700D846A8 /* PrivacyFeaturesSettingsViewController.swift in Sources */,
 				0ECC1E3F1FDB3F2F0039891D /* RegionsViewController.swift in Sources */,
@@ -4942,6 +5015,7 @@
 				DDB6B95121C94E2E00DE8C5F /* TrustedNetworksViewController.swift in Sources */,
 				8276DFE72608B63800BB7B40 /* ShowConnectionStatsViewController.swift in Sources */,
 				0E9452A61FDB578400891948 /* RegionCell.swift in Sources */,
+				6951D8D52BDBB404000F7B28 /* AccountInformationAvailabilityFactory.swift in Sources */,
 				827570D524DAA317008F9800 /* NetworkRuleOptionView.swift in Sources */,
 				0EFDC1ED1FE4B9DC007C0B9B /* AppConstants.swift in Sources */,
 				DD829EE32449A4A400E2EE55 /* SiriShortcutsManager.swift in Sources */,
@@ -4960,6 +5034,7 @@
 				E58A455E2BA8D204002A0704 /* URLRequestMaker.swift in Sources */,
 				E59E8FBC2AEA7A81009278F5 /* GDPRViewController.swift in Sources */,
 				8272C63A2657F54400D846A8 /* DevelopmentSettingsViewController.swift in Sources */,
+				69B82EB62BDA5F72004A12DD /* UserDefaultsType.swift in Sources */,
 				E58A457A2BAA290F002A0704 /* TokenProvider.swift in Sources */,
 				DD9329A3237AFD0A0025B6BC /* ShowQuickSettingsViewController.swift in Sources */,
 				DD606ABD21C904BB00E0781D /* PIAHotspotHelper.swift in Sources */,
@@ -4982,6 +5057,7 @@
 				E59E8FAE2AEA7A81009278F5 /* SignupInProgressViewController.swift in Sources */,
 				0EB966781FDF11B80086ABC2 /* Server+UI.swift in Sources */,
 				DD1C139A21E65F90004004B3 /* IPTileCollectionViewCell.swift in Sources */,
+				69B82EB72BDA5F90004A12DD /* AccountInformationAvailabilityVerifier.swift in Sources */,
 				829EB5332535AD27003E74DD /* DedicatedIpEmptyHeaderViewCell.swift in Sources */,
 				827570D024DAA128008F9800 /* NetworkCollectionViewCell.swift in Sources */,
 				0E9452AC1FDB5EF600891948 /* UINavigationItem+Shortcuts.swift in Sources */,
@@ -5045,6 +5121,7 @@
 				E58A45752BAA28D4002A0704 /* ValidateQRLoginUseCase.swift in Sources */,
 				82CAB8B1255B050000BB08EF /* MessagesCommands.swift in Sources */,
 				DD4E84582243BD1200929B39 /* DashboardCollectionViewUtil.swift in Sources */,
+				69B82EC12BDA6B97004A12DD /* Foundation+PIA.swift in Sources */,
 				DD74695B217F07AC00B7BD73 /* DNSList.swift in Sources */,
 				0E9452AF1FDB5F7A00891948 /* PIAPageControl.swift in Sources */,
 				DDD271F121D6718F00B6D20F /* RegionFilter.swift in Sources */,
@@ -5061,7 +5138,11 @@
 			files = (
 				DD606AC621C9256300E0781D /* PIAHotspotHelperTests.swift in Sources */,
 				DD606AC821C9344100E0781D /* AppTests.swift in Sources */,
+				69B82EC02BDA6857004A12DD /* UserDefaultsMock.swift in Sources */,
+				69B82EBB2BDA614F004A12DD /* AccountInformationAvailabilityVerifierTests.swift in Sources */,
+				69B82EBE2BDA63D1004A12DD /* AccountProviderTypeMock.swift in Sources */,
 				82A1AD2324B7C0020003DD02 /* PIACardTests.swift in Sources */,
+				69B82EBD2BDA6242004A12DD /* NotificationCenterMock.swift in Sources */,
 				8221922B24CECFE700C24F1C /* NMTTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -5091,6 +5172,7 @@
 				82A1AD2624B86AF60003DD02 /* PIACardsViewController.swift in Sources */,
 				DD1AA4962180AD92005116D7 /* CustomDNSSettingsViewController.swift in Sources */,
 				AAA470812B7380EA00F28590 /* IsIkev2SelectedWithDefaultSettings.swift in Sources */,
+				69B82EC22BDA6B98004A12DD /* Foundation+PIA.swift in Sources */,
 				0EFDC1EF1FE4B9E6007C0B9B /* AppConfiguration.swift in Sources */,
 				0E9452A21FDB568700891948 /* MenuItemCell.swift in Sources */,
 				829EB51125359DBB003E74DD /* DedicatedIpRowViewCell.swift in Sources */,
@@ -5146,9 +5228,11 @@
 				0EFDC1D71FE46177007C0B9B /* SensitiveOperation.swift in Sources */,
 				E59E8FAB2AEA7A81009278F5 /* SignupSuccessViewController.swift in Sources */,
 				82C0071325231F2800F21AF2 /* String+VPNType.swift in Sources */,
+				69B82EAB2BDA5084004A12DD /* AccountInformationAvailabilityVerifier.swift in Sources */,
 				826BE8EE253861BE002339F3 /* DedicatedRegionCell.swift in Sources */,
 				0E3A35281FD9A960000B0F99 /* DashboardViewController.swift in Sources */,
 				DDB6B95021C94E2E00DE8C5F /* TrustedNetworksViewController.swift in Sources */,
+				69B82EAC2BDA58CA004A12DD /* PIALibrary+Protocols.swift in Sources */,
 				82C9F3CC25C43863005039F9 /* ActiveDedicatedIpHeaderViewCell.swift in Sources */,
 				E59E8FAF2AEA7A81009278F5 /* MagicLinkLoginViewController.swift in Sources */,
 				8276DFE62608B63800BB7B40 /* ShowConnectionStatsViewController.swift in Sources */,
@@ -5188,6 +5272,7 @@
 				DD76291621ECBD9C0092DF50 /* SubscriptionTile.swift in Sources */,
 				DD522D22237D74380072F555 /* BooleanUtil.swift in Sources */,
 				0EA660081FEC7A9500CB2B0D /* PIATunnelProvider+UI.swift in Sources */,
+				6951D8D42BDBB404000F7B28 /* AccountInformationAvailabilityFactory.swift in Sources */,
 				0E7361EB1FD99A1000706BFF /* MenuViewController.swift in Sources */,
 				DD1C139921E65F90004004B3 /* IPTileCollectionViewCell.swift in Sources */,
 				E5F52A182A8A5D5300828883 /* WifiNetworkMonitor.swift in Sources */,
@@ -5200,6 +5285,7 @@
 				DD3B504624B758330002F4B5 /* Collectable.swift in Sources */,
 				DD9706A4224262BF00630220 /* QuickSettingsTile.swift in Sources */,
 				E520FCE82B90792500D06C03 /* AppPreferences.swift in Sources */,
+				69B82EB52BDA5F72004A12DD /* UserDefaultsType.swift in Sources */,
 				82183D7B2500FD460033023F /* String+Substrings.swift in Sources */,
 				DDFCFA9421E892130081F235 /* RegionTile.swift in Sources */,
 				0E7361A01FD86F8300706BFF /* AccountObserver.swift in Sources */,

--- a/PIA VPN/AccountInformationAvailabilityFactory.swift
+++ b/PIA VPN/AccountInformationAvailabilityFactory.swift
@@ -1,0 +1,24 @@
+//
+//  AccountInformationAvailabilityFactory.swift
+//  PIA VPN
+//
+//  Created by Laura S on 4/26/24.
+//  Copyright © 2024 Private Internet Access Inc. All rights reserved.
+//
+
+import Foundation
+import PIALibrary
+
+class AccountInformationAvailabilityFactory {
+    private static var accountInformationAvailabilityVerifierShared: AccountInformationAvailabilityVerifierType = {
+        guard let defaultAccountProvider = Client.providers.accountProvider as? DefaultAccountProvider else {
+            fatalError("Account provider is not the expected type")
+        }
+        
+        return AccountInformationAvailabilityVerifier(accountProvider: defaultAccountProvider, notificationCenter: NotificationCenter.default, userDefaults: UserDefaults.standard)
+    }()
+    
+    static func makeAccountInformationAvailabilityVerifier() -> AccountInformationAvailabilityVerifierType {
+        return accountInformationAvailabilityVerifierShared
+    }
+}

--- a/PIA VPN/AccountInformationAvailabilityVerifier.swift
+++ b/PIA VPN/AccountInformationAvailabilityVerifier.swift
@@ -1,0 +1,86 @@
+//
+//  AccountInformationVerifier.swift
+//  PIA VPN
+//
+//  Created by Laura S on 4/25/24.
+//  Copyright © 2024 Private Internet Access Inc. All rights reserved.
+//
+
+import Foundation
+import PIALibrary
+
+protocol AccountInformationAvailabilityVerifierType {
+    typealias Completion = (() -> Void)?
+    func verifyAccountInformationAvailabity(after deadline: TimeInterval?, completion: Completion)
+    @available(iOS 13, *)
+    func verifyAccountInformationAvailabity(after deadline: TimeInterval?) async
+    
+}
+
+class AccountInformationAvailabilityVerifier:
+    AccountInformationAvailabilityVerifierType {
+    
+    private let accountProvider: AccountProviderType
+    private let notificationCenter: NotificationCenterType
+    private let userDefaults: UserDefaultsType
+    
+    internal static let defaultDeadlineInSeconds: TimeInterval = 43200
+    static let kAccountInfoAvailabilityDate = "kAccountInfoAvailabilityDate"
+
+    init(accountProvider: AccountProviderType, notificationCenter: NotificationCenterType, userDefaults: UserDefaultsType) {
+        self.accountProvider = accountProvider
+        self.notificationCenter = notificationCenter
+        self.userDefaults = userDefaults
+    }
+    
+    private func shouldVerify(after deadline: TimeInterval) -> Bool {
+        
+        guard let previouslyVerified = userDefaults.date(forKey: Self.kAccountInfoAvailabilityDate),
+              let verifiedSecondsAgo = previouslyVerified.timeIntervalSince1970.timeUntilNow() else { return true }
+        
+        return verifiedSecondsAgo >= deadline
+
+    }
+    
+    func verifyAccountInformationAvailabity(after deadline: TimeInterval?, completion: Completion) {
+        
+        guard let deadline else {
+            verify(with: completion)
+            return
+        }
+        
+        if shouldVerify(after: deadline) {
+            verify(with: completion)
+        } else {
+            completion?()
+        }
+
+    }
+    
+    @available(iOS 13, *)
+    func verifyAccountInformationAvailabity(after deadline: TimeInterval?) async {
+        return await withCheckedContinuation { continuation in
+            self.verifyAccountInformationAvailabity(after: deadline) {
+                continuation.resume()
+            }
+        }
+    }
+    
+}
+
+extension AccountInformationAvailabilityVerifier {
+    private func verify(with completion: Completion) {
+        accountProvider.accountInformation { [weak self] info, error in
+            if let clientError = error as? ClientError,
+               clientError == ClientError.unauthorized {
+                self?.notificationCenter.post(name: .PIAUnauthorized, object: nil)
+                completion?()
+            } else {
+                self?.userDefaults.set(date: Date(), forKey: Self.kAccountInfoAvailabilityDate)
+                completion?()
+            }
+            
+        }
+        
+    }
+}

--- a/PIA VPN/AccountObserver.swift
+++ b/PIA VPN/AccountObserver.swift
@@ -45,6 +45,12 @@ class AccountObserver {
         nc.addObserver(self, selector: #selector(registerExpirationNotifications), name: .PIAAccountDidSignup, object: nil)
         nc.addObserver(self, selector: #selector(registerExpirationNotifications), name: .PIAAccountDidRefresh, object: nil)
         nc.addObserver(self, selector: #selector(accountDidLogout), name: .PIAAccountDidLogout, object: nil)
+        nc.addObserver(self, selector: #selector(registerAccountDidBecomeUnauthorized), name: .PIAUnauthorized, object: nil)
+    }
+    
+    
+    @objc private func registerAccountDidBecomeUnauthorized() {
+        Client.providers.accountProvider.refreshAndLogoutUnauthorized()
     }
     
     @objc private func registerExpirationNotifications() -> [Date]? {

--- a/PIA VPN/AppDelegate.swift
+++ b/PIA VPN/AppDelegate.swift
@@ -58,6 +58,7 @@ class AppDelegate: NSObject, UIApplicationDelegate {
         _ = hotspotHelper.configureHotspotHelper()
 
         instantiateLiveActivityManagerIfNeeded()
+
         return true
     }
     
@@ -229,6 +230,10 @@ class AppDelegate: NSObject, UIApplicationDelegate {
         Macros.removeLocalNotification(NotificationCategory.nonCompliantWifi)
         
         instantiateLiveActivityManagerIfNeeded()
+        
+        let accountInformationVerifier = AccountInformationAvailabilityFactory.makeAccountInformationAvailabilityVerifier()
+        
+        accountInformationVerifier.verifyAccountInformationAvailabity(after: AccountInformationAvailabilityVerifier.defaultDeadlineInSeconds, completion: nil)
 
     }
 

--- a/PIA VPN/DashboardViewController.swift
+++ b/PIA VPN/DashboardViewController.swift
@@ -427,6 +427,11 @@ class DashboardViewController: AutolayoutViewController {
     }
     
     private func manuallyConnect() {
+        let accountInformationVerifier = AccountInformationAvailabilityFactory.makeAccountInformationAvailabilityVerifier()
+        let threeHoursInSeconds: TimeInterval = 10800
+        
+        accountInformationVerifier.verifyAccountInformationAvailabity(after: threeHoursInSeconds, completion: nil)
+        
         Client.providers.vpnProvider.connect({ [weak self] error in
             
             //User clicked the button, the connection of the VPN was manual

--- a/PIA VPN/UserDefaultsType.swift
+++ b/PIA VPN/UserDefaultsType.swift
@@ -1,0 +1,52 @@
+//
+//  UserDefaultsType.swift
+//  PIA VPN
+//
+//  Created by Laura S on 4/25/24.
+//  Copyright © 2024 Private Internet Access Inc. All rights reserved.
+//
+
+import Foundation
+
+public protocol UserDefaultsType {
+    static func resetStandardUserDefaults()
+    
+    init?(suiteName suitename: String?)
+    
+    func object(forKey defaultName: String) -> Any?
+    
+    func set(_ value: Any?, forKey defaultName: String)
+    
+    func set(_ value: Bool, forKey: String)
+    
+    func removeObject(forKey defaultName: String)
+    
+    func string(forKey defaultName: String) -> String?
+    
+    func bool(forKey defaultName: String) -> Bool
+    
+    func set(_ value: Int, forKey defaultName: String)
+    
+    func integer(forKey defaultName: String) -> Int
+    
+    func set(date: Date?, forKey key: String)
+    
+    func date(forKey key: String) -> Date?
+    
+    func removePersistentDomain(forName: String)
+    
+    @discardableResult
+    func synchronize() -> Bool
+}
+
+extension UserDefaults {
+    public func set(date: Date?, forKey key: String) {
+        self.set(date, forKey: key)
+    }
+    
+    public func date(forKey key: String) -> Date? {
+        return self.value(forKey: key) as? Date
+    }
+}
+
+extension UserDefaults: UserDefaultsType {}

--- a/PIA VPNTests/AccountInformationAvailability/AccountInformationAvailabilityVerifierTests.swift
+++ b/PIA VPNTests/AccountInformationAvailability/AccountInformationAvailabilityVerifierTests.swift
@@ -1,0 +1,130 @@
+import XCTest
+import PIALibrary
+@testable import PIA_VPN
+
+@available(iOS 13.0, *)
+class AccountInformationAvailabilityVerifierTests: XCTestCase {
+    class Fixture {
+        let accountProviderMock = AccountProviderTypeMock()
+        let notificationCenterMock = NotificationCenterMock()
+        let userDefaultsMock = UserDefaultsMock(suiteName: "accountInfoAvailabilityTests")!
+        let twelveHoursInSeconds: TimeInterval = 43200
+        
+        func stubAccountInformationAvailabilityChecked(on date: Date) {
+            userDefaultsMock.dateResult = date
+        }
+        
+    }
+    
+    var fixture: Fixture!
+    var sut: AccountInformationAvailabilityVerifier!
+    
+    override func setUp() {
+        fixture = Fixture()
+    }
+    
+    override func tearDown() {
+        fixture = nil
+        sut = nil
+    }
+    
+    private func getDateForHoursAgo(_ hoursAgo: Double) -> Date {
+        let now = Date()
+        let hoursAgoInSeconds = ((hoursAgo * 60) * 60)
+        return Date(timeInterval: -hoursAgoInSeconds, since: now)
+    }
+    
+    private func instantiateSut() {
+        sut = AccountInformationAvailabilityVerifier(accountProvider: fixture.accountProviderMock, notificationCenter: fixture.notificationCenterMock, userDefaults: fixture.userDefaultsMock)
+    }
+    
+    func test_verifyAccountInformationAvailabilityAfterDeadline() async {
+        // GIVEN that the account information has been checked 12 hours ago
+        fixture.stubAccountInformationAvailabilityChecked(on: getDateForHoursAgo(12))
+        
+        instantiateSut()
+        
+        let now = Date()
+        // WHEN calling to verify the account information after the default deadline (12 hours)
+        await sut.verifyAccountInformationAvailabity(after: fixture.twelveHoursInSeconds)
+
+        // THEN the account provider is called to retrieve the information
+        XCTAssertEqual(fixture.accountProviderMock.accountInformationCalledAttempt, 1)
+        
+        // AND the UserDafaults is called to update the date of the account information verification
+        XCTAssertEqual(fixture.userDefaultsMock.setDateAttempt, 1)
+        let setDateForKey = fixture.userDefaultsMock.setDateCalledWithArguments?.key
+        let setDateWithDate = fixture.userDefaultsMock.setDateCalledWithArguments?.date
+        
+        XCTAssertEqual(setDateForKey, "kAccountInfoAvailabilityDate")
+        let isIntheSameMinute = Calendar.current.compare(setDateWithDate ?? Date(), to: now, toGranularity: .minute)
+        XCTAssertEqual(isIntheSameMinute, ComparisonResult.orderedSame)
+        
+        // AND No Notification is posted
+        XCTAssertEqual(fixture.notificationCenterMock.postNotificationCalledAttempt, 0)
+        
+        
+    }
+    
+    func test_verifyAccountInformationAvailabilityBeforeDeadline() async {
+        // GIVEN that the account information has been checked 11 hours ago
+        fixture.stubAccountInformationAvailabilityChecked(on: getDateForHoursAgo(11))
+        
+        instantiateSut()
+        
+        // WHEN calling to verify the account information after the default deadline (12 hours)
+        await sut.verifyAccountInformationAvailabity(after: fixture.twelveHoursInSeconds)
+
+        // THEN the account provider is NOT called to retrieve the information
+        XCTAssertEqual(fixture.accountProviderMock.accountInformationCalledAttempt, 0)
+        
+        // AND the UserDafaults is NOT called to update the date of the account information verification
+        XCTAssertEqual(fixture.userDefaultsMock.setDateAttempt, 0)
+        
+        // AND No Notification is posted
+        XCTAssertEqual(fixture.notificationCenterMock.postNotificationCalledAttempt, 0)
+        
+    }
+    
+    func test_verifyAccountInformationAvailabilityWithoutDeadline() async {
+        // GIVEN that the account information has been checked 11 hours ago
+        fixture.stubAccountInformationAvailabilityChecked(on: getDateForHoursAgo(11))
+        
+        instantiateSut()
+        
+        // WHEN calling to verify the account information without any deadline
+        await sut.verifyAccountInformationAvailabity(after: nil)
+
+        // THEN the account provider is called to retrieve the information
+        XCTAssertEqual(fixture.accountProviderMock.accountInformationCalledAttempt, 1)
+        
+        // AND the UserDafaults is called to update the date of the account information verification
+        XCTAssertEqual(fixture.userDefaultsMock.setDateAttempt, 1)
+        
+        // AND No Notification is posted
+        XCTAssertEqual(fixture.notificationCenterMock.postNotificationCalledAttempt, 0)
+        
+    }
+    
+    func test_verifyAccountInformationAvailabilityWhenUnAuthorizedError() async {
+        // GIVEN that there is an 'unauthorized' error when checking the account information
+        fixture.accountProviderMock.accountInformationError = ClientError.unauthorized
+        
+        instantiateSut()
+        
+        // WHEN calling to verify the account information
+        await sut.verifyAccountInformationAvailabity(after: nil)
+
+        // THEN the account provider is called to retrieve the information
+        XCTAssertEqual(fixture.accountProviderMock.accountInformationCalledAttempt, 1)
+        
+        // AND the `PIAUnauthorized` Notification is posted
+        XCTAssertEqual(fixture.notificationCenterMock.postNotificationCalledAttempt, 1)
+        XCTAssertEqual(fixture.notificationCenterMock.postNotificationCalledWithName, Notification.Name.PIAUnauthorized)
+        
+        // AND the UserDafaults is NOT called to update anything
+        XCTAssertEqual(fixture.userDefaultsMock.setDateAttempt, 0)
+        
+    }
+    
+}

--- a/PIA VPNTests/Mocks/UserDefaultsMock.swift
+++ b/PIA VPNTests/Mocks/UserDefaultsMock.swift
@@ -1,0 +1,79 @@
+//
+//  UserDefaultsMock.swift
+//  PIA VPNTests
+//
+//  Created by Laura S on 4/25/24.
+//  Copyright © 2024 Private Internet Access Inc. All rights reserved.
+//
+
+import Foundation
+@testable import PIA_VPN
+
+class UserDefaultsMock: UserDefaultsType {
+    static func resetStandardUserDefaults() {
+        
+    }
+    
+    required init?(suiteName suitename: String?) {
+        
+    }
+    
+    var objectResult: Any?
+    func object(forKey defaultName: String) -> Any? {
+        return objectResult
+    }
+    
+    func set(_ value: Any?, forKey defaultName: String) {
+    }
+    
+    func set(_ value: Bool, forKey: String) {
+        
+    }
+    
+    func removeObject(forKey defaultName: String) {
+        
+    }
+    
+    var stringResult: String?
+    func string(forKey defaultName: String) -> String? {
+        return stringResult
+    }
+    
+    var boolResult: Bool = false
+    func bool(forKey defaultName: String) -> Bool {
+            return boolResult
+    }
+    
+    func set(_ value: Int, forKey defaultName: String) {
+        
+    }
+    
+    var integerResult: Int = 0
+    func integer(forKey defaultName: String) -> Int {
+        return integerResult
+    }
+    
+    private(set) var setDateAttempt = 0
+    private(set) var setDateCalledWithArguments: (date: Date?, key: String)?
+    func set(date: Date?, forKey key: String) {
+        setDateAttempt += 1
+        setDateCalledWithArguments = (date: date, key: key)
+    }
+    
+    var dateResult: Date?
+    func date(forKey key: String) -> Date? {
+        return dateResult
+    }
+    
+    
+    func removePersistentDomain(forName: String) {
+        
+    }
+    
+    var synchronizeResult: Bool = true
+    func synchronize() -> Bool {
+        return synchronizeResult
+    }
+    
+    
+}


### PR DESCRIPTION
- This PR implements a new object called `AccountInformationAvailabilityVerifier` that checks whether the user information is available given a specific deadline. (For example, if the deadline is 12 hours, then the object does not check again if the last time it checked was less than 12 hours).
- This new object is called:
- When the app becomes active and the account information has not been checked in the last 12 hours.
- When the user taps the connect button and the account information has not been checked in the last 3 hours.

