### PR TITLE
KM-15685 Fix crash in MessagesTile and remove dead survey code

### DIFF
--- a/LocalPackages/PIALibrary/Sources/PIALibrary/AppConstants.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/AppConstants.swift
@@ -114,10 +114,6 @@ public struct AppConstants {
         public static let url = "piavpn:loginqr?token="
     }
 
-    public struct Survey {
-        public static let formURL = URL(string: "https://privateinternetaccess.typeform.com/to/WTFcN77r")!
-    }
-
     public struct HotspotHelper {
         public static let queueLabel = "com.privateinternetaccess.hotspothelper"
     }

--- a/LocalPackages/PIALocalizations/Sources/PIALocalizations/Generated/L10n.swift
+++ b/LocalPackages/PIALocalizations/Sources/PIALocalizations/Generated/L10n.swift
@@ -76,13 +76,6 @@ public enum L10n {
         public static let message = L10n.tr("Localizable", "account.subscriptions.short.message", fallback: "Manage subscription")
       }
     }
-    public enum Survey {
-      /// Want to help make PIA better? Let us know how we can improve!
-      /// Take The Survey
-      public static let message = L10n.tr("Localizable", "account.survey.message", fallback: "Want to help make PIA better? Let us know how we can improve!\nTake The Survey")
-      /// Take The Survey
-      public static let messageLink = L10n.tr("Localizable", "account.survey.messageLink", fallback: "Take The Survey")
-    }
     public enum Username {
       /// Username
       public static let caption = L10n.tr("Localizable", "account.username.caption", fallback: "Username")

--- a/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/ar.lproj/Localizable.strings
+++ b/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/ar.lproj/Localizable.strings
@@ -99,8 +99,6 @@
 "account.subscriptions.trial" = "خطة تجريبية";
 "account.unauthorized" = "حدث خطأ. يرجى محاولة تسجيل الدخول مرة أخرى";
 "account.delete" = "حذف الحساب";
-"account.survey.message" = "هل ترغب في المساهمة لجعل تطبيق PIA أفضل؟ شاركنا بمقترحاتك في الاستطلاع!\n";
-"account.survey.messageLink" = "املأ الاستطلاع";
 
 // SETTINGS
 

--- a/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/da.lproj/Localizable.strings
+++ b/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/da.lproj/Localizable.strings
@@ -99,8 +99,6 @@
 "account.subscriptions.trial" = "Prøveabonnement";
 "account.unauthorized" = "Noget gik galt. Prøv at logge på igen.";
 "account.delete" = "Slet konto";
-"account.survey.message" = "Vil du hjælpe med at gøre PIA bedre? Fortæl os, hvordan vi kan forbedre platformen!\nTag undersøgelsen";
-"account.survey.messageLink" = "Tag undersøgelsen";
 
 // SETTINGS
 

--- a/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/de.lproj/Localizable.strings
+++ b/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/de.lproj/Localizable.strings
@@ -99,8 +99,6 @@
 "account.subscriptions.trial" = "Testversion";
 "account.unauthorized" = "Etwas ging schief. Bitte versuchen, erneut anzumelden";
 "account.delete" = "Konto löschen";
-"account.survey.message" = "Willst du helfen, PIA besser zu machen? Lass uns wissen, wie wir uns verbessern können!\nNimm an der Umfrage teil";
-"account.survey.messageLink" = "An der Umfrage teilnehmen";
 
 // SETTINGS
 

--- a/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/en.lproj/Localizable.strings
+++ b/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/en.lproj/Localizable.strings
@@ -99,8 +99,6 @@
 "account.subscriptions.trial" = "Trial plan";
 "account.unauthorized" = "Something went wrong. Please try logging in again";
 "account.delete" = "Delete Account";
-"account.survey.message" = "Want to help make PIA better? Let us know how we can improve!\nTake The Survey";
-"account.survey.messageLink" = "Take The Survey";
 
 // SETTINGS
 

--- a/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/es-MX.lproj/Localizable.strings
+++ b/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/es-MX.lproj/Localizable.strings
@@ -99,8 +99,6 @@
 "account.subscriptions.trial" = "Plan de prueba";
 "account.unauthorized" = "Se ha producido un error. Intenta volver a iniciar sesión.";
 "account.delete" = "Eliminar cuenta";
-"account.survey.message" = "¿Nos ayudas a mejorar PIA? ¡Dinos cómo podemos ser mejores!\nResponde la encuesta";
-"account.survey.messageLink" = "Responde la encuesta";
 
 // SETTINGS
 

--- a/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/fr.lproj/Localizable.strings
+++ b/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/fr.lproj/Localizable.strings
@@ -99,8 +99,6 @@
 "account.subscriptions.trial" = "Forfait d'essai";
 "account.unauthorized" = "Un problème est survenu. Veuillez réessayer de vous connecter";
 "account.delete" = "Supprimer le compte";
-"account.survey.message" = "Vous souhaitez aider à améliorer PIA ? Dites-nous comment nous pouvons nous améliorer !\nRépondez au sondage";
-"account.survey.messageLink" = "Répondre au sondage";
 
 // SETTINGS
 

--- a/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/it.lproj/Localizable.strings
+++ b/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/it.lproj/Localizable.strings
@@ -99,8 +99,6 @@
 "account.subscriptions.trial" = "Piano di prova";
 "account.unauthorized" = "Qualcosa è andato storto. Prova ad accedere di nuovo";
 "account.delete" = "Elimina account";
-"account.survey.message" = "Vuoi aiutarci a migliorare PIA? Dicci la tua!\nPartecipa al sondaggio";
-"account.survey.messageLink" = "Partecipa al sondaggio";
 
 // SETTINGS
 

--- a/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/ja.lproj/Localizable.strings
+++ b/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/ja.lproj/Localizable.strings
@@ -99,8 +99,6 @@
 "account.subscriptions.trial" = "トライアルプラン";
 "account.unauthorized" = "問題が発生しました。もう一度ログインしてみてください";
 "account.delete" = "アカウントを削除";
-"account.survey.message" = "PIAの改善にご協力いただけますか？\nアンケート調査を受ける";
-"account.survey.messageLink" = "アンケートを受ける";
 
 // SETTINGS
 

--- a/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/ko.lproj/Localizable.strings
+++ b/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/ko.lproj/Localizable.strings
@@ -99,8 +99,6 @@
 "account.subscriptions.trial" = "체험 플랜";
 "account.unauthorized" = "문제가 발생했습니다. 다시 로그인해 보세요";
 "account.delete" = "계정 삭제";
-"account.survey.message" = "PIA 서비스를 개선하도록 도와주시겠나요? 저희가 개선할 수 있는 부분을 알려주세요!\n설문조사 참여";
-"account.survey.messageLink" = "설문조사 참여";
 
 // SETTINGS
 

--- a/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/nb.lproj/Localizable.strings
+++ b/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/nb.lproj/Localizable.strings
@@ -99,7 +99,6 @@
 "account.subscriptions.trial" = "Prøveplan";
 "account.unauthorized" = "Noe gikk galt. Prøv å logge inn igjen.";
 "account.delete" = "Slett konto";
-"account.survey.messageLink" = "Besvar undersøkelsen";
 
 // SETTINGS
 

--- a/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/nl.lproj/Localizable.strings
+++ b/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/nl.lproj/Localizable.strings
@@ -99,8 +99,6 @@
 "account.subscriptions.trial" = "Proefabonnement";
 "account.unauthorized" = "Er is iets fout gegaan. Probeer opnieuw in te loggen.";
 "account.delete" = "Verwijder account";
-"account.survey.message" = "Wil je helpen om PIA beter te maken? Laat ons weten hoe we kunnen verbeteren!\nVul de enquête in";
-"account.survey.messageLink" = "Vul de enquête in";
 
 // SETTINGS
 

--- a/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/pl.lproj/Localizable.strings
+++ b/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/pl.lproj/Localizable.strings
@@ -99,8 +99,6 @@
 "account.subscriptions.trial" = "Plan próbny";
 "account.unauthorized" = "Coś poszło nie tak. zalogować się ponownie.";
 "account.delete" = "Usuń konto";
-"account.survey.message" = "Chcesz pomóc ulepszyć PIA? Daj nam znać, jak możemy to zrobić!\nWeź udział w ankiecie";
-"account.survey.messageLink" = "Weź udział w ankiecie";
 
 // SETTINGS
 

--- a/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/pt-BR.lproj/Localizable.strings
+++ b/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/pt-BR.lproj/Localizable.strings
@@ -99,8 +99,6 @@
 "account.subscriptions.trial" = "Plano de avaliação";
 "account.unauthorized" = "Ocorreu um erro. Tente fazer login novamente.";
 "account.delete" = "Excluir conta";
-"account.survey.message" = "Quer ajudar a tornar a PIA melhor? Diga-nos como podemos melhorar!\nResponda à pesquisa";
-"account.survey.messageLink" = "Responda à pesquisa";
 
 // SETTINGS
 

--- a/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/ru.lproj/Localizable.strings
+++ b/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/ru.lproj/Localizable.strings
@@ -99,8 +99,6 @@
 "account.subscriptions.trial" = "Пробный план";
 "account.unauthorized" = "Что-то пошло не так. Попробуйте выполнить вход еще раз";
 "account.delete" = "﻿Удалить аккаунт";
-"account.survey.message" = "Хотите помочь сделать PIA лучше? Подскажите нам, что можно изменить!\nПройти опрос";
-"account.survey.messageLink" = "Пройти опрос";
 
 // SETTINGS
 

--- a/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/th.lproj/Localizable.strings
+++ b/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/th.lproj/Localizable.strings
@@ -99,8 +99,6 @@
 "account.subscriptions.trial" = "แผนทดลองใช้";
 "account.unauthorized" = "บางอย่างผิดปกติ โปรดลองลงชื่อเข้าใช้อีกครั้ง";
 "account.delete" = "ลบบัญชี";
-"account.survey.message" = "ต้องการช่วยทำให้ PIA ดีขึ้นหรือไม่? แจ้งให้เราทราบว่าเราจะปรับปรุงได้อย่างไร!\nทำแบบสำรวจ";
-"account.survey.messageLink" = "ทำแบบสำรวจ";
 
 // SETTINGS
 

--- a/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/tr.lproj/Localizable.strings
+++ b/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/tr.lproj/Localizable.strings
@@ -99,8 +99,6 @@
 "account.subscriptions.trial" = "Deneme planı";
 "account.unauthorized" = "Bir sorun oluştu. Lütfen tekrar oturum açmayı deneyin";
 "account.delete" = "Hesabı Sil";
-"account.survey.message" = "PIA'yı daha iyi yapmak ister misiniz? Nasıl iyileştirebileceğimizi belirtin!\nAnkete Katılın";
-"account.survey.messageLink" = "Ankete Katıl";
 
 // SETTINGS
 

--- a/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/zh-Hans.lproj/Localizable.strings
+++ b/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/zh-Hans.lproj/Localizable.strings
@@ -99,8 +99,6 @@
 "account.subscriptions.trial" = "试用套餐";
 "account.unauthorized" = "出现问题。请尝试重新登录";
 "account.delete" = "删除账户";
-"account.survey.message" = "想要帮助改进 PIA 吗? 欢迎您提供反馈！\n填写调查问卷";
-"account.survey.messageLink" = "填写调查问卷";
 
 // SETTINGS
 

--- a/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/zh-Hant.lproj/Localizable.strings
+++ b/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/zh-Hant.lproj/Localizable.strings
@@ -99,8 +99,6 @@
 "account.subscriptions.trial" = "試用方案";
 "account.unauthorized" = "發生錯誤，請稍後再嘗試登入。";
 "account.delete" = "刪除帳戶";
-"account.survey.message" = "想要幫忙讓 PIA 變得更好嗎？讓我們知道該如何改進！\n參加調查";
-"account.survey.messageLink" = "參加調查";
 
 // SETTINGS
 

--- a/PIA VPN/Core/Messages/MessagesManager.swift
+++ b/PIA VPN/Core/Messages/MessagesManager.swift
@@ -30,7 +30,6 @@ public class MessagesManager: NSObject {
     public static let shared = MessagesManager()
     private var apiMessage: InAppMessage!
     private var systemMessage: InAppMessage!
-    private static let surveyMessageID = "take-the-survey-message-banner"
 
     public override init() {
         super.init()
@@ -62,10 +61,6 @@ public class MessagesManager: NSObject {
     }
 
     func dismiss(message id: String) {
-        if id == MessagesManager.surveyMessageID {
-            AppPreferences.shared.userInteractedWithSurvey = true
-        }
-
         AppPreferences.shared.dismissedMessages.append(id)
         if apiMessage != nil, id == apiMessage.id {
             apiMessage = nil
@@ -198,12 +193,6 @@ extension MessagesManager {
         }
     }
 
-    func showInAppSurveyMessage() {
-        let message = InAppMessage(withMessage: ["en-US": L10n.Account.Survey.message.appendDetailSymbol()], id: MessagesManager.surveyMessageID, link: ["en-US": L10n.Account.Survey.messageLink.appendDetailSymbol()], type: .link, level: .api, actions: nil, view: nil, uri: AppConstants.Survey.formURL.absoluteString) { [weak self] in
-            self?.dismiss(message: MessagesManager.surveyMessageID)
-        }
-        MessagesManager.shared.postSystemMessage(message: message)
-    }
 }
 
 private extension String {

--- a/PIA VPN/Core/Tiles/MessagesTile.swift
+++ b/PIA VPN/Core/Tiles/MessagesTile.swift
@@ -36,7 +36,6 @@ class MessagesTile: UIView, Tileable {
 
     @IBOutlet private weak var messageTextView: UITextView!
     @IBOutlet private weak var alertIcon: UIImageView!
-    @IBOutlet private weak var dismissButton: UIButton!
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -60,7 +59,6 @@ class MessagesTile: UIView, Tileable {
 
         viewShouldRestyle()
         self.alertIcon.image = Asset.iconAlert.image.withRenderingMode(.alwaysTemplate)
-        self.dismissButton.setImage(Asset.iconClose.image, for: .normal)
 
         if let message = MessagesManager.shared.availableMessage(), let _ = message.linkMessage {
             let tap = UITapGestureRecognizer(target: self, action: #selector(openLink))

--- a/PIA VPN/Global/AppPreferences.swift
+++ b/PIA VPN/Global/AppPreferences.swift
@@ -108,10 +108,6 @@ final class AppPreferences {
         static let showLeakProtectionNotifications = "showLeakProtectionNotifications"
         static let showDynamicIslandLiveActivity = "showDynamicIslandLiveActivity"
 
-        // Survey
-        static let userInteractedWithSurvey = "userInteractedWithSurvey"
-        static let successConnectionsUntilSurvey = "successConnectionsUntilSurvey"
-
         // Dev
         static let appEnvironmentIsProduction = "AppEnvironmentIsProduction"
         static let stagingVersion = "StagingVersion"
@@ -582,24 +578,6 @@ final class AppPreferences {
         }
     }
 
-    var userInteractedWithSurvey: Bool {
-        get {
-            return defaults.bool(forKey: Entries.userInteractedWithSurvey)
-        }
-        set {
-            defaults.set(newValue, forKey: Entries.userInteractedWithSurvey)
-        }
-    }
-
-    var successConnectionsUntilSurvey: Int? {
-        get {
-            return defaults.value(forKey: Entries.successConnectionsUntilSurvey) as? Int
-        }
-        set {
-            defaults.set(newValue, forKey: Entries.successConnectionsUntilSurvey)
-        }
-    }
-
     private init() {
         self.defaults = UserDefaults(suiteName: AppConstants.appGroup) ?? .standard
         #if os(iOS)
@@ -637,7 +615,6 @@ final class AppPreferences {
                 Entries.showServiceMessages: false,
                 Entries.disablesMultiDipTokens: true,
                 Entries.checksDipExpirationRequest: true,
-                Entries.userInteractedWithSurvey: false,
                 Entries.stagingVersion: 0,
                 Entries.appEnvironmentIsProduction: Client.environment == .production ? true : false
             ])
@@ -910,8 +887,6 @@ final class AppPreferences {
         #if os(iOS)
             MessagesManager.shared.reset()
         #endif
-        userInteractedWithSurvey = false
-        successConnectionsUntilSurvey = nil
         Client.preferences.lastKnownException = nil
     }
 


### PR DESCRIPTION
## Summary

- Fixes a crash when the Dashboard loads while a CSI/system message is available and the Messages tile is visible
- Removed all dead survey-related code left over from `KM-12896` (Dec 2025), which replaced the survey tile with `FeedbackTile`: `showInAppSurveyMessage()`, `surveyMessageID`, `userInteractedWithSurvey`/`successConnectionsUntilSurvey` preferences, `AppConstants.Survey`, `L10n.Account.Survey`, and `account.survey.*` keys across all 18 locale files