### PR TITLE
PIA-1824: Recover purchases fix

### DIFF
--- a/PIA VPN-tvOS/LoginQR/Domain/Use cases/LoginWithReceiptUseCase.swift
+++ b/PIA VPN-tvOS/LoginQR/Domain/Use cases/LoginWithReceiptUseCase.swift
@@ -40,7 +40,7 @@ class LoginWithReceiptUseCase: LoginWithReceiptUseCaseType {
     }
     
     private func login(with receipt: Data, continuation: CheckedContinuation<UserAccount, any Error>) {
-        loginProvider.login(with: Data()) { [weak self] result in
+        loginProvider.login(with: receipt) { [weak self] result in
             guard let self else { return }
             
             switch result {


### PR DESCRIPTION
**Summary**
This PR fixes a problem when recovering the purchase in Sign in, since it wasn't passing the real receipt to the API.