### PR TITLE
PIA-0000: Set XCode 15.2 on CI sue to simulator issue in 15.3

### DIFF
--- a/.github/workflows/development_build.yml
+++ b/.github/workflows/development_build.yml
@@ -27,7 +27,7 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Select XCode version
-      run: sudo xcode-select -s /Applications/Xcode_15.3.app
+      run: sudo xcode-select -s /Applications/Xcode_15.2.app
     
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1

--- a/.github/workflows/ios_pull_request.yml
+++ b/.github/workflows/ios_pull_request.yml
@@ -19,6 +19,9 @@ jobs:
         git config --global url."https://${{ secrets.ORG_GITHUB_USERNAME }}:${{ secrets.ORG_GITHUB_TOKEN }}@github.com/".insteadOf "git@github.com:"
 
     - uses: actions/checkout@v3
+
+    - name: Select XCode version
+      run: sudo xcode-select -s /Applications/Xcode_15.2.app
     
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1

--- a/.github/workflows/ios_testflight_deploy.yml
+++ b/.github/workflows/ios_testflight_deploy.yml
@@ -27,7 +27,7 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Select XCode version
-      run: sudo xcode-select -s /Applications/Xcode_15.3.app
+      run: sudo xcode-select -s /Applications/Xcode_15.2.app
     
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1

--- a/.github/workflows/tvos_pull_request.yml
+++ b/.github/workflows/tvos_pull_request.yml
@@ -19,6 +19,9 @@ jobs:
         git config --global url."https://${{ secrets.ORG_GITHUB_USERNAME }}:${{ secrets.ORG_GITHUB_TOKEN }}@github.com/".insteadOf "git@github.com:"
 
     - uses: actions/checkout@v3
+
+    - name: Select XCode version
+      run: sudo xcode-select -s /Applications/Xcode_15.2.app
     
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1

--- a/.github/workflows/tvos_testflight_deploy.yml
+++ b/.github/workflows/tvos_testflight_deploy.yml
@@ -28,6 +28,9 @@ jobs:
         git config --global url."https://${{ secrets.ORG_GITHUB_USERNAME }}:${{ secrets.ORG_GITHUB_TOKEN }}@github.com/".insteadOf "git@github.com:"
 
     - uses: actions/checkout@v3
+
+    - name: Select XCode version
+      run: sudo xcode-select -s /Applications/Xcode_15.2.app
     
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1


### PR DESCRIPTION
**Summary**
This PR sets XCode on CI to 15.2 due to a current issue we face with the simulator on XCode 15.3