### PR TITLE
KM-15765 Fix "Not Protected" gap when changing servers

### DIFF
--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Extensions/NEVPNStatus+Description.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Extensions/NEVPNStatus+Description.swift
@@ -1,0 +1,36 @@
+//
+//  NEVPNStatus+Description.swift
+//  PIALibrary
+//
+//  Copyright © 2026 Private Internet Access, Inc.
+//
+//  This file is part of the Private Internet Access iOS Client.
+//
+//  The Private Internet Access iOS Client is free software: you can redistribute it and/or
+//  modify it under the terms of the GNU General Public License as published by the Free
+//  Software Foundation, either version 3 of the License, or (at your option) any later version.
+//
+//  The Private Internet Access iOS Client is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+//  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+//  details.
+//
+//  You should have received a copy of the GNU General Public License along with the Private
+//  Internet Access iOS Client.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import NetworkExtension
+
+extension NEVPNStatus {
+    var descriptionForLog: String {
+        switch self {
+        case .invalid: return "invalid"
+        case .disconnected: return "disconnected"
+        case .connecting: return "connecting"
+        case .connected: return "connected"
+        case .reasserting: return "reasserting"
+        case .disconnecting: return "disconnecting"
+        @unknown default: return "unknown(\(rawValue))"
+        }
+    }
+}

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/VPN/IKEv2Profile.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/VPN/IKEv2Profile.swift
@@ -28,6 +28,8 @@ private let log = PIALogger.logger(for: IKEv2Profile.self)
 /// Implementation of `VPNProfile` providing IKEv2 connectivity.
 public final class IKEv2Profile: NetworkExtensionProfile {
 
+    private var waitObserver: NSObjectProtocol?
+
     private var currentVPN: NEVPNManager {
         return NEVPNManager.shared()
     }
@@ -79,22 +81,27 @@ public final class IKEv2Profile: NetworkExtensionProfile {
             }
 
             let currentStatus = self.currentVPN.connection.status
+            log.debug("[IKEv2] connect — current status: \(currentStatus.descriptionForLog)")
 
             // If the tunnel is already active, stop it before starting the new one.
             // Calling startVPNTunnel() on a connected IKEv2 tunnel may silently retain
             // the existing connection rather than switching to the new server, resulting
             // in the app believing it is connected when it is not.
             if currentStatus == .connected || currentStatus == .connecting || currentStatus == .reasserting {
+                log.debug("[IKEv2] connect — stopping active tunnel before restart")
                 self.currentVPN.connection.stopVPNTunnel()
             }
 
             if currentStatus == .disconnecting {
+                log.debug("[IKEv2] connect — waiting for .disconnected before start")
                 self.waitForDisconnectedThenStart(callback: callback)
             } else {
                 do {
                     try self.currentVPN.connection.startVPNTunnel()
+                    log.debug("[IKEv2] connect — startVPNTunnel issued")
                     callback?(nil)
                 } catch let e {
+                    log.error("[IKEv2] connect — startVPNTunnel threw: \(e)")
                     callback?(e)
                 }
             }
@@ -102,23 +109,33 @@ public final class IKEv2Profile: NetworkExtensionProfile {
     }
 
     private func waitForDisconnectedThenStart(callback: SuccessLibraryCallback?) {
-        var observer: NSObjectProtocol?
-        observer = NotificationCenter.default.addObserver(forName: .NEVPNStatusDidChange, object: currentVPN.connection, queue: .main) { [currentVPN] _ in
+        if let existing = waitObserver {
+            NotificationCenter.default.removeObserver(existing)
+            waitObserver = nil
+        }
+
+        var token: NSObjectProtocol?
+        token = NotificationCenter.default.addObserver(forName: .NEVPNStatusDidChange, object: currentVPN.connection, queue: .main) { [weak self, currentVPN] _ in
             guard currentVPN.connection.status == .disconnected else {
                 return
             }
 
-            if let observer {
-                NotificationCenter.default.removeObserver(observer)
+            defer {
+                token.map { NotificationCenter.default.removeObserver($0) }
+                self?.waitObserver = nil
             }
 
+            log.debug("[IKEv2] waitForDisconnectedThenStart — disconnected, starting")
             do {
                 try currentVPN.connection.startVPNTunnel()
+                log.debug("[IKEv2] waitForDisconnectedThenStart — startVPNTunnel issued")
                 callback?(nil)
             } catch let e {
+                log.error("[IKEv2] waitForDisconnectedThenStart — startVPNTunnel threw: \(e)")
                 callback?(e)
             }
         }
+        waitObserver = token
     }
 
     /// :nodoc:

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/VPN/PIATunnelProfile.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/VPN/PIATunnelProfile.swift
@@ -29,6 +29,7 @@
     /// Implementation of `VPNProfile` providing OpenVPN connectivity.
     public final class PIATunnelProfile: NetworkExtensionProfile {
         private let bundleIdentifier: String
+        private var waitObserver: NSObjectProtocol?
 
         /**
          Default initializer.
@@ -85,23 +86,28 @@
                     }
 
                     let currentStatus = vpn.connection.status
+                    log.debug("[OpenVPN] connect — current status: \(currentStatus.descriptionForLog)")
 
                     // If the tunnel is already active, stop it before starting the new one.
                     // Calling startTunnel() on a live session may silently retain the existing
                     // connection rather than switching to the new server, leaving the app in a
                     // state where it believes it is connected when it is not.
                     if currentStatus == .connected || currentStatus == .connecting || currentStatus == .reasserting {
+                        log.debug("[OpenVPN] connect — stopping active tunnel before restart")
                         vpn.connection.stopVPNTunnel()
                     }
 
                     if currentStatus == .disconnecting {
+                        log.debug("[OpenVPN] connect — waiting for .disconnected before start")
                         self.waitForDisconnectedThenStart(vpn: vpn, callback: callback)
                     } else {
                         do {
                             let session = vpn.connection as? NETunnelProviderSession
                             try session?.startTunnel(options: nil)
+                            log.debug("[OpenVPN] connect — startTunnel issued")
                             callback?(nil)
                         } catch let e {
+                            log.error("[OpenVPN] connect — startTunnel threw: \(e)")
                             callback?(e)
                         }
                     }
@@ -110,24 +116,34 @@
         }
 
         private func waitForDisconnectedThenStart(vpn: NETunnelProviderManager, callback: SuccessLibraryCallback?) {
-            var observer: NSObjectProtocol?
-            observer = NotificationCenter.default.addObserver(forName: .NEVPNStatusDidChange, object: vpn.connection, queue: .main) { [vpn] _ in
+            if let existing = waitObserver {
+                NotificationCenter.default.removeObserver(existing)
+                waitObserver = nil
+            }
+
+            var token: NSObjectProtocol?
+            token = NotificationCenter.default.addObserver(forName: .NEVPNStatusDidChange, object: vpn.connection, queue: .main) { [weak self, vpn] _ in
                 guard vpn.connection.status == .disconnected else {
                     return
                 }
 
-                if let observer {
-                    NotificationCenter.default.removeObserver(observer)
+                defer {
+                    token.map { NotificationCenter.default.removeObserver($0) }
+                    self?.waitObserver = nil
                 }
 
+                log.debug("[OpenVPN] waitForDisconnectedThenStart — disconnected, starting")
                 do {
                     let session = vpn.connection as? NETunnelProviderSession
                     try session?.startTunnel(options: nil)
+                    log.debug("[OpenVPN] waitForDisconnectedThenStart — startTunnel issued")
                     callback?(nil)
                 } catch let e {
+                    log.error("[OpenVPN] waitForDisconnectedThenStart — startTunnel threw: \(e)")
                     callback?(e)
                 }
             }
+            waitObserver = token
         }
 
         /// :nodoc:

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/VPN/PIATunnelProfile.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/VPN/PIATunnelProfile.swift
@@ -24,6 +24,8 @@
     import TunnelKitOpenVPN
     import NetworkExtension
 
+    private let log = PIALogger.logger(for: PIATunnelProfile.self)
+
     /// Implementation of `VPNProfile` providing OpenVPN connectivity.
     public final class PIATunnelProfile: NetworkExtensionProfile {
         private let bundleIdentifier: String
@@ -81,13 +83,49 @@
                         callback?(error)
                         return
                     }
-                    do {
-                        let session = vpn.connection as? NETunnelProviderSession
-                        try session?.startTunnel(options: nil)
-                        callback?(nil)
-                    } catch let e {
-                        callback?(e)
+
+                    let currentStatus = vpn.connection.status
+
+                    // If the tunnel is already active, stop it before starting the new one.
+                    // Calling startTunnel() on a live session may silently retain the existing
+                    // connection rather than switching to the new server, leaving the app in a
+                    // state where it believes it is connected when it is not.
+                    if currentStatus == .connected || currentStatus == .connecting || currentStatus == .reasserting {
+                        vpn.connection.stopVPNTunnel()
                     }
+
+                    if currentStatus == .disconnecting {
+                        self.waitForDisconnectedThenStart(vpn: vpn, callback: callback)
+                    } else {
+                        do {
+                            let session = vpn.connection as? NETunnelProviderSession
+                            try session?.startTunnel(options: nil)
+                            callback?(nil)
+                        } catch let e {
+                            callback?(e)
+                        }
+                    }
+                }
+            }
+        }
+
+        private func waitForDisconnectedThenStart(vpn: NETunnelProviderManager, callback: SuccessLibraryCallback?) {
+            var observer: NSObjectProtocol?
+            observer = NotificationCenter.default.addObserver(forName: .NEVPNStatusDidChange, object: vpn.connection, queue: .main) { [vpn] _ in
+                guard vpn.connection.status == .disconnected else {
+                    return
+                }
+
+                if let observer {
+                    NotificationCenter.default.removeObserver(observer)
+                }
+
+                do {
+                    let session = vpn.connection as? NETunnelProviderSession
+                    try session?.startTunnel(options: nil)
+                    callback?(nil)
+                } catch let e {
+                    callback?(e)
                 }
             }
         }
@@ -117,20 +155,13 @@
 
         /// :nodoc:
         public func updatePreferences(_ callback: SuccessLibraryCallback?) {
-            find { (vpn, error) in
-                guard let vpn = vpn else {
-                    callback?(error)
-                    return
-                }
-
-                vpn.saveToPreferences { (error) in
-                    if let error = error {
-                        callback?(error)
-                        return
-                    }
-                    callback?(nil)
-                }
-            }
+            // All preference mutations (server address, on-demand rules, etc.) are
+            // applied by connect() via save(force: true) → doSave(). A standalone
+            // loadFromPreferences → saveToPreferences round-trip with no mutations
+            // races with any concurrent connect() call and causes
+            // "configuration is stale" errors.
+            log.debug("[OpenVPN] updatePreferences() — skipped (no-op, changes applied by connect)")
+            callback?(nil)
         }
 
         /// :nodoc:

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/VPN/PIAWGTunnelProfile.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/VPN/PIAWGTunnelProfile.swift
@@ -154,23 +154,28 @@ import Foundation
                     }
 
                     let currentStatus = vpn.connection.status
+                    log.debug("[WG] connect — current status: \(currentStatus.descriptionForLog)")
 
                     // If the tunnel is already active, stop it before starting the new one.
                     // Calling startTunnel() on a live session may silently retain the existing
                     // connection rather than switching to the new server, leaving the app in a
                     // state where it believes it is connected when it is not.
                     if currentStatus == .connected || currentStatus == .connecting || currentStatus == .reasserting {
+                        log.debug("[WG] connect — stopping active tunnel before restart")
                         vpn.connection.stopVPNTunnel()
                     }
 
                     if currentStatus == .disconnecting {
+                        log.debug("[WG] connect — waiting for .disconnected before start")
                         self.waitForDisconnectedThenStart(vpn: vpn, callback: callback)
                     } else {
                         do {
                             let session = vpn.connection as? NETunnelProviderSession
                             try session?.startTunnel(options: nil)
+                            log.debug("[WG] connect — startTunnel issued")
                             callback?(nil)
                         } catch let e {
+                            log.error("[WG] connect — startTunnel threw: \(e)")
                             callback?(e)
                         }
                     }
@@ -185,15 +190,20 @@ import Foundation
                     return
                 }
 
-                if let observer {
-                    NotificationCenter.default.removeObserver(observer)
+                defer {
+                    if let observer {
+                        NotificationCenter.default.removeObserver(observer)
+                    }
                 }
 
+                log.debug("[WG] waitForDisconnectedThenStart — disconnected, starting")
                 do {
                     let session = vpn.connection as? NETunnelProviderSession
                     try session?.startTunnel(options: nil)
+                    log.debug("[WG] waitForDisconnectedThenStart — startTunnel issued")
                     callback?(nil)
                 } catch let e {
+                    log.error("[WG] waitForDisconnectedThenStart — startTunnel threw: \(e)")
                     callback?(e)
                 }
             }

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/VPN/PIAWGTunnelProfile.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/VPN/PIAWGTunnelProfile.swift
@@ -26,6 +26,8 @@ import Foundation
     import PIAWireguard
     import NetworkExtension
 
+    private let log = PIALogger.logger(for: PIAWGTunnelProfile.self)
+
     /// Implementation of `VPNProfile` providing WireGuard connectivity.
     public final class PIAWGTunnelProfile: NetworkExtensionProfile {
 
@@ -150,13 +152,49 @@ import Foundation
                         callback?(error)
                         return
                     }
-                    do {
-                        let session = vpn.connection as? NETunnelProviderSession
-                        try session?.startTunnel(options: nil)
-                        callback?(nil)
-                    } catch let e {
-                        callback?(e)
+
+                    let currentStatus = vpn.connection.status
+
+                    // If the tunnel is already active, stop it before starting the new one.
+                    // Calling startTunnel() on a live session may silently retain the existing
+                    // connection rather than switching to the new server, leaving the app in a
+                    // state where it believes it is connected when it is not.
+                    if currentStatus == .connected || currentStatus == .connecting || currentStatus == .reasserting {
+                        vpn.connection.stopVPNTunnel()
                     }
+
+                    if currentStatus == .disconnecting {
+                        self.waitForDisconnectedThenStart(vpn: vpn, callback: callback)
+                    } else {
+                        do {
+                            let session = vpn.connection as? NETunnelProviderSession
+                            try session?.startTunnel(options: nil)
+                            callback?(nil)
+                        } catch let e {
+                            callback?(e)
+                        }
+                    }
+                }
+            }
+        }
+
+        private func waitForDisconnectedThenStart(vpn: NETunnelProviderManager, callback: SuccessLibraryCallback?) {
+            var observer: NSObjectProtocol?
+            observer = NotificationCenter.default.addObserver(forName: .NEVPNStatusDidChange, object: vpn.connection, queue: .main) { [vpn] _ in
+                guard vpn.connection.status == .disconnected else {
+                    return
+                }
+
+                if let observer {
+                    NotificationCenter.default.removeObserver(observer)
+                }
+
+                do {
+                    let session = vpn.connection as? NETunnelProviderSession
+                    try session?.startTunnel(options: nil)
+                    callback?(nil)
+                } catch let e {
+                    callback?(e)
                 }
             }
         }
@@ -186,20 +224,13 @@ import Foundation
 
         /// :nodoc:
         public func updatePreferences(_ callback: SuccessLibraryCallback?) {
-            find { (vpn, error) in
-                guard let vpn = vpn else {
-                    callback?(error)
-                    return
-                }
-
-                vpn.saveToPreferences { (error) in
-                    if let error = error {
-                        callback?(error)
-                        return
-                    }
-                    callback?(nil)
-                }
-            }
+            // All preference mutations (server address, on-demand rules, etc.) are
+            // applied by connect() via save(force: true) → doSave(). A standalone
+            // loadFromPreferences → saveToPreferences round-trip with no mutations
+            // races with any concurrent connect() call and causes
+            // "configuration is stale" errors.
+            log.debug("[WG] updatePreferences() — skipped (no-op, changes applied by connect)")
+            callback?(nil)
         }
 
         /// :nodoc:

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/VPN/PIAWGTunnelProfile.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/VPN/PIAWGTunnelProfile.swift
@@ -31,6 +31,8 @@ import Foundation
     /// Implementation of `VPNProfile` providing WireGuard connectivity.
     public final class PIAWGTunnelProfile: NetworkExtensionProfile {
 
+        private var waitObserver: NSObjectProtocol?
+
         public func parsedCustomConfiguration(from map: [String: Any]) -> VPNCustomConfiguration? {
 
             let S = PIAWireguardConfiguration.Keys.self
@@ -184,16 +186,20 @@ import Foundation
         }
 
         private func waitForDisconnectedThenStart(vpn: NETunnelProviderManager, callback: SuccessLibraryCallback?) {
-            var observer: NSObjectProtocol?
-            observer = NotificationCenter.default.addObserver(forName: .NEVPNStatusDidChange, object: vpn.connection, queue: .main) { [vpn] _ in
+            if let existing = waitObserver {
+                NotificationCenter.default.removeObserver(existing)
+                waitObserver = nil
+            }
+
+            var token: NSObjectProtocol?
+            token = NotificationCenter.default.addObserver(forName: .NEVPNStatusDidChange, object: vpn.connection, queue: .main) { [weak self, vpn] _ in
                 guard vpn.connection.status == .disconnected else {
                     return
                 }
 
                 defer {
-                    if let observer {
-                        NotificationCenter.default.removeObserver(observer)
-                    }
+                    token.map { NotificationCenter.default.removeObserver($0) }
+                    self?.waitObserver = nil
                 }
 
                 log.debug("[WG] waitForDisconnectedThenStart — disconnected, starting")
@@ -207,6 +213,7 @@ import Foundation
                     callback?(e)
                 }
             }
+            waitObserver = token
         }
 
         /// :nodoc:


### PR DESCRIPTION
## Summary
- Mirror the IKEv2 race-condition fixes in `PIAWGTunnelProfile` and `PIATunnelProfile`

## Test plan
- [ ] Switch servers on WireGuard — verify no "Not Protected" gap
- [ ] Switch servers on OpenVPN — verify no "Not Protected" gap
- [ ] Switch servers on IKEv2 — verify no regression (already fixed)
- [ ] Connect/disconnect cycle on each protocol
- [ ] Toggle on-demand / kill switch settings while connected