### PR TITLE
KM-15954 Fix van mapping preventing OpenVPN/TCP from connecting after PIARegions Swift migration

### DIFF
--- a/LocalPackages/PIARegions/Sources/Regions/Models/VpnRegionsResponse.swift
+++ b/LocalPackages/PIARegions/Sources/Regions/Models/VpnRegionsResponse.swift
@@ -48,6 +48,7 @@ public struct VPNRegionsResponse: Codable, Sendable {
         public var longitude: String?
         public var autoRegion: Bool
         public var portForward: Bool
+        public var proxy: [String]?
         public var servers: [String: [ServerDetails]]
 
         enum CodingKeys: String, CodingKey {
@@ -61,6 +62,7 @@ public struct VPNRegionsResponse: Codable, Sendable {
             case longitude
             case autoRegion = "auto_region"
             case portForward = "port_forward"
+            case proxy
             case servers
         }
 
@@ -75,6 +77,7 @@ public struct VPNRegionsResponse: Codable, Sendable {
             longitude: String? = nil,
             autoRegion: Bool = false,
             portForward: Bool = false,
+            proxy: [String]? = nil,
             servers: [String: [ServerDetails]] = [:]
         ) {
             self.id = id
@@ -87,16 +90,26 @@ public struct VPNRegionsResponse: Codable, Sendable {
             self.longitude = longitude
             self.autoRegion = autoRegion
             self.portForward = portForward
+            self.proxy = proxy
             self.servers = servers
         }
 
         public struct ServerDetails: Codable, Sendable {
             public var ip: String
             public var cn: String
+            public var van: Bool
 
-            public init(ip: String = "", cn: String = "") {
+            public init(ip: String = "", cn: String = "", van: Bool = true) {
                 self.ip = ip
                 self.cn = cn
+                self.van = van
+            }
+
+            public init(from decoder: Decoder) throws {
+                let container = try decoder.container(keyedBy: CodingKeys.self)
+                ip = try container.decode(String.self, forKey: .ip)
+                cn = try container.decode(String.self, forKey: .cn)
+                van = (try? container.decode(Bool.self, forKey: .van)) ?? true
             }
         }
     }


### PR DESCRIPTION
## Summary

- `VPNRegionsResponse.ServerDetails` was missing the `van: Bool` field after the KMP → Swift migration of PIARegions (KM-15346)
- Because the app round-trips region data through JSON (encode → decode into internal `Server`), the missing field didn't trigger a build error and was defaulted to false
- `van = false` forced `usesPIAPatches = true` on all OpenVPN connections, causing TCP connections to fail on servers that only support vanilla OpenVPN
- The KMP implementation defaults `van` to `true` when absent from the API payload — this fix replicates that with a custom `init(from decoder:)` using `?? true` fallback
- Also adds the missing `proxy: [String]` field to `Region` to keep the Swift model 1:1 with the KMP model – but this one seem to be legacy and not used anywhere

## Root cause

`PIATunnelProfile.swift` reads `server.bestAddressForOVPN(tcp: true)?.van` to decide whether to set `usesPIAPatches`. With `van` absent from the JSON round-trip, it always resolved to `false`, enabling PIA-patched OpenVPN even for servers that only accept the vanilla protocol on their TCP listener.

## Test plan

- [ ] Connect using OpenVPN + TCP — verify connection succeeds
- [ ] Connect using OpenVPN + UDP — verify no regression
- [ ] Connect using WireGuard and IKEv2 — verify no regression