### PR TITLE
KM-15784 Only show locations which support the currently selected protocol

### DIFF
--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Extensions/PIALibrary+Protocols.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Extensions/PIALibrary+Protocols.swift
@@ -30,6 +30,7 @@ public protocol ServerType {
     var dipToken: String? { get }
     var dipIKEv2IP: String? { get }
     var dipStatusString: String? { get }
+    func hasEndpoints(for vpnType: String) -> Bool
 }
 
 public protocol DedicatedIPStatusType {

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/WebServices/Server.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/WebServices/Server.swift
@@ -301,6 +301,21 @@ extension Server {
         }
         return availableServer
     }
+
+    public func hasEndpoints(for vpnType: String) -> Bool {
+        switch vpnType {
+        case IKEv2Profile.vpnType:
+            return iKEv2AddressesForUDP?.isEmpty == false
+        case PIATunnelProfile.vpnType:
+            return openVPNAddressesForTCP?.isEmpty == false || openVPNAddressesForUDP?.isEmpty == false
+        case PIAWGTunnelProfile.vpnType:
+            return wireGuardAddressesForUDP?.isEmpty == false
+        case "Mock":  // Simulator
+            return true
+        default:
+            return false
+        }
+    }
 }
 
 extension Server {

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/WebServices/Server.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/WebServices/Server.swift
@@ -306,10 +306,12 @@ extension Server {
         switch vpnType {
         case IKEv2Profile.vpnType:
             return iKEv2AddressesForUDP?.isEmpty == false
-        case PIATunnelProfile.vpnType:
-            return openVPNAddressesForTCP?.isEmpty == false || openVPNAddressesForUDP?.isEmpty == false
-        case PIAWGTunnelProfile.vpnType:
-            return wireGuardAddressesForUDP?.isEmpty == false
+        #if os(iOS)
+            case PIATunnelProfile.vpnType:
+                return openVPNAddressesForTCP?.isEmpty == false || openVPNAddressesForUDP?.isEmpty == false
+            case PIAWGTunnelProfile.vpnType:
+                return wireGuardAddressesForUDP?.isEmpty == false
+        #endif
         case "Mock":  // Simulator
             return true
         default:

--- a/LocalPackages/PIARegions/Sources/Regions/Internals/RegionHttpClient.swift
+++ b/LocalPackages/PIARegions/Sources/Regions/Internals/RegionHttpClient.swift
@@ -27,7 +27,7 @@ internal enum RegionHttpClient {
         certificate: String? = nil,
         pinnedEndpoint: (hostname: String, commonName: String)? = nil
     ) -> (URLSession?, Error?) {
-        let config = URLSessionConfiguration.default
+        let config = URLSessionConfiguration.ephemeral
         config.timeoutIntervalForRequest = requestTimeoutSeconds
 
         if let cert = certificate, let pinned = pinnedEndpoint {

--- a/PIA VPN-tvOS/RegionsSelection/UseCases/RegionsFilterUseCase.swift
+++ b/PIA VPN-tvOS/RegionsSelection/UseCases/RegionsFilterUseCase.swift
@@ -128,7 +128,7 @@ extension RegionsFilterUseCase {
     private func filteredByProtocol(_ servers: [ServerType]) -> [ServerType] {
         let currentVPNType = Client.providers.vpnProvider.currentVPNType
         return servers.filter { server in
-            guard let concrete = server as? Server else { return true }
+            guard let concrete = server as? Server else { return false }
             return server.dipToken != nil || concrete.hasEndpoints(for: currentVPNType)
         }
     }

--- a/PIA VPN-tvOS/RegionsSelection/UseCases/RegionsFilterUseCase.swift
+++ b/PIA VPN-tvOS/RegionsSelection/UseCases/RegionsFilterUseCase.swift
@@ -101,7 +101,7 @@ class RegionsFilterUseCase: RegionsFilterUseCaseType {
 
 extension RegionsFilterUseCase {
     private func getServers(with filter: RegionsListFilter, sorting: SortingOrder) -> [ServerType] {
-        let allServers = serversUseCase.getCurrentServers()
+        let allServers = filteredByProtocol(serversUseCase.getCurrentServers())
 
         switch filter {
         case .all:
@@ -123,6 +123,14 @@ extension RegionsFilterUseCase {
             return getPreviouslySearchedRegions(from: allServers)
         }
 
+    }
+
+    private func filteredByProtocol(_ servers: [ServerType]) -> [ServerType] {
+        let currentVPNType = Client.providers.vpnProvider.currentVPNType
+        return servers.filter { server in
+            guard let concrete = server as? Server else { return true }
+            return server.dipToken != nil || concrete.hasEndpoints(for: currentVPNType)
+        }
     }
 
     private func getServersWithoutDip(from servers: [ServerType]) -> [ServerType] {

--- a/PIA VPN-tvOS/RegionsSelection/UseCases/RegionsFilterUseCase.swift
+++ b/PIA VPN-tvOS/RegionsSelection/UseCases/RegionsFilterUseCase.swift
@@ -128,8 +128,7 @@ extension RegionsFilterUseCase {
     private func filteredByProtocol(_ servers: [ServerType]) -> [ServerType] {
         let currentVPNType = Client.providers.vpnProvider.currentVPNType
         return servers.filter { server in
-            guard let concrete = server as? Server else { return false }
-            return server.dipToken != nil || concrete.hasEndpoints(for: currentVPNType)
+            server.dipToken != nil || server.hasEndpoints(for: currentVPNType)
         }
     }
 

--- a/PIA VPN-tvOSTests/Common/Mocks/ServerMock.swift
+++ b/PIA VPN-tvOSTests/Common/Mocks/ServerMock.swift
@@ -41,4 +41,8 @@ class ServerMock: ServerType {
         self.init(name: "mock-server-name", identifier: "mock-server-id", regionIdentifier: "mock-server-region-id", country: "mock-country", geo: false)
     }
 
+    func hasEndpoints(for vpnType: String) -> Bool {
+        true
+    }
+
 }

--- a/PIA VPN-tvOSTests/DedicatedIp/DedicatedIPViewModelTests.swift
+++ b/PIA VPN-tvOSTests/DedicatedIp/DedicatedIPViewModelTests.swift
@@ -165,6 +165,10 @@ struct ServerTypeStub: ServerType {
     var dipIKEv2IP: String?
     var dipStatusString: String?
 
+    func hasEndpoints(for vpnType: String) -> Bool {
+        true
+    }
+
     static func makeValidServerTypeStub() -> ServerType {
         ServerTypeStub(
             name: "name",

--- a/PIA VPN/UI/Menu/RegionsViewController.swift
+++ b/PIA VPN/UI/Menu/RegionsViewController.swift
@@ -243,6 +243,11 @@ class RegionsViewController: AutolayoutViewController {
             self.servers = self.servers.filter({ $0.geo == AppPreferences.shared.showGeoServers })
         }
 
+        let currentVPNType = Client.providers.vpnProvider.currentVPNType
+        self.servers = self.servers.filter { server in
+            server.dipToken != nil || server.hasEndpoints(for: currentVPNType)
+        }
+
         tableView.reloadData()
         if tableView.numberOfRows(inSection: 0) > 0 {
             tableView.scrollToRow(at: IndexPath(row: 0, section: 0), at: .top, animated: true)


### PR DESCRIPTION
## Summary
- Filter the region list so regions without endpoints for the user's currently selected VPN protocol are hidden. DIP regions are exempt; connection logic is unchanged
- Fix cache policy in PIARegions so regions are not cached