### PR TITLE
KM-15296 Reset location sorting order to default after logout

### DIFF
--- a/PIA VPN/Global/AppPreferences.swift
+++ b/PIA VPN/Global/AppPreferences.swift
@@ -882,6 +882,7 @@ class AppPreferences {
         lastRatingRejection = nil
         lastPositiveRatingSubmitted = nil
         lastNegativeRatingSubmitted = nil
+        regionFilter = .latency
         showGeoServers = true
         showServiceMessages = false
         dismissedMessages = []


### PR DESCRIPTION
## Summary
- `regionFilter` was not being reset on logout, causing the sort order to persist across sessions
- Added `regionFilter = .latency` to `AppPreferences.reset()` to restore the default on logout