### PR TITLE
KM-15303: Fix delayed IP

### DIFF
--- a/LocalPackages/PIAAccount/Sources/PIAAccount/PIAAccountAPI.swift
+++ b/LocalPackages/PIAAccount/Sources/PIAAccount/PIAAccountAPI.swift
@@ -126,10 +126,10 @@ public protocol PIAAccountAPI {
     func deleteAccount() async throws
 
     /// Retrieves client connection status
-    /// - Parameter requestTimeoutMillis: Optional timeout in milliseconds (default: 30000ms)
+    /// - Parameter requestTimeoutMillis: Timeout in milliseconds
     /// - Returns: Client status information
     /// - Throws: PIAAccountError if the request fails
-    func clientStatus(requestTimeoutMillis: Int) async throws -> ClientStatusInformation
+    func clientStatus(requestTimeoutMillis: UInt) async throws -> ClientStatusInformation
 
     // MARK: - Email Management
 

--- a/LocalPackages/PIAAccount/Sources/PIAAccount/PIAAccountClient.swift
+++ b/LocalPackages/PIAAccount/Sources/PIAAccount/PIAAccountClient.swift
@@ -204,7 +204,7 @@ public final class PIAAccountClient: PIAAccountAPI {
         await updateCachedTokens()
     }
 
-    public func clientStatus(requestTimeoutMillis: Int = 30000) async throws -> ClientStatusInformation {
+    public func clientStatus(requestTimeoutMillis: UInt) async throws -> ClientStatusInformation {
         return try await endpointManager.executeWithFailover(
             path: .clientStatus,
             method: .get

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Account/DefaultAccountProvider.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Account/DefaultAccountProvider.swift
@@ -645,8 +645,13 @@ public final class DefaultAccountProvider: AccountProvider, ConfigurationAccess,
     }
 
     public func isAPIEndpointAvailable(_ callback: LibraryCallback<Bool>?) {
-        webServices.taskForConnectivityCheck { (_, error) in
-            callback?(error == nil, error)
+        Task {
+            switch await webServices.connectivityCheck() {
+            case .failure(let error):
+                callback?(false, error)
+            case .success:
+                callback?(true, nil)
+            }
         }
     }
 

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Account/EphemeralAccountProvider.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Account/EphemeralAccountProvider.swift
@@ -146,8 +146,13 @@ final class EphemeralAccountProvider: AccountProvider, ProvidersAccess, InAppAcc
             callback?(false, nil)
             return
         }
-        webServices.taskForConnectivityCheck { (_, error) in
-            callback?(error == nil, error)
+        Task {
+            switch await webServices.connectivityCheck() {
+            case .failure(let error):
+                callback?(false, error)
+            case .success:
+                callback?(true, nil)
+            }
         }
     }
 

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Account/NativeAccountProvider.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Account/NativeAccountProvider.swift
@@ -680,8 +680,13 @@ open class NativeAccountProvider: AccountProvider, ConfigurationAccess, Database
     }
 
     public func isAPIEndpointAvailable(_ callback: LibraryCallback<Bool>?) {
-        webServices.taskForConnectivityCheck { (_, error) in
-            callback?(error == nil, error)
+        Task {
+            switch await webServices.connectivityCheck() {
+            case .failure(let error):
+                callback?(false, error)
+            case .success:
+                callback?(true, nil)
+            }
         }
     }
 

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Daemons/ConnectivityDaemon.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Daemons/ConnectivityDaemon.swift
@@ -118,13 +118,15 @@ final class ConnectivityDaemon: Daemon, ConfigurationAccess, DatabaseAccess, Pre
         }
 
         isCheckingConnectivity.withLock { $0 = true }
-        accessedWebServices.taskForConnectivityCheck { [weak self] (connectivity, error) in
+        Task { [weak self] in
             guard let self else { return }
+            let result = await self.accessedWebServices.connectivityCheck()
             self.isCheckingConnectivity.withLock { $0 = false }
 
-            guard let connectivity = connectivity else {
+            switch result {
+            case .failure(let error):
                 self.failedConnectivityAttempts += 1
-                log.error("Failed to check network connectivity (error: \(error?.localizedDescription ?? ""))")
+                log.error("Failed to check network connectivity (error: \(error))")
 
                 guard (self.failedConnectivityAttempts < self.accessedConfiguration.connectivityMaxAttempts) else {
                     log.debug("Giving up, network is unreachable")
@@ -140,23 +142,22 @@ final class ConnectivityDaemon: Daemon, ConfigurationAccess, DatabaseAccess, Pre
                     self.checkConnectivityOrRetry()
                 }
 
-                return
+            case .success(let connectivity):
+                self.failedConnectivityAttempts = 0
+                self.accessedDatabase.transient.isInternetReachable = true
+                log.debug("Saving new info about network connectivity: \(connectivity)")
+
+                let ipAddress = connectivity.ipAddress
+                if connectivity.isVPN {
+                    self.accessedDatabase.transient.vpnIP = ipAddress
+                    log.debug("VPN IP -> \(ipAddress)")
+                } else {
+                    self.accessedDatabase.plain.publicIP = ipAddress
+                    log.debug("Public IP -> \(ipAddress)")
+                }
+
+                Macros.postNotification(.PIADaemonsDidUpdateConnectivity)
             }
-
-            self.failedConnectivityAttempts = 0
-            self.accessedDatabase.transient.isInternetReachable = true
-            log.debug("Saving new info about network connectivity: \(connectivity)")
-
-            let ipAddress = connectivity.ipAddress
-            if connectivity.isVPN {
-                self.accessedDatabase.transient.vpnIP = ipAddress
-                log.debug("VPN IP -> \(ipAddress)")
-            } else {
-                self.accessedDatabase.plain.publicIP = ipAddress
-                log.debug("Public IP -> \(ipAddress)")
-            }
-
-            Macros.postNotification(.PIADaemonsDidUpdateConnectivity)
         }
     }
 

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Daemons/ConnectivityDaemon.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Daemons/ConnectivityDaemon.swift
@@ -38,7 +38,7 @@ final class ConnectivityDaemon: Daemon, ConfigurationAccess, DatabaseAccess, Pre
 
     private let reachability = try! Reachability(hostname: "8.8.8.8")
 
-    private var isCheckingConnectivity: Mutex<Bool> = .init(false)
+    private lazy var checker = ConnectivityChecker(webServices: accessedWebServices)
 
     private var failedConnectivityAttempts: Int = 0
 
@@ -104,12 +104,6 @@ final class ConnectivityDaemon: Daemon, ConfigurationAccess, DatabaseAccess, Pre
         guard hasEnabledUpdates else {
             return
         }
-        guard !isCheckingConnectivity.withLock(\.self) else {
-            log.debug("Skipped \(#function), is already checking...")
-            return
-        }
-
-        log.debug("Checking network connectivity...")
 
         // Clear vpnIP if VPN is not connected
         if accessedDatabase.transient.vpnStatus != .connected {
@@ -117,14 +111,15 @@ final class ConnectivityDaemon: Daemon, ConfigurationAccess, DatabaseAccess, Pre
             Macros.postNotification(.PIADaemonsDidUpdateConnectivity)
         }
 
-        isCheckingConnectivity.withLock { $0 = true }
         Task { [weak self] in
             guard let self else { return }
-            let result = await self.accessedWebServices.connectivityCheck()
-            self.isCheckingConnectivity.withLock { $0 = false }
 
-            switch result {
-            case .failure(let error):
+            log.debug("Checking connectivity.")
+            switch await self.checker.checkConnectivity() {
+            case .failure(.alreadyChecking):
+                log.debug("Skipping: already checking.")
+
+            case .failure(.other(let error)):
                 self.failedConnectivityAttempts += 1
                 log.error("Failed to check network connectivity (error: \(error))")
 
@@ -256,5 +251,29 @@ final class ConnectivityDaemon: Daemon, ConfigurationAccess, DatabaseAccess, Pre
             }
             completionHandler?(pingTime)
         }
+    }
+}
+
+// MARK: - ConnectivityChecker
+
+private actor ConnectivityChecker {
+    enum Error: Swift.Error {
+        case alreadyChecking
+        case other(Swift.Error)
+    }
+
+    private var isChecking = false
+    private let webServices: WebServices
+
+    init(webServices: WebServices) {
+        self.webServices = webServices
+    }
+
+    func checkConnectivity() async -> Result<ConnectivityStatus, Error> {
+        guard !isChecking else { return .failure(.alreadyChecking) }
+        isChecking = true
+        let result = await webServices.connectivityCheck()
+        isChecking = false
+        return result.mapError(Error.other(_:))
     }
 }

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Mock/MockWebServices.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Mock/MockWebServices.swift
@@ -94,8 +94,8 @@ final class MockWebServices: WebServices {
         return URL(fileURLWithPath: "")
     }
 
-    func taskForConnectivityCheck(_ callback: ((ConnectivityStatus?, Error?) -> Void)?) {
-        callback?(nil, nil)
+    func connectivityCheck() async -> Result<ConnectivityStatus, Error> {
+        return .success(ConnectivityStatus(ipAddress: "8.8.8.8", isVPN: true))
     }
 
     func submitDebugReport() async throws -> String {

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Persistence/MemoryStore.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Persistence/MemoryStore.swift
@@ -65,7 +65,7 @@ final class MemoryStore: TransientStore, ConfigurationAccess {
 
     var vpnIP: String? {
         didSet {
-            log.debug("Did set \(#function): \(String(describing: vpnIP))")
+            log.debug("Did set \(#function): \(vpnIP ?? "nil")")
             Macros.postNotification(.PIADaemonsDidUpdateConnectivity)
         }
     }

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/WebServices/PIAWebServices+Ephemeral.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/WebServices/PIAWebServices+Ephemeral.swift
@@ -27,14 +27,12 @@ private let log = PIALogger.logger(for: PIAWebServices.self)
 
 extension PIAWebServices {
 
-    func taskForConnectivityCheck(_ callback: ((ConnectivityStatus?, Error?) -> Void)?) {
-        Task { @MainActor in
-            do {
-                let information = try await nativeAccountAPI.clientStatus(requestTimeoutMillis: 10000)
-                callback?(ConnectivityStatus(ipAddress: information.ip, isVPN: information.connected), nil)
-            } catch {
-                callback?(nil, error)
-            }
+    func connectivityCheck() async -> Result<ConnectivityStatus, Error> {
+        do {
+            let information = try await nativeAccountAPI.clientStatus(requestTimeoutMillis: 1_000)
+            return .success(ConnectivityStatus(ipAddress: information.ip, isVPN: information.connected))
+        } catch {
+            return .failure(error)
         }
     }
 

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/WebServices/WebServices.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/WebServices/WebServices.swift
@@ -75,7 +75,7 @@ protocol WebServices: AnyObject {
 
     func downloadServers(_ callback: LibraryCallback<ServersBundle>?)
 
-    func taskForConnectivityCheck(_ callback: LibraryCallback<ConnectivityStatus>?)
+    func connectivityCheck() async -> Result<ConnectivityStatus, Error>
 
     func submitDebugReport() async throws -> String
 


### PR DESCRIPTION
- Rename `WebServices.taskForConnectivityCheck` to `connectivityCheck` and make it async.
- The connectivity check is inside an actor, managing concurrent checks.
- Reduce timeout to 1 second instead of 10. It is going to be retried anyways.