### PR TITLE
KM-11906: Fix crashes on automation settings

### DIFF
--- a/.github/workflows/ios_pull_request.yml
+++ b/.github/workflows/ios_pull_request.yml
@@ -21,7 +21,7 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Select XCode version
-      run: sudo xcode-select -s /Applications/Xcode_16.2.0.app
+      run: sudo xcode-select -s /Applications/Xcode_16.4.0.app
     
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1

--- a/PIA VPN/AddCustomNetworksViewController.swift
+++ b/PIA VPN/AddCustomNetworksViewController.swift
@@ -134,8 +134,9 @@ extension AddCustomNetworksViewController: UICollectionViewDelegateFlowLayout, U
 
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForHeaderInSection section: Int) -> CGSize {
 
-        let indexPath = IndexPath(row: 0, section: section)
-        let headerView = self.collectionView(collectionView, viewForSupplementaryElementOfKind: UICollectionView.elementKindSectionHeader, at: indexPath) as! PIAHeaderCollectionViewCell
+        let nib = UINib(nibName: Cells.header, bundle: nil)
+        let headerView = nib.instantiate(withOwner: nil, options: nil).first as! PIAHeaderCollectionViewCell
+        headerView.setup(withTitle: L10n.Localizable.Network.Management.Tool.Add.rule, andSubtitle: L10n.Localizable.Network.Management.Tool.Choose.wifi + L10n.Localizable.Settings.Hotspothelper.Available.help)
 
         return headerView.systemLayoutSizeFitting(CGSize(width: collectionView.frame.width, height: UIView.layoutFittingExpandedSize.height),
                                                   withHorizontalFittingPriority: .defaultHigh,

--- a/PIA VPN/TrustedNetworksViewController.swift
+++ b/PIA VPN/TrustedNetworksViewController.swift
@@ -231,19 +231,21 @@ extension TrustedNetworksViewController: UICollectionViewDelegateFlowLayout, UIC
 
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForHeaderInSection section: Int) -> CGSize {
 
-        let indexPath = IndexPath(row: 0, section: section)
-        let headerView = self.collectionView(collectionView, viewForSupplementaryElementOfKind: UICollectionView.elementKindSectionHeader, at: indexPath) as! PIAHeaderCollectionViewCell
+        let nib = UINib(nibName: Cells.header, bundle: nil)
+        let headerView = nib.instantiate(withOwner: nil, options: nil).first as! PIAHeaderCollectionViewCell
+        headerView.setup(withTitle: L10n.Localizable.Network.Management.Tool.title, andSubtitle: L10n.Localizable.Settings.Hotspothelper.description)
 
         return headerView.systemLayoutSizeFitting(CGSize(width: collectionView.frame.width, height: UIView.layoutFittingExpandedSize.height),
                                                   withHorizontalFittingPriority: .defaultHigh,
-                                                  verticalFittingPriority: .fittingSizeLevel) 
+                                                  verticalFittingPriority: .fittingSizeLevel)
 
     }
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForFooterInSection section: Int) -> CGSize {
 
-        let indexPath = IndexPath(row: 0, section: section)
-        let footerView = self.collectionView(collectionView, viewForSupplementaryElementOfKind: UICollectionView.elementKindSectionFooter, at: indexPath) as! NetworkFooterCollectionViewCell
+        let nib = UINib(nibName: Cells.footer, bundle: nil)
+        let footerView = nib.instantiate(withOwner: nil, options: nil).first as! NetworkFooterCollectionViewCell
+        footerView.setup()
 
         return footerView.systemLayoutSizeFitting(CGSize(width: collectionView.frame.width, height: UIView.layoutFittingExpandedSize.height),
                                                   withHorizontalFittingPriority: .defaultHigh,

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -18,7 +18,7 @@ platform :ios do
     run_tests(
       scheme: "PIA VPN dev",
       testplan: "PIA-VPN-e2e-simulator",
-      devices: ["iPhone 14"],
+      devices: ["iPhone 16"],
       prelaunch_simulator: true,
       test_without_building: true
     )


### PR DESCRIPTION

**Summary**

This PR fixes a couple of crashes that were happening when performing various actions on the "Manage Automation" settings screen. 
The root cause:
- Directly calling the collection view's data source methods to calculate the reference size of header and footer views, which deques views improperly. 

This PR fixes/implements the following **bugs/features**

* [x] Bug 1
* [ ] Bug 2
* [ ] Feature 1
* [ ] Feature 2
* [ ] Breaking changes

<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

Explain the **motivation** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

**Test plan (required)**

Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.

<!-- Make sure tests pass on both Travis and Circle CI. -->

**Code formatting**

<!-- See the simple style guide. -->

**Closing issues**

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
Fixes #