### PR TITLE
KM-4856: Fix DIP on tvOS due to Accounts migrations

### DIFF
--- a/PIA VPN-tvOS/Bootstraper/BootstraperFactory.swift
+++ b/PIA VPN-tvOS/Bootstraper/BootstraperFactory.swift
@@ -45,6 +45,7 @@ class BootstraperFactory {
     
     private static func loadDataBase() {
         Client.database = Client.Database(group: AppConstants.appGroup)
+        Client.providers.serverProvider = ServerProviderFactory.makeDefaultServerProvider()
     }
     
     private static func setupPreferences() {

--- a/PIA VPN-tvOS/DedicatedIp/Presentation/DedicatedIPViewModel.swift
+++ b/PIA VPN-tvOS/DedicatedIp/Presentation/DedicatedIPViewModel.swift
@@ -33,7 +33,9 @@ class DedicatedIPViewModel: ObservableObject {
         guard let server = getDedicatedIp(),
               let dipIKEv2IP = server.dipIKEv2IP,
               let dipStatusString = server.dipStatusString else {
-            dedicatedIPStats = []
+            Task { @MainActor in
+                dedicatedIPStats = []
+            }
             return
         }
         Task { @MainActor in
@@ -55,8 +57,8 @@ class DedicatedIPViewModel: ObservableObject {
         
         do {
             try await activateDIPToken(token: token)
-            onAppear()
             Task { @MainActor in
+                onAppear()
                 showActivatedDialog = true
             }
         } catch {

--- a/PIA VPN.xcodeproj/project.pbxproj
+++ b/PIA VPN.xcodeproj/project.pbxproj
@@ -7771,7 +7771,7 @@
 			repositoryURL = "https://github.com/pia-foss/mobile-ios-library.git";
 			requirement = {
 				kind = revision;
-				revision = e864a59d6d1aa2d820016dcac074bfc070a89aca;
+				revision = 40c1afb5f143bd061e322093a6d11e798739c10c;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */


### PR DESCRIPTION
**Summary**
This PR fixes the DIP issue after migrating the Accounts screen by using the same `DefaultServerProvider` instance across the app. By using one single instance, we guarantee that we use the same Keychain instance as well which is required to save and fetch the dip token.