### PR TITLE
KM-15351 tvOS: navigate to expired screen on login with expired account

### DIFF
--- a/PIA VPN-tvOS/Login/CompositionRoot/LoginFactory.swift
+++ b/PIA VPN-tvOS/Login/CompositionRoot/LoginFactory.swift
@@ -19,7 +19,8 @@ class LoginFactory {
                        checkLoginAvailability: CheckLoginAvailability(),
                        validateLoginCredentials: ValidateCredentialsFormat(),
                        errorHandler: makeLoginViewModelErrorHandler(),
-                       onSuccessAction: .navigate(router: AppRouter.shared, destination: OnboardingDestinations.connectionstats))
+                       onSuccessAction: .navigate(router: AppRouter.shared, destination: OnboardingDestinations.connectionstats),
+                       onExpiredAction: .navigate(router: AppRouter.shared, destination: AuthenticationDestinations.expired))
     }
     
     private static func makeLoginWithCredentialsUseCase() -> LoginWithCredentialsUseCaseType {

--- a/PIA VPN-tvOS/Login/Presentation/LoginViewModel.swift
+++ b/PIA VPN-tvOS/Login/Presentation/LoginViewModel.swift
@@ -17,17 +17,19 @@ class LoginViewModel: ObservableObject {
     private let validateLoginCredentials: ValidateCredentialsFormatType
     private let errorHandler: LoginViewModelErrorHandlerType
     private let onSuccessAction: AppRouter.Actions
+    private let onExpiredAction: AppRouter.Actions
     
     @Published var isAccountExpired = false
     @Published var shouldShowErrorMessage = false
     @Published var loginStatus: LoginStatus = .none
     
-    init(loginWithCredentialsUseCase: LoginWithCredentialsUseCaseType, checkLoginAvailability: CheckLoginAvailabilityType, validateLoginCredentials: ValidateCredentialsFormatType, errorHandler: LoginViewModelErrorHandlerType, onSuccessAction: AppRouter.Actions) {
+    init(loginWithCredentialsUseCase: LoginWithCredentialsUseCaseType, checkLoginAvailability: CheckLoginAvailabilityType, validateLoginCredentials: ValidateCredentialsFormatType, errorHandler: LoginViewModelErrorHandlerType, onSuccessAction: AppRouter.Actions, onExpiredAction: AppRouter.Actions) {
         self.loginWithCredentialsUseCase = loginWithCredentialsUseCase
         self.checkLoginAvailability = checkLoginAvailability
         self.validateLoginCredentials = validateLoginCredentials
         self.errorHandler = errorHandler
         self.onSuccessAction = onSuccessAction
+        self.onExpiredAction = onExpiredAction
     }
     
     func login(username: String, password: String) {
@@ -74,6 +76,7 @@ class LoginViewModel: ObservableObject {
             Task { @MainActor in
                 loginStatus = .failed(errorMessage: nil, field: .none)
                 isAccountExpired = true
+                onExpiredAction()
             }
             return
         }

--- a/PIA VPN-tvOSTests/Login/LoginIntegrationTests.swift
+++ b/PIA VPN-tvOSTests/Login/LoginIntegrationTests.swift
@@ -32,7 +32,8 @@ final class LoginIntegrationTests: XCTestCase {
                                  checkLoginAvailability: CheckLoginAvailability(),
                                  validateLoginCredentials: ValidateCredentialsFormat(),
                                  errorHandler: LoginViewModelErrorHandler(errorMapper: LoginPresentableErrorMapper()),
-                                 onSuccessAction: .navigate(router: appRouter, destination: OnboardingDestinations.installVPNProfile))
+                                 onSuccessAction: .navigate(router: appRouter, destination: OnboardingDestinations.installVPNProfile),
+                                 onExpiredAction: .navigate(router: appRouter, destination: AuthenticationDestinations.expired))
         
         var cancellables = Set<AnyCancellable>()
         let expectation = expectation(description: "Waiting for didLoginSuccessfully property to be updated")
@@ -103,21 +104,21 @@ final class LoginIntegrationTests: XCTestCase {
         let sut = LoginViewModel(loginWithCredentialsUseCase: loginWithCredentialsUseCase,
                                  checkLoginAvailability: CheckLoginAvailability(),
                                  validateLoginCredentials: ValidateCredentialsFormat(),
-                                 errorHandler: LoginViewModelErrorHandler(errorMapper: LoginPresentableErrorMapper()), 
-                                 onSuccessAction: .navigate(router: appRouter, destination: OnboardingDestinations.installVPNProfile))
+                                 errorHandler: LoginViewModelErrorHandler(errorMapper: LoginPresentableErrorMapper()),
+                                 onSuccessAction: .navigate(router: appRouter, destination: OnboardingDestinations.installVPNProfile),
+                                 onExpiredAction: .navigate(router: appRouter, destination: AuthenticationDestinations.expired))
         
         var cancellables = Set<AnyCancellable>()
-        let expectation = expectation(description: "Waiting for isAccountExpired property to be updated")
+        let expectation = expectation(description: "Waiting for expired navigation to be triggered")
         XCTAssertEqual(sut.loginStatus, .none)
-                                 
+
         var capturedLoginStatuses = [LoginStatus]()
         
         sut.$loginStatus.dropFirst().sink(receiveValue: { status in
             capturedLoginStatuses.append(status)
         }).store(in: &cancellables)
         
-        sut.$isAccountExpired.dropFirst().sink(receiveValue: { status in
-            XCTAssertTrue(status)
+        appRouter.$path.dropFirst().sink(receiveValue: { _ in
             expectation.fulfill()
         }).store(in: &cancellables)
         
@@ -126,8 +127,9 @@ final class LoginIntegrationTests: XCTestCase {
         
         // THEN
         wait(for: [expectation], timeout: 1)
+        XCTAssertTrue(sut.isAccountExpired)
         XCTAssertFalse(sut.shouldShowErrorMessage)
-        XCTAssertEqual(appRouter.path, NavigationPath())
+        XCTAssertEqual(appRouter.path, NavigationPath([AuthenticationDestinations.expired]))
         XCTAssertEqual(capturedLoginStatuses.count, 2)
         XCTAssertEqual(capturedLoginStatuses[0], LoginStatus.isLogging)
         XCTAssertEqual(capturedLoginStatuses[1], LoginStatus.failed(errorMessage: nil, field: .none))

--- a/PIA VPN-tvOSTests/Login/LoginViewModelTests.swift
+++ b/PIA VPN-tvOSTests/Login/LoginViewModelTests.swift
@@ -27,7 +27,8 @@ final class LoginViewModelTests: XCTestCase {
                                  checkLoginAvailability: checkLoginAvailabilityMock,
                                  validateLoginCredentials: ValidateCredentialsFormat(),
                                  errorHandler: LoginViewModelErrorHandler(errorMapper: LoginPresentableErrorMapper()),
-                                 onSuccessAction: .navigate(router: appRouterSpy, destination: OnboardingDestinations.installVPNProfile))
+                                 onSuccessAction: .navigate(router: appRouterSpy, destination: OnboardingDestinations.installVPNProfile),
+                                 onExpiredAction: .navigate(router: appRouterSpy, destination: AuthenticationDestinations.expired))
         
         var cancellables = Set<AnyCancellable>()
         let expectation = expectation(description: "Waiting for shouldShowErrorMessage property to be updated")
@@ -71,7 +72,8 @@ final class LoginViewModelTests: XCTestCase {
                                  checkLoginAvailability: checkLoginAvailabilityMock,
                                  validateLoginCredentials: ValidateCredentialsFormat(),
                                  errorHandler: LoginViewModelErrorHandler(errorMapper: LoginPresentableErrorMapper()),
-                                 onSuccessAction: .navigate(router: appRouterSpy, destination: OnboardingDestinations.installVPNProfile))
+                                 onSuccessAction: .navigate(router: appRouterSpy, destination: OnboardingDestinations.installVPNProfile),
+                                 onExpiredAction: .navigate(router: appRouterSpy, destination: AuthenticationDestinations.expired))
         
         var cancellables = Set<AnyCancellable>()
         let expectation = expectation(description: "Waiting for shouldShowErrorMessage property to be updated")
@@ -115,7 +117,8 @@ final class LoginViewModelTests: XCTestCase {
                                  checkLoginAvailability: checkLoginAvailabilityMock,
                                  validateLoginCredentials: ValidateCredentialsFormat(),
                                  errorHandler: LoginViewModelErrorHandler(errorMapper: LoginPresentableErrorMapper()),
-                                 onSuccessAction: .navigate(router: appRouterSpy, destination: OnboardingDestinations.installVPNProfile))
+                                 onSuccessAction: .navigate(router: appRouterSpy, destination: OnboardingDestinations.installVPNProfile),
+                                 onExpiredAction: .navigate(router: appRouterSpy, destination: AuthenticationDestinations.expired))
         
         var cancellables = Set<AnyCancellable>()
         let expectation = expectation(description: "Waiting for shouldShowErrorMessage property to be updated")
@@ -160,7 +163,8 @@ final class LoginViewModelTests: XCTestCase {
                                  checkLoginAvailability: checkLoginAvailabilityMock,
                                  validateLoginCredentials: ValidateCredentialsFormat(),
                                  errorHandler: LoginViewModelErrorHandler(errorMapper: LoginPresentableErrorMapper()),
-                                 onSuccessAction: .navigate(router: appRouterSpy, destination: OnboardingDestinations.installVPNProfile))
+                                 onSuccessAction: .navigate(router: appRouterSpy, destination: OnboardingDestinations.installVPNProfile),
+                                 onExpiredAction: .navigate(router: appRouterSpy, destination: AuthenticationDestinations.expired))
         
         var cancellables = Set<AnyCancellable>()
         let expectation = expectation(description: "Waiting for didLoginSuccessfully property to be updated")
@@ -201,10 +205,11 @@ final class LoginViewModelTests: XCTestCase {
                                  checkLoginAvailability: checkLoginAvailabilityMock,
                                  validateLoginCredentials: ValidateCredentialsFormat(),
                                  errorHandler: LoginViewModelErrorHandler(errorMapper: LoginPresentableErrorMapper()),
-                                 onSuccessAction: .navigate(router: appRouterSpy, destination: OnboardingDestinations.installVPNProfile))
+                                 onSuccessAction: .navigate(router: appRouterSpy, destination: OnboardingDestinations.installVPNProfile),
+                                 onExpiredAction: .navigate(router: appRouterSpy, destination: AuthenticationDestinations.expired))
         
         var cancellables = Set<AnyCancellable>()
-        let expectation = expectation(description: "Waiting for isAccountExpired property to be updated")
+        let expectation = expectation(description: "Waiting for expired navigation to be triggered")
         XCTAssertEqual(sut.loginStatus, LoginStatus.none)
         
         var capturedLoginStatuses = [LoginStatus]()
@@ -213,21 +218,19 @@ final class LoginViewModelTests: XCTestCase {
             capturedLoginStatuses.append(status)
         }).store(in: &cancellables)
         
-        sut.$isAccountExpired.dropFirst().sink(receiveValue: { status in
-            XCTAssertTrue(status)
-            expectation.fulfill()
-        }).store(in: &cancellables)
+        appRouterSpy.didGetARequest = { expectation.fulfill() }
         
         // WHEN
         sut.login(username: "username", password: "password")
         
         // THEN
         wait(for: [expectation], timeout: 1)
+        XCTAssertTrue(sut.isAccountExpired)
         XCTAssertFalse(sut.shouldShowErrorMessage)
         XCTAssertEqual(capturedLoginStatuses.count, 2)
         XCTAssertEqual(capturedLoginStatuses[0], LoginStatus.isLogging)
         XCTAssertEqual(capturedLoginStatuses[1], LoginStatus.failed(errorMessage: nil, field: .none))
-        XCTAssertEqual(appRouterSpy.requests, [])
+        XCTAssertEqual(appRouterSpy.requests, [.navigate(AuthenticationDestinations.expired)])
     }
     
     func test_login_fails_when_loginUseCase_completes_with_unauthorized_error() {
@@ -244,7 +247,8 @@ final class LoginViewModelTests: XCTestCase {
                                  checkLoginAvailability: checkLoginAvailabilityMock,
                                  validateLoginCredentials: ValidateCredentialsFormat(),
                                  errorHandler: LoginViewModelErrorHandler(errorMapper: LoginPresentableErrorMapper()),
-                                 onSuccessAction: .navigate(router: appRouterSpy, destination: OnboardingDestinations.installVPNProfile))
+                                 onSuccessAction: .navigate(router: appRouterSpy, destination: OnboardingDestinations.installVPNProfile),
+                                 onExpiredAction: .navigate(router: appRouterSpy, destination: AuthenticationDestinations.expired))
         
         var cancellables = Set<AnyCancellable>()
         let expectation = expectation(description: "Waiting for shouldShowErrorMessage property to be updated")


### PR DESCRIPTION
## Summary
- `LoginViewModel` was setting `isAccountExpired = true` on expired login but never triggering navigation, so users saw a blank/stuck login screen
- Added `onExpiredAction: AppRouter.Actions` to `LoginViewModel`, following the same pattern as `onSuccessAction`
- Wired it up in `LoginFactory` to navigate to `AuthenticationDestinations.expired`
- Updated unit and integration tests to verify router navigation is triggered instead of asserting it was not called