### PR TITLE
PIA-1873: Remove duplicated strings

### DIFF
--- a/PIA VPN-tvOS/Signup/Presentation/SignupViewModel.swift
+++ b/PIA VPN-tvOS/Signup/Presentation/SignupViewModel.swift
@@ -10,7 +10,7 @@ import Foundation
 import PIALibrary
 
 class SignupViewModel: ObservableObject {
-    let title: String = L10n.Localizable.Tvos.Signup.Subscription.Paywall.title
+    let title: String = L10n.Signup.Purchase.Trials.region
     let optionButtons: [OnboardingComponentButton]
     let subscribeButtonTitle = L10n.Localizable.Tvos.Signup.Subscription.Paywall.Button.subscribe
     @Published var subtitle: String = L10n.Localizable.Tvos.Signup.Subscription.Paywall.subtitle("")

--- a/PIA VPN-tvOS/Signup/Presentation/SubscriptionOptionViewModelMapper.swift
+++ b/PIA VPN-tvOS/Signup/Presentation/SubscriptionOptionViewModelMapper.swift
@@ -17,7 +17,7 @@ class SubscriptionOptionViewModelMapper {
         let rawPrice = product.product.price.stringValue + currency
         let price = rawPrice + " "
         + (isYearlyPlan ? L10n.Localizable.Tvos.Signup.Subscription.Paywall.Price.year
-           : L10n.Localizable.Tvos.Signup.Subscription.Paywall.Price.month)
+           : L10n.Welcome.Plan.Accessibility.perMonth)
         let monthlyPrice = (monthlyPrice(price: product.product.price.doubleValue) ?? "") + currency +  L10n.Localizable.Tvos.Signup.Subscription.Paywall.Price.Month.simplified
         
         return SubscriptionOptionViewModel(productId: product.product.identifier,

--- a/PIA VPN-tvOS/Signup/UI/SignupView.swift
+++ b/PIA VPN-tvOS/Signup/UI/SignupView.swift
@@ -20,7 +20,7 @@ struct SignupView: View {
                     
                     Image.onboarding_pia_brand
                     
-                    Text(L10n.Localizable.Tvos.Signup.Subscription.title)
+                    Text(L10n.Localizable.Tvos.Welcome.Button.signup)
                         .font(.system(size: 76))
                         .foregroundColor(.piaOnBackground)
                         

--- a/PIA VPN-tvOS/SignupCredentials/UI/SignupCredentialsView.swift
+++ b/PIA VPN-tvOS/SignupCredentials/UI/SignupCredentialsView.swift
@@ -48,10 +48,10 @@ struct SignupCredentialsView: View {
                 }
                 
                 VStack(alignment: .leading, spacing: 40) {
-                    SignupCredentialsFieldView(title: L10n.Localizable.Tvos.Signup.Credentials.Details.username,
+                    SignupCredentialsFieldView(title: L10n.Signup.Success.Username.caption,
                                                subtitle: credentials.username)
                     
-                    SignupCredentialsFieldView(title: L10n.Localizable.Tvos.Signup.Credentials.Details.password, 
+                    SignupCredentialsFieldView(title: L10n.Signup.Success.Password.caption,
                                                subtitle: credentials.password)
                 }
                 .frame(height: 250)

--- a/PIA VPN/SwiftGen+Strings.swift
+++ b/PIA VPN/SwiftGen+Strings.swift
@@ -1648,14 +1648,10 @@ internal enum L10n {
           internal enum Details {
             /// Get Started
             internal static let button = L10n.tr("Localizable", "tvos.signup.credentials.details.button", fallback: "Get Started")
-            /// Password
-            internal static let password = L10n.tr("Localizable", "tvos.signup.credentials.details.password", fallback: "Password")
             /// You will also receive an email shortly with your username and password.
             internal static let subtitle = L10n.tr("Localizable", "tvos.signup.credentials.details.subtitle", fallback: "You will also receive an email shortly with your username and password.")
             /// Card redeemed sucessfully
             internal static let title = L10n.tr("Localizable", "tvos.signup.credentials.details.title", fallback: "Card redeemed sucessfully")
-            /// Username
-            internal static let username = L10n.tr("Localizable", "tvos.signup.credentials.details.username", fallback: "Username")
           }
         }
         internal enum Email {
@@ -1667,11 +1663,7 @@ internal enum L10n {
           }
         }
         internal enum Subscription {
-          /// Sign Up
-          internal static let title = L10n.tr("Localizable", "tvos.signup.subscription.title", fallback: "Sign Up")
           internal enum Error {
-            /// Error
-            internal static let title = L10n.tr("Localizable", "tvos.signup.subscription.error.title", fallback: "Error")
             internal enum Message {
               /// Something went wrong. Please try again.
               internal static let generic = L10n.tr("Localizable", "tvos.signup.subscription.error.message.generic", fallback: "Something went wrong. Please try again.")
@@ -1684,15 +1676,11 @@ internal enum L10n {
             internal static func subtitle(_ p1: Any) -> String {
               return L10n.tr("Localizable", "tvos.signup.subscription.paywall.subtitle", String(describing: p1), fallback: "Start your 7 days free trial then %@ per year.")
             }
-            /// Connect to any region easily
-            internal static let title = L10n.tr("Localizable", "tvos.signup.subscription.paywall.title", fallback: "Connect to any region easily")
             internal enum Button {
               /// Subscribe Now
               internal static let subscribe = L10n.tr("Localizable", "tvos.signup.subscription.paywall.button.subscribe", fallback: "Subscribe Now")
             }
             internal enum Price {
-              /// per month
-              internal static let month = L10n.tr("Localizable", "tvos.signup.subscription.paywall.price.month", fallback: "per month")
               /// BEST VALUE - FREE TRIAL
               internal static let trial = L10n.tr("Localizable", "tvos.signup.subscription.paywall.price.trial", fallback: "BEST VALUE - FREE TRIAL")
               /// per year

--- a/PIA VPN/en.lproj/Localizable.strings
+++ b/PIA VPN/en.lproj/Localizable.strings
@@ -577,16 +577,12 @@
 "tvos.signin.expired.trial.subtitle" = "If you enjoyed premium VPN protection, subscribe to PIA!";
 
 //SignUp with subscription (tvOS)
-"tvos.signup.subscription.title" = "Sign Up";
-"tvos.signup.subscription.paywall.title" = "Connect to any region easily";
 "tvos.signup.subscription.paywall.subtitle" = "Start your 7 days free trial then %@ per year.";
 "tvos.signup.subscription.paywall.price.year" = "per year";
 "tvos.signup.subscription.paywall.price.trial" = "BEST VALUE - FREE TRIAL";
-"tvos.signup.subscription.paywall.price.month" = "per month";
 "tvos.signup.subscription.paywall.price.month.simplified" = "/mo";
 "tvos.signup.subscription.paywall.button.subscribe" = "Subscribe Now";
 
-"tvos.signup.subscription.error.title" = "Error";
 "tvos.signup.subscription.error.message.generic" = "Something went wrong. Please try again.";
 "tvos.signup.subscription.error.message.paymentCancelled" = "Payment was cancelled. Please try again.";
 
@@ -595,8 +591,7 @@
 "tvos.signup.credentials.title" = "Success!";
 "tvos.signup.credentials.details.title" = "Card redeemed sucessfully";
 "tvos.signup.credentials.details.subtitle" = "You will also receive an email shortly with your username and password.";
-"tvos.signup.credentials.details.username" = "Username";
-"tvos.signup.credentials.details.password" = "Password";
+
 "tvos.signup.credentials.details.button" = "Get Started";
 
 "tvos.signup.terms_conditions.title" = "Terms and Conditions";


### PR DESCRIPTION
**Summary**
This PR removes strings that are already translated in other keys so Translators don't have issues with the editor in Crowdin.