### PR TITLE
Migrate VPN profiles to async/await

### DIFF
--- a/LocalPackages/PIADashboard/Sources/PIADashboard/UseCases/VpnConnectionUseCase.swift
+++ b/LocalPackages/PIADashboard/Sources/PIADashboard/UseCases/VpnConnectionUseCase.swift
@@ -7,7 +7,7 @@ private let log = PIALogger.logger(for: VpnConnectionUseCase.self)
 public protocol VpnConnectionUseCaseType {
     func connect() async throws
     func disconnect() async throws
-    func getConnectionIntent() -> AnyPublisher<VpnConnectionIntent, Error>
+    func getConnectionIntent() -> AnyPublisher<VpnConnectionIntent, Never>
 }
 
 public enum VpnConnectionIntent: Equatable {
@@ -18,7 +18,7 @@ public enum VpnConnectionIntent: Equatable {
 
 public final class VpnConnectionUseCase: VpnConnectionUseCaseType {
 
-    internal var connectionIntent: CurrentValueSubject<VpnConnectionIntent, Error>
+    internal var connectionIntent: CurrentValueSubject<VpnConnectionIntent, Never>
 
     let serverProvider: ServerProviderType
     let vpnProvider: VPNStatusProviderType
@@ -45,7 +45,7 @@ public final class VpnConnectionUseCase: VpnConnectionUseCaseType {
             vpnProvider.connect { error in
                 if let error = error {
                     log.error("VPN connect failed: \(error.localizedDescription)")
-                    self.connectionIntent.send(completion: .failure(error))
+                    self.connectionIntent.send(.none)
                     continuation.resume(throwing: error)
                 } else {
                     log.info("VPN connect call succeeded")
@@ -64,7 +64,7 @@ public final class VpnConnectionUseCase: VpnConnectionUseCaseType {
             vpnProvider.disconnect { error in
                 if let error = error {
                     log.error("VPN disconnect failed: \(error.localizedDescription)")
-                    self.connectionIntent.send(completion: .failure(error))
+                    self.connectionIntent.send(.none)
                     continuation.resume(throwing: error)
                 } else {
                     log.info("VPN disconnect call succeeded")
@@ -74,7 +74,7 @@ public final class VpnConnectionUseCase: VpnConnectionUseCaseType {
         }
     }
 
-    public func getConnectionIntent() -> AnyPublisher<VpnConnectionIntent, Error> {
+    public func getConnectionIntent() -> AnyPublisher<VpnConnectionIntent, Never> {
         return connectionIntent.eraseToAnyPublisher()
     }
 }

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Daemons/VPNDaemon.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Daemons/VPNDaemon.swift
@@ -119,12 +119,26 @@ final class VPNDaemon: Daemon, DatabaseAccess, ProvidersAccess {
         case .connecting, .reasserting:
 
             nextStatus = .connecting
+            // If a reconnect cycle was in progress, it has now successfully reached
+            // .connecting — clear the flag here instead of in the reconnect callback so
+            // that the intermediate .disconnecting → .disconnected status changes are
+            // suppressed (isReconnecting=true) and vpnStatus never briefly touches
+            // .disconnected between the two connecting states.
+            isReconnecting = false
+            // Reset the attempt counter each time we enter .connecting so that each
+            // new connection attempt starts fresh. This preserves the retry-indefinitely
+            // behaviour for unreachable servers: the fallback timer fires every 5s,
+            // marking one IP unavailable per tick, so the counter resets when the next
+            // .connecting status arrives and the cycle can continue without hitting max.
+            if numberOfAttempts > 0 {
+                numberOfAttempts = 0
+                updateUIWithAttemptNumber(0)
+            }
             Client.preferences.lastVPNConnectionAttempt = Date().timeIntervalSince1970
 
             if accessedDatabase.transient.vpnStatus == .disconnected,
                 self.lastKnownVpnStatus == .disconnected,
-                Client.preferences.shareServiceQualityData,
-                self.numberOfAttempts == 0
+                Client.preferences.shareServiceQualityData
             {
                 ServiceQualityManager.shared.connectionAttemptEvent()
             }
@@ -144,8 +158,16 @@ final class VPNDaemon: Daemon, DatabaseAccess, ProvidersAccess {
                         log.debug("NEVPNManager is still connecting. Reconnecting with a different server...")
                         self.updateUIWithAttemptNumber(self.numberOfAttempts)
                         self.isReconnecting = true
-                        Client.providers.vpnProvider.reconnect(after: 0, forceDisconnect: true) { _ in
-                            self.isReconnecting = false
+                        Client.providers.vpnProvider.reconnect(after: 0, forceDisconnect: true) { error in
+                            if error != nil {
+                                // Reconnect initiation failed — clear flag immediately so the
+                                // subsequent .disconnected status change can clean up normally.
+                                self.isReconnecting = false
+                            }
+                            // On success: leave isReconnecting=true. It will be cleared in
+                            // tryUpdateStatus when .connecting status arrives, ensuring that
+                            // the intermediate .disconnecting → .disconnected transitions do
+                            // not briefly expose vpnStatus = .disconnected to the rest of the app.
                         }
                     } else {
                         log.debug("Max number of VPN reconnections. Disconnecting...")

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Daemons/VPNDaemon.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Daemons/VPNDaemon.swift
@@ -142,11 +142,9 @@ final class VPNDaemon: Daemon, DatabaseAccess, ProvidersAccess {
                     if self.numberOfAttempts < Client.configuration.vpnConnectivityMaxAttempts || self.isReconnectingAfterConnectivityFailure {
                         self.updateUIWithAttemptNumber(self.numberOfAttempts)
                         self.isReconnecting = true
-                        Client.providers.vpnProvider.reconnect(
-                            after: 0,
-                            { _ in
-                                self.isReconnecting = false
-                            })
+                        Client.providers.vpnProvider.reconnect(after: 0, forceDisconnect: true) { _ in
+                            self.isReconnecting = false
+                        }
                     } else {
                         log.debug("MAX number of VPN reconnections. Disconnecting...")
                         Client.providers.vpnProvider.disconnect({ error in
@@ -232,9 +230,11 @@ final class VPNDaemon: Daemon, DatabaseAccess, ProvidersAccess {
                 }
             #endif
 
-            // IKEv2 connectivity check failure
+            // IKEv2 connectivity check failure.
+            // On tvOS, IKEv2 errors are reported under NEVPNConnectionErrorDomainPlugin
+            // rather than NEVPNConnectionErrorDomain, so check both when IKEv2 is active.
             if #available(iOS 16, *) {
-                if errorDomain == NEVPNConnectionErrorDomain {
+                if errorDomain == NEVPNConnectionErrorDomain || errorDomain == "NEVPNConnectionErrorDomainPlugin" {
                     connectivityCheckFailed = true
                 }
             }

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Daemons/VPNDaemon.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Daemons/VPNDaemon.swift
@@ -130,28 +130,30 @@ final class VPNDaemon: Daemon, DatabaseAccess, ProvidersAccess {
             }
 
             if fallbackTimer == nil {
+                log.debug("Setting up fallbackTimer...")
 
                 fallbackTimer = Timer.scheduledTimer(withTimeInterval: Client.configuration.vpnConnectivityRetryDelay, repeats: true) { [weak self] timer in
                     guard let self else { return }
+                    log.debug("Executing fallbackTimer...")
 
                     let address = try? Client.providers.serverProvider.targetServer.bestAddress()
                     address?.markServerAsUnavailable()
 
-                    log.debug("NEVPNManager is still connecting. Reconnecting with a different server...")
                     self.numberOfAttempts += 1
                     if self.numberOfAttempts < Client.configuration.vpnConnectivityMaxAttempts || self.isReconnectingAfterConnectivityFailure {
+                        log.debug("NEVPNManager is still connecting. Reconnecting with a different server...")
                         self.updateUIWithAttemptNumber(self.numberOfAttempts)
                         self.isReconnecting = true
                         Client.providers.vpnProvider.reconnect(after: 0, forceDisconnect: true) { _ in
                             self.isReconnecting = false
                         }
                     } else {
-                        log.debug("MAX number of VPN reconnections. Disconnecting...")
-                        Client.providers.vpnProvider.disconnect({ error in
+                        log.debug("Max number of VPN reconnections. Disconnecting...")
+                        Client.providers.vpnProvider.disconnect { error in
                             Macros.postNotification(.PIAVPNDidFail)
                             self.reset()
                             self.invalidateTimer()
-                        })
+                        }
                     }
                 }
 

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Extensions/NETunnelProviderSession+Async.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Extensions/NETunnelProviderSession+Async.swift
@@ -1,0 +1,38 @@
+//
+//  NETunnelProviderSession+Async.swift
+//  PIALibrary
+//
+//  Copyright © 2020 Private Internet Access, Inc.
+//
+//  This file is part of the Private Internet Access iOS Client.
+//
+//  The Private Internet Access iOS Client is free software: you can redistribute it and/or
+//  modify it under the terms of the GNU General Public License as published by the Free
+//  Software Foundation, either version 3 of the License, or (at your option) any later version.
+//
+//  The Private Internet Access iOS Client is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+//  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+//  details.
+//
+//  You should have received a copy of the GNU General Public License along with the Private
+//  Internet Access iOS Client.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+#if os(iOS)
+    import NetworkExtension
+
+    extension NETunnelProviderSession {
+        func sendProviderMessage(_ messageData: Data) async throws -> Data? {
+            try await withCheckedThrowingContinuation { continuation in
+                do {
+                    try sendProviderMessage(messageData) { data in
+                        continuation.resume(returning: data)
+                    }
+                } catch {
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+    }
+#endif

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/VPN/DefaultVPNProvider.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/VPN/DefaultVPNProvider.swift
@@ -144,43 +144,50 @@ public final class DefaultVPNProvider: VPNProvider, ConfigurationAccess, Databas
         }
 
         var previousProfile: VPNProfile?
-        if (newVPNType != activeProfile?.vpnType) {
+        if newVPNType != activeProfile?.vpnType {
             previousProfile = activeProfile
         }
 
         let forcedStatuses = DefaultVPNProvider.forcedStatuses.contains(accessedDatabase.transient.vpnStatus)
         let installBlock: SuccessLibraryCallback = { (error) in
             guard let configuration = self.vpnClientConfiguration(for: profile) else {
-                callback?(ClientError.vpnProfileUnavailable)
+                DispatchQueue.main.async { callback?(ClientError.vpnProfileUnavailable) }
                 return
             }
-            profile.save(withConfiguration: configuration, force: forcedStatuses) { (error) in
-                if let error = error {
-                    callback?(error)
-                    return
-                }
-                self.activeProfile = profile
+            Task { @MainActor in
+                do {
+                    try await profile.save(withConfiguration: configuration, force: forcedStatuses)
+                    self.activeProfile = profile
 
-                if let previousProfile = previousProfile,
-                    !((profile.vpnType == IPSecProfile.vpnType || profile.vpnType == IKEv2Profile.vpnType) && (previousProfile.vpnType == IPSecProfile.vpnType || previousProfile.vpnType == IKEv2Profile.vpnType))
-                {
-                    //only remove the profile if is not Ipsec or IKEv2, if are one of them, override instead
-                    previousProfile.remove({ _ in
+                    if let previousProfile = previousProfile,
+                        !((profile.vpnType == IPSecProfile.vpnType || profile.vpnType == IKEv2Profile.vpnType) && (previousProfile.vpnType == IPSecProfile.vpnType || previousProfile.vpnType == IKEv2Profile.vpnType))
+                    {
+                        //only remove the profile if is not Ipsec or IKEv2, if are one of them, override instead
+                        try? await previousProfile.remove()
                         Macros.postNotification(.PIAVPNDidInstall)
                         callback?(nil)
-                    })
-                } else {
-                    if previousProfile != nil {  // dont connect after install
-                        self.connect(nil)
+                    } else {
+                        if previousProfile != nil {  // dont connect after install
+                            self.connect(nil)
+                        }
+                        Macros.postNotification(.PIAVPNDidInstall)
+                        callback?(nil)
                     }
-                    Macros.postNotification(.PIAVPNDidInstall)
-                    callback?(nil)
+                } catch {
+                    callback?(error)
                 }
             }
         }
 
         if let previousProfile = previousProfile {
-            previousProfile.disconnect(installBlock)
+            Task {
+                do {
+                    try await previousProfile.disconnect()
+                    installBlock(nil)
+                } catch {
+                    installBlock(error)
+                }
+            }
         } else {
             if newVPNType != activeProfile?.vpnType || !forcedStatuses || forceInstall {
                 //only install if new and connected
@@ -196,8 +203,15 @@ public final class DefaultVPNProvider: VPNProvider, ConfigurationAccess, Databas
             callback?(ClientError.vpnProfileUnavailable)
             return
         }
-        activeProfile.disconnect(nil)
-        activeProfile.disable(callback)
+        Task { @MainActor in
+            try? await activeProfile.disconnect()
+            do {
+                try await activeProfile.disable()
+                callback?(nil)
+            } catch {
+                callback?(error)
+            }
+        }
     }
 
     public func uninstall(_ callback: SuccessLibraryCallback?) {
@@ -205,11 +219,18 @@ public final class DefaultVPNProvider: VPNProvider, ConfigurationAccess, Databas
             callback?(ClientError.vpnProfileUnavailable)
             return
         }
-        activeProfile.disconnect(nil)
-        activeProfile.remove { (error) in
-            self.activeProfile = nil
-            self.accessedDatabase.transient.vpnStatus = .disconnected
-            callback?(error)
+        Task { @MainActor in
+            try? await activeProfile.disconnect()
+            do {
+                try await activeProfile.remove()
+                self.activeProfile = nil
+                self.accessedDatabase.transient.vpnStatus = .disconnected
+                callback?(nil)
+            } catch {
+                self.activeProfile = nil
+                self.accessedDatabase.transient.vpnStatus = .disconnected
+                callback?(error)
+            }
         }
     }
 
@@ -221,8 +242,10 @@ public final class DefaultVPNProvider: VPNProvider, ConfigurationAccess, Databas
             guard let profile = accessedConfiguration.profile(forVPNType: vpnType) else {
                 continue
             }
-            profile.disconnect(nil)
-            profile.remove(nil)
+            Task {
+                try? await profile.disconnect()
+                try? await profile.remove()
+            }
         }
     }
 
@@ -241,7 +264,14 @@ public final class DefaultVPNProvider: VPNProvider, ConfigurationAccess, Databas
             callback?(ClientError.vpnClientConfigurationUnavailable)
             return
         }
-        activeProfile.connect(withConfiguration: configuration, callback)
+        Task { @MainActor in
+            do {
+                try await activeProfile.connect(withConfiguration: configuration)
+                callback?(nil)
+            } catch {
+                callback?(error)
+            }
+        }
     }
 
     public func disconnect(_ callback: SuccessLibraryCallback?) {
@@ -259,12 +289,18 @@ public final class DefaultVPNProvider: VPNProvider, ConfigurationAccess, Databas
             callback?(ClientError.vpnProfileUnavailable)
             return
         }
-        activeProfile.requestLog(withCustomConfiguration: configuration.customConfiguration) { (content, error) in
-            let log = self.accessedDatabase.transient.vpnLog + "\n\n" + (content ?? "Unknown Protocol Logs \(error.debugDescription)")
+        Task { @MainActor in
+            let content = try? await activeProfile.requestLog(withCustomConfiguration: configuration.customConfiguration)
+            let log = self.accessedDatabase.transient.vpnLog + "\n\n" + (content ?? "Unknown Protocol Logs")
             self.accessedDatabase.transient.vpnLog = log
-            activeProfile.disconnect(callback)
-        }
 
+            do {
+                try await activeProfile.disconnect()
+                callback?(nil)
+            } catch {
+                callback?(error)
+            }
+        }
     }
 
     public func updatePreferences(_ callback: SuccessLibraryCallback?) {
@@ -276,7 +312,14 @@ public final class DefaultVPNProvider: VPNProvider, ConfigurationAccess, Databas
             callback?(ClientError.vpnProfileUnavailable)
             return
         }
-        activeProfile.updatePreferences(callback)
+        Task { @MainActor in
+            do {
+                try await activeProfile.updatePreferences()
+                callback?(nil)
+            } catch {
+                callback?(error)
+            }
+        }
     }
 
     public func reconnect(after delay: Int?, forceDisconnect: Bool = false, _ callback: SuccessLibraryCallback?) {
@@ -292,29 +335,21 @@ public final class DefaultVPNProvider: VPNProvider, ConfigurationAccess, Databas
 
         let shouldDisconnectFirst = (activeProfile.vpnType != IKEv2Profile.vpnType || forceDisconnect)
 
-        if shouldDisconnectFirst {
-            activeProfile.disconnect { (error) in
-                if let _ = error {
-                    callback?(error)
-                    return
+        Task { @MainActor in
+            do {
+                if shouldDisconnectFirst {
+                    try await activeProfile.disconnect()
+                } else {
+                    try await activeProfile.updatePreferences()
                 }
                 guard let configuration = self.vpnClientConfiguration() else {
                     callback?(ClientError.vpnProfileUnavailable)
                     return
                 }
-                activeProfile.connect(withConfiguration: configuration, callback)
-            }
-        } else {
-            activeProfile.updatePreferences { (error) in
-                if let _ = error {
-                    callback?(error)
-                    return
-                }
-                guard let configuration = self.vpnClientConfiguration() else {
-                    callback?(ClientError.vpnProfileUnavailable)
-                    return
-                }
-                activeProfile.connect(withConfiguration: configuration, callback)
+                try await activeProfile.connect(withConfiguration: configuration)
+                callback?(nil)
+            } catch {
+                callback?(error)
             }
         }
     }
@@ -335,12 +370,13 @@ public final class DefaultVPNProvider: VPNProvider, ConfigurationAccess, Databas
             callback?(nil, ClientError.vpnProfileUnavailable)
             return
         }
-        activeProfile.requestDataUsage(withCustomConfiguration: configuration.customConfiguration) { (usage, error) in
-            guard let usage = usage else {
+        Task { @MainActor in
+            do {
+                let usage = try await activeProfile.requestDataUsage(withCustomConfiguration: configuration.customConfiguration)
+                callback?(usage, nil)
+            } catch {
                 callback?(nil, error)
-                return
             }
-            callback?(usage, nil)
         }
     }
 
@@ -358,8 +394,10 @@ public final class DefaultVPNProvider: VPNProvider, ConfigurationAccess, Databas
                 if let activeProfile {
                     if !((profile.vpnType == IPSecProfile.vpnType || profile.vpnType == IKEv2Profile.vpnType) && (activeProfile.vpnType == IPSecProfile.vpnType || activeProfile.vpnType == IKEv2Profile.vpnType)) {
                         //only remove the profile if is not Ipsec or IKEv2, if are one of them, override instead
-                        profile.disconnect(nil)
-                        profile.remove(nil)
+                        Task {
+                            try? await profile.disconnect()
+                            try? await profile.remove()
+                        }
                     }
                 }
                 continue

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/VPN/IKEv2Profile.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/VPN/IKEv2Profile.swift
@@ -78,17 +78,42 @@ public final class IKEv2Profile: NetworkExtensionProfile {
                 return
             }
 
+            let currentStatus = self.currentVPN.connection.status
+
             // If the tunnel is already active, stop it before starting the new one.
             // Calling startVPNTunnel() on a connected IKEv2 tunnel may silently retain
             // the existing connection rather than switching to the new server, resulting
             // in the app believing it is connected when it is not.
-            let currentStatus = self.currentVPN.connection.status
             if currentStatus == .connected || currentStatus == .connecting || currentStatus == .reasserting {
                 self.currentVPN.connection.stopVPNTunnel()
             }
 
+            if currentStatus == .disconnecting {
+                self.waitForDisconnectedThenStart(callback: callback)
+            } else {
+                do {
+                    try self.currentVPN.connection.startVPNTunnel()
+                    callback?(nil)
+                } catch let e {
+                    callback?(e)
+                }
+            }
+        }
+    }
+
+    private func waitForDisconnectedThenStart(callback: SuccessLibraryCallback?) {
+        var observer: NSObjectProtocol?
+        observer = NotificationCenter.default.addObserver(forName: .NEVPNStatusDidChange, object: currentVPN.connection, queue: .main) { [currentVPN] _ in
+            guard currentVPN.connection.status == .disconnected else {
+                return
+            }
+
+            if let observer {
+                NotificationCenter.default.removeObserver(observer)
+            }
+
             do {
-                try self.currentVPN.connection.startVPNTunnel()
+                try currentVPN.connection.startVPNTunnel()
                 callback?(nil)
             } catch let e {
                 callback?(e)

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/VPN/IKEv2Profile.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/VPN/IKEv2Profile.swift
@@ -59,116 +59,59 @@ public final class IKEv2Profile: NetworkExtensionProfile {
     }
 
     /// :nodoc:
-    public func save(withConfiguration configuration: VPNConfiguration, force: Bool, _ callback: SuccessLibraryCallback?) {
-
-        currentVPN.loadFromPreferences { (error) in
-            if let error = error {
-                callback?(error)
-                return
-            }
-            self.doSave(self.currentVPN, withConfiguration: configuration, force: force, callback)
-        }
+    public func save(withConfiguration configuration: VPNConfiguration, force: Bool) async throws {
+        try await currentVPN.loadFromPreferences()
+        try await doSave(currentVPN, withConfiguration: configuration, force: force)
     }
 
     /// :nodoc:
-    public func connect(withConfiguration configuration: VPNConfiguration, _ callback: SuccessLibraryCallback?) {
-        save(withConfiguration: configuration, force: true) { (error) in
-            if let error = error {
-                callback?(error)
-                return
-            }
+    public func connect(withConfiguration configuration: VPNConfiguration) async throws {
+        try await save(withConfiguration: configuration, force: true)
 
-            let currentStatus = self.currentVPN.connection.status
-
-            // If the tunnel is already active, stop it before starting the new one.
-            // Calling startVPNTunnel() on a connected IKEv2 tunnel may silently retain
-            // the existing connection rather than switching to the new server, resulting
-            // in the app believing it is connected when it is not.
-            if currentStatus == .connected || currentStatus == .connecting || currentStatus == .reasserting {
-                self.currentVPN.connection.stopVPNTunnel()
-            }
-
-            if currentStatus == .disconnecting {
-                self.waitForDisconnectedThenStart(callback: callback)
-            } else {
-                do {
-                    try self.currentVPN.connection.startVPNTunnel()
-                    callback?(nil)
-                } catch let e {
-                    callback?(e)
-                }
-            }
+        // If the tunnel is already active, stop it before starting the new one.
+        // Calling startVPNTunnel() on a connected IKEv2 tunnel may silently retain
+        // the existing connection rather than switching to the new server, resulting
+        // in the app believing it is connected when it is not.
+        let currentStatus = currentVPN.connection.status
+        if currentStatus == .connected || currentStatus == .connecting || currentStatus == .reasserting {
+            currentVPN.connection.stopVPNTunnel()
         }
-    }
-
-    private func waitForDisconnectedThenStart(callback: SuccessLibraryCallback?) {
-        var observer: NSObjectProtocol?
-        observer = NotificationCenter.default.addObserver(forName: .NEVPNStatusDidChange, object: currentVPN.connection, queue: .main) { [currentVPN] _ in
-            guard currentVPN.connection.status == .disconnected else {
-                return
-            }
-
-            if let observer {
-                NotificationCenter.default.removeObserver(observer)
-            }
-
-            do {
-                try currentVPN.connection.startVPNTunnel()
-                callback?(nil)
-            } catch let e {
-                callback?(e)
-            }
-        }
+        try currentVPN.connection.startVPNTunnel()
     }
 
     /// :nodoc:
-    public func disconnect(_ callback: SuccessLibraryCallback?) {
-        currentVPN.loadFromPreferences { (error) in
-            if let error = error {
-                callback?(error)
-                return
-            }
+    public func disconnect() async throws {
+        try await currentVPN.loadFromPreferences()
 
-            // prevent reconnection
-            self.currentVPN.isOnDemandEnabled = false
+        // prevent reconnection
+        currentVPN.isOnDemandEnabled = false
 
-            self.currentVPN.saveToPreferences { (error) in
-                if let error = error {
-                    self.currentVPN.connection.stopVPNTunnel()
-                    callback?(error)
-                    return
-                }
-                self.currentVPN.connection.stopVPNTunnel()
-                callback?(nil)
-            }
-        }
+        defer { currentVPN.connection.stopVPNTunnel() }
+        try await currentVPN.saveToPreferences()
     }
 
     /// :nodoc:
-    public func updatePreferences(_ callback: SuccessLibraryCallback?) {
+    public func updatePreferences() async throws {
         // For IKEv2 there is nothing to update here: all preference changes
         // (server address, on-demand rules, etc.) are applied by connect() via
         // save(force:true) → doSave(). A standalone loadFromPreferences →
         // saveToPreferences round-trip with no mutations races with any
         // concurrent connect() call and causes "configuration is stale" errors.
         log.debug("[IKEv2] updatePreferences() — skipped (no-op for IKEv2, changes applied by connect)")
-        callback?(nil)
     }
 
     /// :nodoc:
-    public func remove(_ callback: SuccessLibraryCallback?) {
-        currentVPN.loadFromPreferences { (error) in
-            self.currentVPN.removeFromPreferences(completionHandler: callback)
-        }
+    public func remove() async throws {
+        try await currentVPN.loadFromPreferences()
+        try await currentVPN.removeFromPreferences()
     }
 
     /// :nodoc:
-    public func disable(_ callback: SuccessLibraryCallback?) {
-        currentVPN.loadFromPreferences { (error) in
-            self.currentVPN.isEnabled = false
-            self.currentVPN.isOnDemandEnabled = false
-            self.currentVPN.saveToPreferences(completionHandler: callback)
-        }
+    public func disable() async throws {
+        try await currentVPN.loadFromPreferences()
+        currentVPN.isEnabled = false
+        currentVPN.isOnDemandEnabled = false
+        try await currentVPN.saveToPreferences()
     }
 
     /// :nodoc:
@@ -177,13 +120,13 @@ public final class IKEv2Profile: NetworkExtensionProfile {
     }
 
     /// :nodoc:
-    public func requestLog(withCustomConfiguration customConfiguration: VPNCustomConfiguration?, _ callback: ((String?, Error?) -> Void)?) {
-        callback?(self.currentVPN.description, nil)
+    public func requestLog(withCustomConfiguration customConfiguration: VPNCustomConfiguration?) async throws -> String {
+        currentVPN.description
     }
 
     /// :nodoc:
-    public func requestDataUsage(withCustomConfiguration customConfiguration: VPNCustomConfiguration?, _ callback: LibraryCallback<Usage>?) {
-        callback?(nil, ClientError.unsupported)
+    public func requestDataUsage(withCustomConfiguration customConfiguration: VPNCustomConfiguration?) async throws -> Usage {
+        throw ClientError.unsupported
     }
 
     // MARK: NetworkExtensionProfile

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/VPN/IKEv2Profile.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/VPN/IKEv2Profile.swift
@@ -77,6 +77,16 @@ public final class IKEv2Profile: NetworkExtensionProfile {
                 callback?(error)
                 return
             }
+
+            // If the tunnel is already active, stop it before starting the new one.
+            // Calling startVPNTunnel() on a connected IKEv2 tunnel may silently retain
+            // the existing connection rather than switching to the new server, resulting
+            // in the app believing it is connected when it is not.
+            let currentStatus = self.currentVPN.connection.status
+            if currentStatus == .connected || currentStatus == .connecting || currentStatus == .reasserting {
+                self.currentVPN.connection.stopVPNTunnel()
+            }
+
             do {
                 try self.currentVPN.connection.startVPNTunnel()
                 callback?(nil)
@@ -111,20 +121,13 @@ public final class IKEv2Profile: NetworkExtensionProfile {
 
     /// :nodoc:
     public func updatePreferences(_ callback: SuccessLibraryCallback?) {
-        currentVPN.loadFromPreferences { (error) in
-            if let error = error {
-                callback?(error)
-                return
-            }
-
-            self.currentVPN.saveToPreferences { (error) in
-                if let error = error {
-                    callback?(error)
-                    return
-                }
-                callback?(nil)
-            }
-        }
+        // For IKEv2 there is nothing to update here: all preference changes
+        // (server address, on-demand rules, etc.) are applied by connect() via
+        // save(force:true) → doSave(). A standalone loadFromPreferences →
+        // saveToPreferences round-trip with no mutations races with any
+        // concurrent connect() call and causes "configuration is stale" errors.
+        log.debug("[IKEv2] updatePreferences() — skipped (no-op for IKEv2, changes applied by connect)")
+        callback?(nil)
     }
 
     /// :nodoc:

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/VPN/IKEv2Profile.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/VPN/IKEv2Profile.swift
@@ -76,7 +76,20 @@ public final class IKEv2Profile: NetworkExtensionProfile {
         if currentStatus == .connected || currentStatus == .connecting || currentStatus == .reasserting {
             currentVPN.connection.stopVPNTunnel()
         }
+
+        if currentStatus == .disconnecting {
+            await waitForDisconnected()
+        }
         try currentVPN.connection.startVPNTunnel()
+    }
+
+    private func waitForDisconnected() async {
+        let connection = currentVPN.connection
+        for await _ in NotificationCenter.default.notifications(named: .NEVPNStatusDidChange, object: connection) {
+            if connection.status == .disconnected {
+                return
+            }
+        }
     }
 
     /// :nodoc:

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/VPN/NetworkExtensionProfile.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/VPN/NetworkExtensionProfile.swift
@@ -55,21 +55,22 @@ extension NetworkExtensionProfile {
      - Parameter vpn: The target `NEVPNManager` to which the generated protocol will be committed.
      - Parameter configuration: The `VPNConfiguration` to use for generating the `NEVPNProtocol` object.
      - Parameter force: If `true`, apply changes forcibly.
-     - Parameter callback: Returns `nil` on success.
      - Seealso: `NetworkExtensionProfile.generatedProtocol(...)`
      */
-    public func doSave(_ vpn: NEVPNManager, withConfiguration configuration: VPNConfiguration, force: Bool, _ callback: SuccessLibraryCallback?) {
+    public func doSave(_ vpn: NEVPNManager, withConfiguration configuration: VPNConfiguration, force: Bool) async throws {
         do {
             vpn.protocolConfiguration = try generatedProtocol(withConfiguration: configuration)
         } catch {
-            callback?(error)
-            return
+            throw error
         }
 
         let protocolConfiguration = vpn.protocolConfiguration!  // Safe to force unwrap
 
         vpn.localizedDescription = configuration.name
-        vpn.isOnDemandEnabled = Client.providers.vpnProvider.isVPNConnected || vpn.isEnabled ? configuration.isOnDemand : false  //if the VPN is disconnected, don't activate the onDemand property to don't autoconnect the VPN without user permission
+        vpn.isOnDemandEnabled =
+            Client.providers.vpnProvider.isVPNConnected || vpn.isEnabled
+            ? configuration.isOnDemand
+            : false  //if the VPN is disconnected, don't activate the onDemand property to don't autoconnect the VPN without user permission
 
         let trustedNetworks = Client.preferences.nmtTrustedNetworkRules
 
@@ -115,15 +116,8 @@ extension NetworkExtensionProfile {
         log.debug("Raw manager: \(vpn)")
 
         vpn.isEnabled = true
-        vpn.saveToPreferences { (error) in
-            if let error = error {
-                callback?(error)
-                return
-            }
-            vpn.loadFromPreferences { (error) in
-                callback?(nil)
-            }
-        }
+        try await vpn.saveToPreferences()
+        try await vpn.loadFromPreferences()
     }
 
     private func configureOnDemandOnWiFiNetworksFor(

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/VPN/PIATunnelProfile.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/VPN/PIATunnelProfile.swift
@@ -54,106 +54,52 @@
 
         /// :nodoc:
         public func prepare() {
-            find(completionHandler: nil)
+            Task { try? await find() }
         }
 
         /// :nodoc:
-        public func save(withConfiguration configuration: VPNConfiguration, force: Bool, _ callback: SuccessLibraryCallback?) {
-            find { (vpn, error) in
-                guard let vpn = vpn else {
-                    callback?(error)
-                    return
-                }
-                self.doSave(vpn, withConfiguration: configuration, force: force, callback)
-            }
+        public func save(withConfiguration configuration: VPNConfiguration, force: Bool) async throws {
+            let vpn = try await find()
+            try await doSave(vpn, withConfiguration: configuration, force: force)
         }
 
         /// :nodoc:
-        public func connect(withConfiguration configuration: VPNConfiguration, _ callback: SuccessLibraryCallback?) {
-            find { (vpn, error) in
-                guard let vpn = vpn else {
-                    callback?(error)
-                    return
-                }
-
-                self.doSave(vpn, withConfiguration: configuration, force: true) { (error) in
-                    if let _ = error {
-                        callback?(error)
-                        return
-                    }
-                    do {
-                        let session = vpn.connection as? NETunnelProviderSession
-                        try session?.startTunnel(options: nil)
-                        callback?(nil)
-                    } catch let e {
-                        callback?(e)
-                    }
-                }
-            }
+        public func connect(withConfiguration configuration: VPNConfiguration) async throws {
+            let vpn = try await find()
+            try await doSave(vpn, withConfiguration: configuration, force: true)
+            let session = vpn.connection as? NETunnelProviderSession
+            try session?.startTunnel(options: nil)
         }
 
         /// :nodoc:
-        public func disconnect(_ callback: SuccessLibraryCallback?) {
-            find { (vpn, error) in
-                guard let vpn = vpn else {
-                    callback?(error)
-                    return
-                }
+        public func disconnect() async throws {
+            let vpn = try await find()
 
-                // prevent reconnection
-                vpn.isOnDemandEnabled = false
+            // prevent reconnection
+            vpn.isOnDemandEnabled = false
 
-                vpn.saveToPreferences { (error) in
-                    if let error = error {
-                        vpn.connection.stopVPNTunnel()
-                        callback?(error)
-                        return
-                    }
-                    vpn.connection.stopVPNTunnel()
-                    callback?(nil)
-                }
-            }
+            defer { vpn.connection.stopVPNTunnel() }
+            try await vpn.saveToPreferences()
         }
 
         /// :nodoc:
-        public func updatePreferences(_ callback: SuccessLibraryCallback?) {
-            find { (vpn, error) in
-                guard let vpn = vpn else {
-                    callback?(error)
-                    return
-                }
-
-                vpn.saveToPreferences { (error) in
-                    if let error = error {
-                        callback?(error)
-                        return
-                    }
-                    callback?(nil)
-                }
-            }
+        public func updatePreferences() async throws {
+            let vpn = try await find()
+            try await vpn.saveToPreferences()
         }
 
         /// :nodoc:
-        public func disable(_ callback: SuccessLibraryCallback?) {
-            find { (vpn, error) in
-                guard let vpn = vpn else {
-                    return
-                }
-                vpn.isEnabled = false
-                vpn.isOnDemandEnabled = false
-                vpn.saveToPreferences(completionHandler: callback)
-            }
+        public func disable() async throws {
+            let vpn = try await find()
+            vpn.isEnabled = false
+            vpn.isOnDemandEnabled = false
+            try await vpn.saveToPreferences()
         }
 
         /// :nodoc:
-        public func remove(_ callback: SuccessLibraryCallback?) {
-            find { (vpn, error) in
-                guard let vpn = vpn else {
-                    callback?(nil)
-                    return
-                }
-                vpn.removeFromPreferences(completionHandler: callback)
-            }
+        public func remove() async throws {
+            let vpn = try await find()
+            try await vpn.removeFromPreferences()
         }
 
         /// :nodoc:
@@ -190,68 +136,33 @@
         }
 
         /// :nodoc:
-        public func requestLog(withCustomConfiguration customConfiguration: VPNCustomConfiguration?, _ callback: ((String?, Error?) -> Void)?) {
-            find { (vpn, error) in
-                guard let vpn = vpn else {
-                    callback?(nil, error)
-                    return
-                }
+        public func requestLog(withCustomConfiguration customConfiguration: VPNCustomConfiguration?) async throws -> String {
+            let vpn = try await find()
 
-                do {
-                    let session = vpn.connection as? NETunnelProviderSession
-                    try session?.sendProviderMessage(OpenVPNProvider.Message.requestLog.data) { (data) in
-                        guard let data = data, !data.isEmpty else {
-                            guard let providerConfiguration = customConfiguration as? OpenVPNProvider.Configuration else {
-                                callback?(nil, nil)
-                                return
-                            }
-                            guard let recentLog = self.lastLogSnapshot(withProviderConfiguration: providerConfiguration) else {
-                                callback?(nil, nil)
-                                return
-                            }
-                            callback?(recentLog, nil)
-                            return
-                        }
-                        let log = String(data: data, encoding: .utf8)
-                        callback?(log, nil)
-                    }
-                } catch let e {
-                    callback?(nil, e)
-                }
+            guard
+                let session = vpn.connection as? NETunnelProviderSession,
+                let data = try await session.sendProviderMessage(OpenVPNProvider.Message.requestLog.data),
+                !data.isEmpty
+            else {
+                return (customConfiguration as? OpenVPNProvider.Configuration).flatMap { lastLogSnapshot(withProviderConfiguration: $0) } ?? ""
             }
+
+            return String(data: data, encoding: .utf8) ?? ""
         }
 
         /// :nodoc:
-        public func requestDataUsage(withCustomConfiguration customConfiguration: VPNCustomConfiguration?, _ callback: ((Usage?, Error?) -> Void)?) {
-            find { (vpn, error) in
-                guard let vpn = vpn else {
-                    callback?(nil, error)
-                    return
-                }
+        public func requestDataUsage(withCustomConfiguration customConfiguration: VPNCustomConfiguration?) async throws -> Usage {
+            let vpn = try await find()
 
-                do {
-                    let session = vpn.connection as? NETunnelProviderSession
-                    try session?.sendProviderMessage(OpenVPNProvider.Message.dataCount.data) { (data) in
-                        guard let data = data, !data.isEmpty else {
-                            guard let _ = customConfiguration as? OpenVPNProvider.Configuration else {
-                                callback?(nil, nil)
-                                return
-                            }
-                            callback?(nil, ClientError.vpnProfileUnavailable)
-                            return
-                        }
-
-                        let downloaded = data.getInt64(start: 0)
-                        let uploaded = data.getInt64(start: 8)
-                        let usage = Usage(uploaded: uploaded, downloaded: downloaded)
-                        callback?(
-                            usage,
-                            nil)
-                    }
-                } catch let e {
-                    callback?(nil, e)
-                }
+            guard
+                let session = vpn.connection as? NETunnelProviderSession,
+                let data = try await session.sendProviderMessage(OpenVPNProvider.Message.dataCount.data),
+                !data.isEmpty
+            else {
+                throw ClientError.vpnProfileUnavailable
             }
+
+            return Usage(uploaded: data.getInt64(start: 8), downloaded: data.getInt64(start: 0))
         }
 
         // MARK: NetworkExtensionProfile
@@ -316,33 +227,27 @@
 
         // MARK: Helpers
 
-        private func find(completionHandler: LibraryCallback<NETunnelProviderManager>?) {
-            PIATunnelProfile.find(withBundleIdentifier: bundleIdentifier) { (vpn, error) in
-                self.native = vpn
-                completionHandler?(vpn, error)
-            }
+        @discardableResult
+        private func find() async throws -> NETunnelProviderManager {
+            let vpn = try await PIATunnelProfile.findWithBundleIdentifier(bundleIdentifier)
+            self.native = vpn
+            return vpn
         }
 
-        private static func find(withBundleIdentifier identifier: String?, completionHandler: LibraryCallback<NETunnelProviderManager>?) {
-            NETunnelProviderManager.loadAllFromPreferences { (managers, error) in
-                guard let managers = managers else {
-                    completionHandler?(nil, error)
-                    return
+        private static func findWithBundleIdentifier(_ identifier: String?) async throws -> NETunnelProviderManager {
+            let managers = try await NETunnelProviderManager.loadAllFromPreferences()
+            var foundVPN: NETunnelProviderManager?
+            for m in managers {
+                guard let tunnelProtocol = m.protocolConfiguration as? NETunnelProviderProtocol else {
+                    continue
                 }
-                var foundVPN: NETunnelProviderManager?
-                for m in managers {
-                    guard let tunnelProtocol = m.protocolConfiguration as? NETunnelProviderProtocol else {
-                        continue
-                    }
-                    guard ((identifier == nil) || (tunnelProtocol.providerBundleIdentifier == identifier)) else {
-                        continue
-                    }
-                    foundVPN = m
-                    break
+                guard (identifier == nil) || (tunnelProtocol.providerBundleIdentifier == identifier) else {
+                    continue
                 }
-                let vpn = foundVPN ?? NETunnelProviderManager()
-                completionHandler?(vpn, nil)
+                foundVPN = m
+                break
             }
+            return foundVPN ?? NETunnelProviderManager()
         }
 
         private func lastLogSnapshot(withProviderConfiguration providerConfiguration: OpenVPNProvider.Configuration) -> String? {

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/VPN/PIAWGTunnelProfile.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/VPN/PIAWGTunnelProfile.swift
@@ -42,57 +42,32 @@ import Foundation
 
         }
 
-        public func requestLog(withCustomConfiguration customConfiguration: VPNCustomConfiguration?, _ callback: LibraryCallback<String>?) {
-            find { (vpn, error) in
-                guard let vpn = vpn else {
-                    callback?(nil, error)
-                    return
-                }
+        public func requestLog(withCustomConfiguration customConfiguration: VPNCustomConfiguration?) async throws -> String {
+            let vpn = try await find()
 
-                do {
-                    let session = vpn.connection as? NETunnelProviderSession
-                    try session?.sendProviderMessage(WGPacketTunnelProvider.Message.requestLog.data) { (data) in
-                        guard let data = data, !data.isEmpty else {
-                            callback?(nil, nil)
-                            return
-                        }
-                        let log = String(data: data, encoding: .utf8)
-                        callback?(log, nil)
-                    }
-                } catch let e {
-                    callback?(nil, e)
-                }
+            guard
+                let session = vpn.connection as? NETunnelProviderSession,
+                let data = try await session.sendProviderMessage(WGPacketTunnelProvider.Message.requestLog.data),
+                !data.isEmpty
+            else {
+                return ""
             }
 
+            return String(data: data, encoding: .utf8) ?? ""
         }
 
-        public func requestDataUsage(withCustomConfiguration customConfiguration: VPNCustomConfiguration?, _ callback: LibraryCallback<Usage>?) {
-            find { (vpn, error) in
-                guard let vpn = vpn else {
-                    callback?(nil, error)
-                    return
-                }
+        public func requestDataUsage(withCustomConfiguration customConfiguration: VPNCustomConfiguration?) async throws -> Usage {
+            let vpn = try await find()
 
-                do {
-                    let session = vpn.connection as? NETunnelProviderSession
-                    try session?.sendProviderMessage(WGPacketTunnelProvider.Message.dataCount.data) { (data) in
-                        guard let data = data, !data.isEmpty else {
-                            callback?(nil, ClientError.vpnProfileUnavailable)
-                            return
-                        }
-
-                        let downloaded = data.getInt64(start: 0)
-                        let uploaded = data.getInt64(start: 8)
-                        let usage = Usage(uploaded: uploaded, downloaded: downloaded)
-                        callback?(
-                            usage,
-                            nil)
-                    }
-                } catch let e {
-                    callback?(nil, e)
-                }
+            guard
+                let session = vpn.connection as? NETunnelProviderSession,
+                let data = try await session.sendProviderMessage(WGPacketTunnelProvider.Message.dataCount.data),
+                !data.isEmpty
+            else {
+                throw ClientError.vpnProfileUnavailable
             }
 
+            return Usage(uploaded: data.getInt64(start: 8), downloaded: data.getInt64(start: 0))
         }
 
         private let bundleIdentifier: String
@@ -123,106 +98,52 @@ import Foundation
 
         /// :nodoc:
         public func prepare() {
-            find(completionHandler: nil)
+            Task { try? await find() }
         }
 
         /// :nodoc:
-        public func save(withConfiguration configuration: VPNConfiguration, force: Bool, _ callback: SuccessLibraryCallback?) {
-            find { (vpn, error) in
-                guard let vpn = vpn else {
-                    callback?(error)
-                    return
-                }
-                self.doSave(vpn, withConfiguration: configuration, force: force, callback)
-            }
+        public func save(withConfiguration configuration: VPNConfiguration, force: Bool) async throws {
+            let vpn = try await find()
+            try await doSave(vpn, withConfiguration: configuration, force: force)
         }
 
         /// :nodoc:
-        public func connect(withConfiguration configuration: VPNConfiguration, _ callback: SuccessLibraryCallback?) {
-            find { (vpn, error) in
-                guard let vpn = vpn else {
-                    callback?(error)
-                    return
-                }
-
-                self.doSave(vpn, withConfiguration: configuration, force: true) { (error) in
-                    if let _ = error {
-                        callback?(error)
-                        return
-                    }
-                    do {
-                        let session = vpn.connection as? NETunnelProviderSession
-                        try session?.startTunnel(options: nil)
-                        callback?(nil)
-                    } catch let e {
-                        callback?(e)
-                    }
-                }
-            }
+        public func connect(withConfiguration configuration: VPNConfiguration) async throws {
+            let vpn = try await find()
+            try await doSave(vpn, withConfiguration: configuration, force: true)
+            let session = vpn.connection as? NETunnelProviderSession
+            try session?.startTunnel(options: nil)
         }
 
         /// :nodoc:
-        public func disconnect(_ callback: SuccessLibraryCallback?) {
-            find { (vpn, error) in
-                guard let vpn = vpn else {
-                    callback?(error)
-                    return
-                }
+        public func disconnect() async throws {
+            let vpn = try await find()
 
-                // prevent reconnection
-                vpn.isOnDemandEnabled = false
+            // prevent reconnection
+            vpn.isOnDemandEnabled = false
 
-                vpn.saveToPreferences { (error) in
-                    if let error = error {
-                        vpn.connection.stopVPNTunnel()
-                        callback?(error)
-                        return
-                    }
-                    vpn.connection.stopVPNTunnel()
-                    callback?(nil)
-                }
-            }
+            defer { vpn.connection.stopVPNTunnel() }
+            try await vpn.saveToPreferences()
         }
 
         /// :nodoc:
-        public func updatePreferences(_ callback: SuccessLibraryCallback?) {
-            find { (vpn, error) in
-                guard let vpn = vpn else {
-                    callback?(error)
-                    return
-                }
-
-                vpn.saveToPreferences { (error) in
-                    if let error = error {
-                        callback?(error)
-                        return
-                    }
-                    callback?(nil)
-                }
-            }
+        public func updatePreferences() async throws {
+            let vpn = try await find()
+            try await vpn.saveToPreferences()
         }
 
         /// :nodoc:
-        public func disable(_ callback: SuccessLibraryCallback?) {
-            find { (vpn, error) in
-                guard let vpn = vpn else {
-                    return
-                }
-                vpn.isEnabled = false
-                vpn.isOnDemandEnabled = false
-                vpn.saveToPreferences(completionHandler: callback)
-            }
+        public func disable() async throws {
+            let vpn = try await find()
+            vpn.isEnabled = false
+            vpn.isOnDemandEnabled = false
+            try await vpn.saveToPreferences()
         }
 
         /// :nodoc:
-        public func remove(_ callback: SuccessLibraryCallback?) {
-            find { (vpn, error) in
-                guard let vpn = vpn else {
-                    callback?(nil)
-                    return
-                }
-                vpn.removeFromPreferences(completionHandler: callback)
-            }
+        public func remove() async throws {
+            let vpn = try await find()
+            try await vpn.removeFromPreferences()
         }
 
         // MARK: NetworkExtensionProfile
@@ -272,34 +193,29 @@ import Foundation
 
         // MARK: Helpers
 
-        private func find(completionHandler: LibraryCallback<NETunnelProviderManager>?) {
-            PIAWGTunnelProfile.find(withBundleIdentifier: bundleIdentifier) { (vpn, error) in
-                self.native = vpn
-                completionHandler?(vpn, error)
-            }
+        @discardableResult
+        private func find() async throws -> NETunnelProviderManager {
+            let vpn = try await PIAWGTunnelProfile.findWithBundleIdentifier(bundleIdentifier)
+            self.native = vpn
+            return vpn
         }
 
-        private static func find(withBundleIdentifier identifier: String?, completionHandler: LibraryCallback<NETunnelProviderManager>?) {
-            NETunnelProviderManager.loadAllFromPreferences { (managers, error) in
-                guard let managers = managers else {
-                    completionHandler?(nil, error)
-                    return
+        private static func findWithBundleIdentifier(_ identifier: String?) async throws -> NETunnelProviderManager {
+            let managers = try await NETunnelProviderManager.loadAllFromPreferences()
+            var foundVPN: NETunnelProviderManager?
+            for m in managers {
+                guard let tunnelProtocol = m.protocolConfiguration as? NETunnelProviderProtocol else {
+                    continue
                 }
-                var foundVPN: NETunnelProviderManager?
-                for m in managers {
-                    guard let tunnelProtocol = m.protocolConfiguration as? NETunnelProviderProtocol else {
-                        continue
-                    }
-                    guard ((identifier == nil) || (tunnelProtocol.providerBundleIdentifier == identifier)) else {
-                        continue
-                    }
-                    foundVPN = m
-                    break
+                guard (identifier == nil) || (tunnelProtocol.providerBundleIdentifier == identifier) else {
+                    continue
                 }
-                let vpn = foundVPN ?? NETunnelProviderManager()
-                completionHandler?(vpn, nil)
+                foundVPN = m
+                break
             }
+            return foundVPN ?? NETunnelProviderManager()
         }
 
     }
+
 #endif

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/VPN/VPNAction.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/VPN/VPNAction.swift
@@ -62,6 +62,16 @@ final class VPNActionReinstall: VPNAction, ProvidersAccess {
 
     func execute(_ callback: SuccessLibraryCallback?) {
         let vpn = accessedProviders.vpnProvider
+
+        // For IKEv2, connect() always follows a server/preference change and applies all
+        // settings via save(force:true) → doSave → saveToPreferences. Running install()
+        // or updatePreferences() concurrently causes "configuration is stale" races on
+        // NEVPNManager.shared(). Both branches are no-ops for IKEv2.
+        guard vpn.currentVPNType != IKEv2Profile.vpnType else {
+            callback?(nil)
+            return
+        }
+
         let connected = accessedProviders.vpnProvider.isVPNConnected
         if connected {
             vpn.install(

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/VPN/VPNProfile.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/VPN/VPNProfile.swift
@@ -47,46 +47,36 @@ public protocol VPNProfile: AnyObject {
 
      - Parameter configuration: The `VPNConfiguration` to commit.
      - Parameter force: If `true`, it will enforce the save operation.
-     - Parameter callback: Returns `nil` on success.
      */
-    func save(withConfiguration configuration: VPNConfiguration, force: Bool, _ callback: SuccessLibraryCallback?)
+    func save(withConfiguration configuration: VPNConfiguration, force: Bool) async throws
 
     /**
      Connects the VPN via this profile with a specified configuration, which is saved right before the connection attempt.
 
      - Parameter configuration: The `VPNConfiguration` to commit.
-     - Parameter callback: Returns `nil` on success.
      - Seealso: `VPNProfile.save(...)`
      */
-    func connect(withConfiguration configuration: VPNConfiguration, _ callback: SuccessLibraryCallback?)
+    func connect(withConfiguration configuration: VPNConfiguration) async throws
 
     /**
      Disconnects from the VPN.
-
-     - Parameter callback: Returns `nil` on success.
      */
-    func disconnect(_ callback: SuccessLibraryCallback?)
+    func disconnect() async throws
 
     /**
      Update preferences from the VPN.
-
-     - Parameter callback: Returns `nil` on success.
      */
-    func updatePreferences(_ callback: SuccessLibraryCallback?)
+    func updatePreferences() async throws
 
     /**
      Removes the profile from the device.
-
-     - Parameter callback: Returns `nil` on success.
      */
-    func remove(_ callback: SuccessLibraryCallback?)
+    func remove() async throws
 
     /**
      Disables the profile.
-
-     - Parameter callback: Returns `nil` on success.
      */
-    func disable(_ callback: SuccessLibraryCallback?)
+    func disable() async throws
 
     /**
      Returns a concrete `VPNCustomConfiguration` from a map of raw parameters.
@@ -100,17 +90,17 @@ public protocol VPNProfile: AnyObject {
      Requests a log from this profile.
 
      - Parameter customConfiguration: The optional `VPNCustomConfiguration` required to access the debug log.
-     - Parameter callback: Returns `ClientError.unsupported` if the profile doesn't support logging.
+     - Returns: The log string.
      */
-    func requestLog(withCustomConfiguration customConfiguration: VPNCustomConfiguration?, _ callback: LibraryCallback<String>?)
+    func requestLog(withCustomConfiguration customConfiguration: VPNCustomConfiguration?) async throws -> String
 
     /**
      Requests the data usage from this profile.
 
-     - Parameter customConfiguration: The optional `VPNCustomConfiguration` required to access the debug log.
-     - Parameter callback: Returns `ClientError.unsupported` if the profile doesn't support logging.
+     - Parameter customConfiguration: The optional `VPNCustomConfiguration` required to access the data usage.
+     - Returns: The `Usage` value.
      */
-    func requestDataUsage(withCustomConfiguration customConfiguration: VPNCustomConfiguration?, _ callback: LibraryCallback<Usage>?)
+    func requestDataUsage(withCustomConfiguration customConfiguration: VPNCustomConfiguration?) async throws -> Usage
 
 }
 

--- a/PIA VPN-tvOS/Dashboard/Presentation/PIAConnectionButtonViewModel.swift
+++ b/PIA VPN-tvOS/Dashboard/Presentation/PIAConnectionButtonViewModel.swift
@@ -91,6 +91,7 @@ extension PIAConnectionButtonViewModel {
                 try await vpnConnectionUseCase.connect()
             } catch {
                 DispatchQueue.main.async {
+                    self.state = .error(error)
                     self.isShowingErrorAlert = true
                 }
             }

--- a/PIA VPN-tvOS/Shared/StateMonitors/ConnectionStateMonitor.swift
+++ b/PIA VPN-tvOS/Shared/StateMonitors/ConnectionStateMonitor.swift
@@ -12,6 +12,8 @@ import PIADashboard
 import PIALibrary
 import PIALocalizations
 
+private let log = PIALogger.logger(for: ConnectionStateMonitor.self)
+
 enum ConnectionState: Equatable {
     case unkown
     case disconnected
@@ -81,39 +83,34 @@ final class ConnectionStateMonitor: ConnectionStateMonitorType {
     }
 
     func callAsFunction() {
-        cancellable = vpnStatusMonitor.getStatus()
-            .setFailureType(to: Error.self)
-            .combineLatest(vpnConnectionUseCase.getConnectionIntent()) { vpnStatus, connectionIntent in
-                return (status: vpnStatus, intent: connectionIntent)
-            }
-            .receive(on: RunLoop.main)
-            .sink(
-                receiveCompletion: { completion in
-                    switch completion {
-                    case .finished:
-                        break
-                    case .failure(let failure):
-                        self.connectionState = .error(failure)
-                    }
-                },
-                receiveValue: { result in
-                    self.calculateState(for: result.intent, vpnStatus: result.status)
-
-                })
+        cancellable = Publishers.CombineLatest(
+            vpnStatusMonitor.getStatus(),
+            vpnConnectionUseCase.getConnectionIntent()
+        )
+        .receive(on: RunLoop.main)
+        .sink { [weak self] vpnStatus, connectionIntent in
+            self?.calculateState(for: connectionIntent, vpnStatus: vpnStatus)
+        }
     }
 
     private func calculateState(for connectionIntent: VpnConnectionIntent, vpnStatus: VPNStatus) {
+        let previousState = connectionState
+
         switch (connectionIntent, vpnStatus) {
+        case (.disconnect, _):
+            self.connectionState = .disconnecting
         case (_, .connected):
             self.connectionState = .connected
         case (.connect, _):
             self.connectionState = .connecting
         case (_, .disconnected):
             self.connectionState = .disconnected
-        case (.disconnect, _):
-            self.connectionState = .disconnecting
         default:
             self.connectionState = vpnStatus.toConnectionState()
+        }
+
+        if previousState != connectionState {
+            log.debug("ConnectionState: \(previousState) → \(connectionState) [intent: \(connectionIntent), vpnStatus: \(vpnStatus)]")
         }
     }
 

--- a/PIA VPN-tvOSTests/Common/ConnectionStateMonitorTests.swift
+++ b/PIA VPN-tvOSTests/Common/ConnectionStateMonitorTests.swift
@@ -137,24 +137,5 @@ class ConnectionStateMonitorTests: XCTestCase {
 
     }
 
-    func test_connectionStateWhen_errorInConnectionIntent() {
-        fixture.vpnStatusMonitorMock.status.send(.connecting)
-        instantiateSut()
-        let connectionError: Error = NSError(domain: "test.connection_error", code: 1) as Error
-        let connectionStateExp = expectation(description: "Wait for expected conn state")
-        fulfillOnConnectionState(.error(connectionError), expectation: connectionStateExp)
-
-        // AND GIVEN that the vpn status is connected
-        fixture.vpnStatusMonitorMock.status.send(.connected)
-
-        // AND GIVEN that the conection intent stops with an error
-        fixture.vpnConnectionUseCaseMock.getConnectionIntentResult.send(completion: .failure(connectionError))
-
-        wait(for: [connectionStateExp], timeout: 3)
-
-        // THEN the connection state becomes 'error'
-        XCTAssertEqual(capturedConnectionStates.last!, .error(connectionError))
-
-    }
 
 }

--- a/PIA VPN-tvOSTests/Common/ConnectionStateMonitorTests.swift
+++ b/PIA VPN-tvOSTests/Common/ConnectionStateMonitorTests.swift
@@ -123,7 +123,7 @@ class ConnectionStateMonitorTests: XCTestCase {
         fixture.vpnStatusMonitorMock.status.send(.connecting)
         instantiateSut()
         let connectionStateExp = expectation(description: "Wait for expected conn state")
-        fulfillOnConnectionState(.connected, expectation: connectionStateExp)
+        fulfillOnConnectionState(.disconnecting, expectation: connectionStateExp)
 
         // GIVEN that the conection intent is 'disconnect'
         fixture.vpnConnectionUseCaseMock.getConnectionIntentResult.send(.disconnect)
@@ -132,10 +132,9 @@ class ConnectionStateMonitorTests: XCTestCase {
         fixture.vpnStatusMonitorMock.status.send(.connected)
 
         wait(for: [connectionStateExp], timeout: 3)
-        // THEN the connection state is 'connected'
-        XCTAssertEqual(capturedConnectionStates.last!, .connected)
+        // THEN the connection state is 'disconnecting' (disconnect intent takes priority over connected status)
+        XCTAssertEqual(capturedConnectionStates.last!, .disconnecting)
 
     }
-
 
 }

--- a/PIA VPN-tvOSTests/Common/Mocks/VpnConnectionUseCaseMock.swift
+++ b/PIA VPN-tvOSTests/Common/Mocks/VpnConnectionUseCaseMock.swift
@@ -16,8 +16,8 @@ class VpnConnectionUseCaseMock: VpnConnectionUseCaseType {
 
     var getConnectionIntentCalled = false
     var getConnectionIntentCalledAttempt = 0
-    var getConnectionIntentResult = CurrentValueSubject<VpnConnectionIntent, Error>(VpnConnectionIntent.none)
-    func getConnectionIntent() -> AnyPublisher<VpnConnectionIntent, Error> {
+    var getConnectionIntentResult = CurrentValueSubject<VpnConnectionIntent, Never>(VpnConnectionIntent.none)
+    func getConnectionIntent() -> AnyPublisher<VpnConnectionIntent, Never> {
         return getConnectionIntentResult.eraseToAnyPublisher()
     }
 

--- a/PIA VPN-tvOSTests/Common/VpnConnectionUseCaseTests.swift
+++ b/PIA VPN-tvOSTests/Common/VpnConnectionUseCaseTests.swift
@@ -102,22 +102,11 @@ class VpnConnectionUseCaseTests: XCTestCase {
         // The initial state of the connection intent is 'none'
         XCTAssertEqual(sut.connectionIntent.value, .none)
 
-        var connectionIntentFinishedError: Error?
-        sut.getConnectionIntent()
-            .sink { completion in
-                switch completion {
-                case .failure(let error):
-                    connectionIntentFinishedError = error
-                default:
-                    break
-                }
-            } receiveValue: { newValue in
-            }.store(in: &subscriptions)
-
         // WHEN trying to connect
         try? await sut.connect()
-        // THEN an error is thown
-        XCTAssertNotNil(connectionIntentFinishedError)
+
+        // THEN the connection intent is reset back to 'none' (publisher never fails, error is thrown instead)
+        XCTAssertEqual(sut.connectionIntent.value, .none)
     }
 
     func test_disconnect() async throws {
@@ -159,22 +148,11 @@ class VpnConnectionUseCaseTests: XCTestCase {
         // The initial state of the connection intent is 'none'
         XCTAssertEqual(sut.connectionIntent.value, .none)
 
-        var disconnectionIntentFinishedError: Error?
-        sut.getConnectionIntent()
-            .sink { completion in
-                switch completion {
-                case .failure(let error):
-                    disconnectionIntentFinishedError = error
-                default:
-                    break
-                }
-            } receiveValue: { newValue in
-            }.store(in: &subscriptions)
-
         // WHEN trying to disconnect
         try? await sut.disconnect()
-        // THEN an error is thown
-        XCTAssertNotNil(disconnectionIntentFinishedError)
+
+        // THEN the connection intent is reset back to 'none' (publisher never fails, error is thrown instead)
+        XCTAssertEqual(sut.connectionIntent.value, .none)
     }
 
 }


### PR DESCRIPTION
## Summary

- Migrates all `VPNProfile` protocol methods (`save`, `connect`, `disconnect`, `remove`, `disable`, `updatePreferences`, `requestLog`, `requestDataUsage`) from callback-based (`SuccessLibraryCallback`) to `async throws`
- Adds `NETunnelProviderSession+Async.swift` extension to wrap `NETunnelProviderSession` IPC calls in async/await
- Updates `DefaultVPNProvider` to call the new async profile methods