### PR TITLE
KM-15263 Debug menu for tvOS [Additional fixes]

### DIFF
--- a/LocalPackages/PIADebugMenu/Sources/PIADebugMenu/Components/DebugInfoRow.swift
+++ b/LocalPackages/PIADebugMenu/Sources/PIADebugMenu/Components/DebugInfoRow.swift
@@ -15,7 +15,6 @@ struct DebugInfoRow: View {
         }
         #if os(tvOS)
         .padding(.vertical, 8)
-        .focusable()
         #else
         .padding(.vertical, 2)
         #endif

--- a/LocalPackages/PIADebugMenu/Sources/PIADebugMenu/DebugMenuView.swift
+++ b/LocalPackages/PIADebugMenu/Sources/PIADebugMenu/DebugMenuView.swift
@@ -99,9 +99,15 @@ public struct DebugMenuView: View {
         ScrollView {
             VStack(alignment: .leading, spacing: 40) {
                 appInfoSection
+                    .focusable()
+                vpnSection
+                    .focusable()
                 accountSection
+                    .focusable()
                 receiptSection
+                    .focusable()
                 logsSection
+                    .focusable()
                 supportSection
             }
             .padding(.horizontal, 60)
@@ -126,6 +132,15 @@ public struct DebugMenuView: View {
             DebugInfoRow(label: "Version", value: appVersion)
             DebugInfoRow(label: "Environment", value: environment)
             DebugInfoRow(label: "Base URL", value: baseUrl)
+        }
+    }
+
+    private var vpnSection: some View {
+        DebugSection("VPN") {
+            DebugInfoRow(label: "Status", value: Client.daemons.vpnStatus.rawValue)
+            DebugInfoRow(label: "Protocol", value: Client.preferences.vpnType)
+            DebugInfoRow(label: "Local IP", value: Client.daemons.publicIP ?? "---")
+            DebugInfoRow(label: "VPN IP", value: Client.daemons.vpnIP ?? "---")
         }
     }
 
@@ -157,7 +172,6 @@ public struct DebugMenuView: View {
                 .padding(.vertical, 8)
                 .padding(.horizontal, 12)
                 .frame(maxWidth: .infinity, alignment: .leading)
-                .focusable()
                 #else
                 .padding(.vertical, 2)
                 #endif
@@ -199,7 +213,6 @@ public struct DebugMenuView: View {
             .padding(.vertical, 8)
             .padding(.horizontal, 12)
             .frame(maxWidth: .infinity, alignment: .leading)
-            .focusable()
             #else
             .padding(.vertical, 2)
             #endif
@@ -272,7 +285,7 @@ public struct DebugMenuView: View {
                     }
 
                     do {
-                        let reportId = try await Client.submitDebugReport()
+                        let reportId = try await Client.submitDebugReport(includeDebug: true, redactIPs: false)
                         reportResult = ReportResult(
                             title: "Debug information submitted",
                             message: "Report ID: \(reportId)\nPlease note this ID — support will need it to locate your submission."

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Client+DebugReport.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Client+DebugReport.swift
@@ -4,7 +4,15 @@ extension Client {
     /// Submits a CSI debug report directly, bypassing the VPN provider.
     /// Use this instead of `providers.vpnProvider.submitDebugReport` when a VPN
     /// profile may not be configured (e.g. simulator, mock VPN builds).
+    /// Includes debug logs only if the user has enabled debug logging. IPs are always redacted.
     public static func submitDebugReport() async throws -> String {
         try await PIAWebServices().submitDebugReport()
+    }
+
+    /// Submits a CSI debug report with explicit control over log verbosity and IP redaction.
+    /// Use this overload when the caller needs to override the defaults, e.g. internal debug tools
+    /// that always include debug logs and don't need IP redaction.
+    public static func submitDebugReport(includeDebug: Bool, redactIPs: Bool) async throws -> String {
+        try await PIAWebServices().submitDebugReport(includeDebug: includeDebug, redactIPs: redactIPs)
     }
 }

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Providers/CSI/PIACSILogInformationProvider.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Providers/CSI/PIACSILogInformationProvider.swift
@@ -26,14 +26,15 @@ import PIACSI
 struct PIACSILogInformationProvider: CSIDataProvider {
     var sectionName: String { "application.log" }
     var content: String? { getApplicationLogs() }
+    let includeDebug: Bool
+    let redactIPs: Bool
 
     private func getApplicationLogs() -> String {
-        #if os(tvOS)
-        // Force includeDebug on tvOS since logs submission is only accessible for internal use
-        let logs = PIALogHandler.logStorage.getAllLogs(includeDebug: true)
-        #else
-        let logs = PIALogHandler.logStorage.getAllLogs(includeDebug: Client.preferences.debugLogging)
-        #endif
-        return logs.isEmpty ? "No logs available" : logs.redactIPs()
+        let logs = PIALogHandler.logStorage.getAllLogs(includeDebug: includeDebug)
+        guard !logs.isEmpty else {
+            return "No logs available"
+        }
+
+        return redactIPs ? logs.redactIPs() : logs
     }
 }

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Providers/CSI/PIACSIRegionInformationProvider.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Providers/CSI/PIACSIRegionInformationProvider.swift
@@ -12,6 +12,7 @@ import PIACSI
 struct PIACSIRegionInformationProvider: CSIDataProvider {
     var sectionName: String { "regions.json" }
     var content: String? { regionInformation() }
+    let redactIPs: Bool
 
     private func regionInformation() -> String {
         var redactedServers: [String] = []
@@ -45,6 +46,6 @@ struct PIACSIRegionInformationProvider: CSIDataProvider {
             }
         }
 
-        return redactedServers.debugDescription.redactIPs()
+        return redactIPs ? redactedServers.debugDescription.redactIPs() : redactedServers.debugDescription
     }
 }

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Providers/CSI/PIACSIUserInformationProvider.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Providers/CSI/PIACSIUserInformationProvider.swift
@@ -12,6 +12,7 @@ import PIACSI
 struct PIACSIUserInformationProvider: CSIDataProvider {
     var sectionName: String { "user_settings" }
     var content: String? { getUserInformation() }
+    let redactIPs: Bool
 
     private func getUserInformation() -> String {
         guard let defaults = UserDefaults(suiteName: Client.Configuration.appGroup) else {
@@ -19,6 +20,7 @@ struct PIACSIUserInformationProvider: CSIDataProvider {
         }
 
         let filteredPreferences = WhitelistUtil.filter(preferences: defaults.dictionaryRepresentation())
-        return filteredPreferences.map { "\($0): \($1)" }.joined(separator: "\n").redactIPs()
+        let result = filteredPreferences.map { "\($0): \($1)" }.joined(separator: "\n")
+        return redactIPs ? result.redactIPs() : result
     }
 }

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Util/iOS/String+Components.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Util/iOS/String+Components.swift
@@ -37,8 +37,10 @@ extension String {
     }
 
     func redactIPs() -> String {
-        return self.replacingOccurrences(of: "\\b(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\b",
-                                         with: "REDACTED",
-                                         options: [.regularExpression])
+        replacingOccurrences(
+            of: "\\b(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\b",
+            with: "REDACTED",
+            options: [.regularExpression]
+        )
     }
 }

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/WebServices/PIAWebServices+Ephemeral.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/WebServices/PIAWebServices+Ephemeral.swift
@@ -46,13 +46,17 @@ extension PIAWebServices {
     }
     
     func submitDebugReport() async throws -> String {
+        try await submitDebugReport(includeDebug: Client.preferences.debugLogging, redactIPs: true)
+    }
+
+    func submitDebugReport(includeDebug: Bool, redactIPs: Bool) async throws -> String {
         let providers: [CSIDataProvider] = [
             PIACSIProtocolInformationProvider(),
             PIACSIDeviceInformationProvider(),
-            PIACSILogInformationProvider(),
+            PIACSILogInformationProvider(includeDebug: includeDebug, redactIPs: redactIPs),
             PIACSISubscriptionInformationProvider(),
-            PIACSIRegionInformationProvider(),
-            PIACSIUserInformationProvider(),
+            PIACSIRegionInformationProvider(redactIPs: redactIPs),
+            PIACSIUserInformationProvider(redactIPs: redactIPs),
             PIACSILastKnownExceptionProvider(),
         ]
 


### PR DESCRIPTION
## Summary
- Adds a VPN section to the tvOS debug menu showing status, protocol, local IP and VPN IP
- Fixes tvOS scrolling by applying `.focusable()` at section level
- Refactors CSI debug report submission to make IP redaction and log verbosity configurable per call site; the debug menu sends unredacted reports with full debug logs, all other callers retain the existing behaviour