### PR TITLE
KM-5043: Dismiss any other view that is presented before showing Force Update

### DIFF
--- a/PIA VPN/DashboardViewController.swift
+++ b/PIA VPN/DashboardViewController.swift
@@ -706,7 +706,20 @@ class DashboardViewController: AutolayoutViewController {
         let forceUpdate = ForceUpdateViewController()
         forceUpdate.modalPresentationStyle = .fullScreen
         DispatchQueue.main.async { [weak self] in
-            self?.present(forceUpdate, animated: false)
+            var isOtherViewPresented = false
+            if let presented = self?.presentedViewController {
+                if !(presented is ForceUpdateViewController) {
+                    isOtherViewPresented = true
+                }
+            }
+            
+            if isOtherViewPresented {
+                self?.dismiss(animated: false, completion: {
+                    self?.present(forceUpdate, animated: false)
+                })
+            } else {
+                self?.present(forceUpdate, animated: false)
+            }
         }
     }
     

--- a/PIA VPN/PIAWelcomeViewController.swift
+++ b/PIA VPN/PIAWelcomeViewController.swift
@@ -209,7 +209,20 @@ public class PIAWelcomeViewController: AutolayoutViewController, WelcomeCompleti
         let forceUpdate = ForceUpdateViewController()
         forceUpdate.modalPresentationStyle = .fullScreen
         DispatchQueue.main.async { [weak self] in
-            self?.present(forceUpdate, animated: false)
+            var isOtherViewPresented = false
+            if let presented = self?.presentedViewController {
+                if !(presented is ForceUpdateViewController) {
+                    isOtherViewPresented = true
+                }
+            }
+            
+            if isOtherViewPresented {
+                self?.dismiss(animated: false, completion: {
+                    self?.present(forceUpdate, animated: false)
+                })
+            } else {
+                self?.present(forceUpdate, animated: false)
+            }
         }
     }
     


### PR DESCRIPTION
- When the Flag for force update gets enabled, the app might be in a state where any other view could be modally presented over the current context like settings, menu, options, etc. So we want to make sure that the Force Update screen is presented when intended also in those scenarios.


For more information, see the [CONTRIBUTING](/.github.com/CONTRIBUTING.md) readme or the contributing [guide](https://pia-oss.github.io/contribute).


**Summary**

<!-- Summary of the PR -->

This PR fixes/implements the following **bugs/features**

* [x] Force Update Feature Enhancement

