### PR TITLE
KM-13361 Fix login showing wrong credentials error on connection failures

### DIFF
--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Account/Domain/UseCases/LoginUseCase.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Account/Domain/UseCases/LoginUseCase.swift
@@ -72,14 +72,13 @@ private extension LoginUseCase {
 
             guard let self else { return }
 
-            if error != nil {
-
-                completion(.unauthorized)
+            if let error {
+                completion(error)
             } else if let dataResponse {
                 let shouldSaveToken = configuration.path == .login
                 self.handleDataResponse(dataResponse, shouldSaveTokenFromResponse: shouldSaveToken, completion: completion)
             } else {
-                completion(.unauthorized)
+                completion(.noErrorAndNoResponse)
             }
         }
     }

--- a/LocalPackages/PIALibrary/Tests/PIALibraryTests/Accounts/LoginUseCaseTests.swift
+++ b/LocalPackages/PIALibrary/Tests/PIALibraryTests/Accounts/LoginUseCaseTests.swift
@@ -175,9 +175,9 @@ class LoginUseCaseTests: XCTestCase {
         // AND the Vpn token is NOT refreshed
         XCTAssertEqual(fixture.refreshVpnTokenUseCaseMock.callAsFunctionCalledAttempt, 0)
 
-        // AND an 'unauthorized' error is returned
+        // AND the actual connection error is returned (not 'unauthorized')
         XCTAssertNotNil(capturedError)
-        XCTAssertEqual(capturedError!, .unauthorized)
+        XCTAssertEqual(capturedError!, .connectionError(statusCode: 500))
 
     }
 
@@ -275,9 +275,9 @@ class LoginUseCaseTests: XCTestCase {
         // AND the Vpn token is NOT refreshed
         XCTAssertEqual(fixture.refreshVpnTokenUseCaseMock.callAsFunctionCalledAttempt, 0)
 
-        // AND an 'unauthorized' error is returned
+        // AND the actual connection error is returned (not 'unauthorized')
         XCTAssertNotNil(capturedError)
-        XCTAssertEqual(capturedError!, .unauthorized)
+        XCTAssertEqual(capturedError!, .connectionError(statusCode: 500))
 
     }
 
@@ -334,9 +334,9 @@ class LoginUseCaseTests: XCTestCase {
         XCTAssertEqual(fixture.networkClientMock.executeRequestCalledAttempt, 1)
         XCTAssertEqual(fixture.networkClientMock.executeRequestWithConfiguation?.path, RequestAPI.Path.loginLink)
 
-        // AND an 'unauthorized' error is returned
+        // AND the actual connection error is returned (not 'unauthorized')
         XCTAssertNotNil(capturedError)
-        XCTAssertEqual(capturedError!, .unauthorized)
+        XCTAssertEqual(capturedError!, .connectionError(statusCode: 500))
 
     }
 


### PR DESCRIPTION
## Summary
- `LoginUseCase.executeNetworkRequest` was overriding every error with `.unauthorized`, causing users to see "Incorrect Email or Password" even when the real cause was a network failure or PIA being blocked
- Backend confirmed the endpoint (`POST /api/client/v5/api_token`) only returns 200 or 401 for credential issues — all other errors are connection-related
- The fix passes errors through as-is; only an actual 401 response produces `.unauthorized`