### PR TITLE
KM-15679 Fix crash when using Quick Actions when app is already running

### DIFF
--- a/PIA VPN/UI/Dashboard/DashboardViewController.swift
+++ b/PIA VPN/UI/Dashboard/DashboardViewController.swift
@@ -232,7 +232,7 @@ final class DashboardViewController: AutolayoutViewController {
         nc.addObserver(self, selector: #selector(handleDidConnectToRFC1918CompliantWifi(_:)), name: NSNotification.Name.DeviceDidConnectToRFC1918CompliantWifi, object: nil)
         nc.addObserver(self, selector: #selector(checkConnectToRFC1918VulnerableWifi(_:)), name: NSNotification.Name.DeviceDidConnectToRFC1918VulnerableWifi, object: nil)
         nc.addObserver(self, selector: #selector(presentForceUpdate), name: NSNotification.Name.__AppDidFetchForceUpdateFeatureFlag, object: nil)
-        nc.addObserver(self, selector: #selector(dismissModalViewController), name: .PIADashboardShouldDismissModal, object: nil)
+        nc.addObserver(self, selector: #selector(handleDismissModal), name: .PIADashboardShouldDismissModal, object: nil)
     }
 
     private func removeObservers() {
@@ -808,7 +808,11 @@ final class DashboardViewController: AutolayoutViewController {
         #endif
     }
 
-    @objc private func dismissModalViewController(completion: (() -> Void)? = nil) {
+    @objc private func handleDismissModal() {
+        dismissModalViewController()
+    }
+
+    private func dismissModalViewController(completion: (() -> Void)? = nil) {
         if presentedViewController != nil {
             dismiss(animated: false, completion: completion)
         } else {


### PR DESCRIPTION
## Summary

- Fixes a crash (`EXC_BAD_ACCESS` at `0x8`) triggered when the user taps a **Connect** or **Disconnect** Home Screen Quick Action while app is running
- Root cause: `dismissModalViewController(completion:)` was registered directly as a `NSNotificationCenter` observer selector; the notification object was passed as the `completion` block parameter, causing `_Block_copy` to crash on an invalid memory address