### PR TITLE
KM-15998: welcome spinner

### DIFF
--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Account/AccountProvider.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Account/AccountProvider.swift
@@ -27,7 +27,7 @@ public protocol AccountProvider: AnyObject {
 
     #if os(iOS) || os(tvOS)
         /// The in-app products required to purchase a `Plan`.
-        var planProducts: [Plan: InAppProduct]? { get }
+        var planProducts: [Plan: any InAppProduct]? { get }
     #endif
 
     /// Returns `true` if accountInfo is nil and loggedIn true.
@@ -181,7 +181,7 @@ public protocol AccountProvider: AnyObject {
 
          - Parameter callback: Returns a map of `Plan`s with the associated `InAppProduct` to purchase.
          */
-        func listPlanProducts(_ callback: LibraryCallback<[Plan: InAppProduct]>?)
+        func listPlanProducts(_ callback: LibraryCallback<[Plan: any InAppProduct]>?)
 
         /**
          Purchases a subscription plan and save purchase to history.

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Account/DefaultAccountProvider.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Account/DefaultAccountProvider.swift
@@ -45,11 +45,11 @@ public final class DefaultAccountProvider: AccountProvider, ConfigurationAccess,
     // MARK: AccountProvider
 
     #if os(iOS) || os(tvOS)
-        public var planProducts: [Plan: InAppProduct]? {
+        public var planProducts: [Plan: any InAppProduct]? {
             guard let products = accessedStore.availableProducts else {
                 return nil
             }
-            var map = [Plan: InAppProduct]()
+            var map = [Plan: any InAppProduct]()
             for product in products {
                 guard let plan = accessedConfiguration.plan(forProductIdentifier: product.identifier) else {
                     continue
@@ -401,7 +401,7 @@ public final class DefaultAccountProvider: AccountProvider, ConfigurationAccess,
             }
         }
 
-        public func listPlanProducts(_ callback: (([Plan: InAppProduct]?, Error?) -> Void)?) {
+        public func listPlanProducts(_ callback: (([Plan: any InAppProduct]?, Error?) -> Void)?) {
             log.debug("Fetching available products...")
 
             if let products = planProducts {
@@ -414,7 +414,7 @@ public final class DefaultAccountProvider: AccountProvider, ConfigurationAccess,
             log.debug("No available products in cache, requesting from store...")
 
             let identifiers = accessedConfiguration.allProductIdentifiers()
-            accessedStore.fetchProducts(identifiers: identifiers) { (products, error) in
+            accessedStore.fetchProducts(identifiers: identifiers) { (_, error) in
                 let products = self.planProducts ?? [:]
                 log.debug("Available products from store: \(products)")
                 Macros.postNotification(.__InAppDidFetchProducts, [.products: products])

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Account/EphemeralAccountProvider.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Account/EphemeralAccountProvider.swift
@@ -20,7 +20,7 @@ final class EphemeralAccountProvider: AccountProvider, ProvidersAccess, InAppAcc
         return accountProvider.webServices
     }
 
-    var planProducts: [Plan: InAppProduct]? {
+    var planProducts: [Plan: any InAppProduct]? {
         return accessedProviders.accountProvider.planProducts
     }
 
@@ -98,7 +98,7 @@ final class EphemeralAccountProvider: AccountProvider, ProvidersAccess, InAppAcc
         log.error("Not implemented")
     }
 
-    func listPlanProducts(_ callback: (([Plan: InAppProduct]?, Error?) -> Void)?) {
+    func listPlanProducts(_ callback: (([Plan: any InAppProduct]?, Error?) -> Void)?) {
         accessedProviders.accountProvider.listPlanProducts(callback)
     }
 

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Client.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Client.swift
@@ -50,9 +50,7 @@ public final class Client {
 
     static var webServices: WebServices = PIAWebServices()
 
-    #if os(iOS) || os(tvOS)
-        public static var store: InAppProvider = AppStoreProvider()
-    #endif
+    public static var store: InAppProvider = AppStoreProvider()
 
     // MARK: Initialization
 

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/InApp/AppStoreProduct.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/InApp/AppStoreProduct.swift
@@ -23,26 +23,27 @@
 import Foundation
 import StoreKit
 
-class AppStoreProduct: InAppProduct {
+final class AppStoreProduct: InAppProduct {
+
     var identifier: String {
-        return nativeProduct.productIdentifier
+        return native.productIdentifier
     }
 
     var price: NSNumber {
-        return nativeProduct.price
+        return native.price
     }
 
     var priceLocale: Locale {
-        return nativeProduct.priceLocale
+        return native.priceLocale
     }
 
-    let native: Any?
+    // TODO: Replace with StoreKit.Product
+    let native: SKProduct
 
-    private var nativeProduct: SKProduct {
-        return native as! SKProduct
-    }
+    let hasIntroOffer: Bool
 
-    init(native: SKProduct) {
+    init(native: SKProduct, hasIntroOffer: Bool) {
         self.native = native
+        self.hasIntroOffer = hasIntroOffer
     }
 }

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/InApp/AppStoreProvider.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/InApp/AppStoreProvider.swift
@@ -25,12 +25,12 @@ import StoreKit
 
 private let log = PIALogger.logger(for: AppStoreProvider.self)
 
-class AppStoreProvider: NSObject, InAppProvider {
+final class AppStoreProvider: NSObject, InAppProvider {
     private var productsRequest: SKProductsRequest?
 
     private var receiptRefreshRequest: SKReceiptRefreshRequest?
 
-    private var productsCallback: LibraryCallback<[InAppProduct]>?
+    private var productsCallback: LibraryCallback<[any InAppProduct]>?
 
     private var purchaseCallback: LibraryCallback<InAppTransaction>?
 
@@ -42,7 +42,7 @@ class AppStoreProvider: NSObject, InAppProvider {
 
     // MARK: InAppProvider
 
-    private(set) var availableProducts: [InAppProduct]?
+    private(set) var availableProducts: [any InAppProduct]?
 
     var paymentReceipt: Data? {
         guard let url = Bundle.main.appStoreReceiptURL else {
@@ -70,7 +70,7 @@ class AppStoreProvider: NSObject, InAppProvider {
         SKPaymentQueue.default().remove(self)
     }
 
-    func fetchProducts(identifiers: [String], _ callback: (([InAppProduct]?, Error?) -> Void)?) {
+    func fetchProducts(identifiers: [String], _ callback: (([any InAppProduct]?, Error?) -> Void)?) {
         guard !identifiers.isEmpty else {
             callback?([], nil)
             return
@@ -85,7 +85,7 @@ class AppStoreProvider: NSObject, InAppProvider {
         productsRequest?.start()
     }
 
-    func purchaseProduct(_ product: InAppProduct, _ callback: ((InAppTransaction?, Error?) -> Void)?) {
+    func purchaseProduct(_ product: any InAppProduct, _ callback: ((InAppTransaction?, Error?) -> Void)?) {
         guard product is AppStoreProduct else {
             log.error("Product must be AppStoreProduct, but got \(type(of: product))")
             callback?(nil, ClientError.productUnavailable)
@@ -156,15 +156,21 @@ extension AppStoreProvider: SKProductsRequestDelegate {
         productsRequest = nil
         log.debug("Retrieved products: \(response.products)")
 
-        var availableProducts = [InAppProduct]()
-        for product in response.products {
-            log.debug("  -> \(product.localizedTitle) @ \(product.price)")
-            availableProducts.append(AppStoreProduct(native: product))
-        }
-        self.availableProducts = availableProducts
+        Task {
+            var hasIntroOffer: Bool?
+            var availableProducts = [any InAppProduct]()
+            for product in response.products {
+                if hasIntroOffer == nil, let groupId = product.subscriptionGroupIdentifier {
+                    hasIntroOffer = await StoreKit.Product.SubscriptionInfo.isEligibleForIntroOffer(for: groupId)
+                }
+                log.debug("  -> \(product.localizedTitle) @ \(product.price)")
+                availableProducts.append(AppStoreProduct(native: product, hasIntroOffer: hasIntroOffer ?? false))
+            }
+            self.availableProducts = availableProducts
 
-        productsCallback?(availableProducts, nil)
-        productsCallback = nil
+            productsCallback?(availableProducts, nil)
+            productsCallback = nil
+        }
     }
 }
 

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/InApp/InAppProduct.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/InApp/InAppProduct.swift
@@ -24,7 +24,8 @@ import Foundation
 import StoreKit
 
 /// Wraps any native implementation of an in-app product by providing a common interface.
-public protocol InAppProduct: AnyObject, CustomStringConvertible {
+public protocol InAppProduct: AnyObject, CustomStringConvertible, Sendable {
+    associatedtype Native: Sendable
 
     /// The product identifier.
     var identifier: String { get }
@@ -36,7 +37,10 @@ public protocol InAppProduct: AnyObject, CustomStringConvertible {
     var priceLocale: Locale { get }
 
     /// The underlying native product implementation.
-    var native: Any? { get }
+    var native: Native { get }
+
+    /// `true` if the user is eligible for an intro offer.
+    var hasIntroOffer: Bool { get }
 }
 
 extension InAppProduct {

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/InApp/InAppProvider.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/InApp/InAppProvider.swift
@@ -23,7 +23,7 @@
 import Foundation
 
 public protocol InAppProvider: AnyObject {
-    var availableProducts: [InAppProduct]? { get }
+    var availableProducts: [any InAppProduct]? { get }
 
     var paymentReceipt: Data? { get }
 
@@ -31,9 +31,9 @@ public protocol InAppProvider: AnyObject {
 
     func stopObservingTransactions()
 
-    func fetchProducts(identifiers: [String], _ callback: LibraryCallback<[InAppProduct]>?)
+    func fetchProducts(identifiers: [String], _ callback: LibraryCallback<[any InAppProduct]>?)
 
-    func purchaseProduct(_ product: InAppProduct, _ callback: LibraryCallback<InAppTransaction>?)
+    func purchaseProduct(_ product: any InAppProduct, _ callback: LibraryCallback<InAppTransaction>?)
 
     func finishTransaction(_ transaction: InAppTransaction, success: Bool)
 

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/InApp/PurchasePlan.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/InApp/PurchasePlan.swift
@@ -22,15 +22,21 @@
 
 import Foundation
 
-public class PurchasePlan: NSObject {
-    private class DummyInAppProduct: InAppProduct {
+public final class PurchasePlan: NSObject {
+    private final class DummyInAppProduct: InAppProduct {
+        enum Native {
+            case none
+        }
+
         let identifier = ""
 
         let price: NSNumber = 0
 
         let priceLocale = Locale.current
 
-        let native: Any? = nil
+        let native: Native = .none
+
+        let hasIntroOffer: Bool = false
     }
 
     private static let formatter: NumberFormatter = {
@@ -55,7 +61,7 @@ public class PurchasePlan: NSObject {
 
     public let plan: Plan
 
-    public let product: InAppProduct
+    public let product: any InAppProduct
 
     public let monthlyFactor: Double
 
@@ -64,8 +70,6 @@ public class PurchasePlan: NSObject {
     public var detail = ""
 
     public var bestValue = false
-
-    public var hasIntroOffer: Bool = false
 
     public var price: NSNumber {
         return product.price
@@ -103,11 +107,10 @@ public class PurchasePlan: NSObject {
         monthlyFactor = 1.0
     }
 
-    public init(plan: Plan, product: InAppProduct, monthlyFactor: Double) async {
+    public init(plan: Plan, product: any InAppProduct, monthlyFactor: Double) {
         precondition(monthlyFactor > 0.0)
         self.plan = plan
         self.product = product
-        self.hasIntroOffer = await product.isEligibleForIntroOffer()
         self.monthlyFactor = monthlyFactor
     }
 

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Mock/MockAccountProvider.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Mock/MockAccountProvider.swift
@@ -157,7 +157,7 @@ public final class MockAccountProvider: AccountProvider, WebServicesConsumer {
 
     #if os(iOS) || os(tvOS)
         /// :nodoc:
-        public var planProducts: [Plan: InAppProduct]? {
+        public var planProducts: [Plan: any InAppProduct]? {
             return delegate.planProducts
         }
     #endif
@@ -281,7 +281,7 @@ public final class MockAccountProvider: AccountProvider, WebServicesConsumer {
 
     #if os(iOS) || os(tvOS)
         /// :nodoc:
-        public func listPlanProducts(_ callback: (([Plan: InAppProduct]?, Error?) -> Void)?) {
+        public func listPlanProducts(_ callback: (([Plan: any InAppProduct]?, Error?) -> Void)?) {
             delegate.listPlanProducts(callback)
         }
 

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Mock/MockInAppProvider.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Mock/MockInAppProvider.swift
@@ -24,13 +24,17 @@ import Foundation
 
 #if os(iOS) || os(tvOS)
     private final class MockProduct: InAppProduct {
+        enum Native { case none }
+
         let identifier: String
 
         let price: NSNumber
 
         let priceLocale = Locale.current
 
-        let native: Any? = nil
+        let native: Native = .none
+
+        var hasIntroOffer: Bool { false }
 
         init(_ identifier: String, _ price: NSNumber) {
             self.identifier = identifier
@@ -49,7 +53,7 @@ import Foundation
         init(with receipt: Data? = Data()) {
             self.paymentReceipt = receipt
         }
-        var availableProducts: [InAppProduct]?
+        var availableProducts: [any InAppProduct]?
 
         var paymentReceipt: Data?
 
@@ -59,7 +63,7 @@ import Foundation
         func stopObservingTransactions() {
         }
 
-        func fetchProducts(identifiers: [String], _ callback: (([InAppProduct]?, Error?) -> Void)?) {
+        func fetchProducts(identifiers: [String], _ callback: (([any InAppProduct]?, Error?) -> Void)?) {
             availableProducts = []
             for (i, identifier) in accessedConfiguration.allProductIdentifiers().enumerated() {
                 let price = (Double(i + 1) * 50.0) as NSNumber
@@ -73,7 +77,7 @@ import Foundation
                 ])
         }
 
-        func purchaseProduct(_ product: InAppProduct, _ callback: ((InAppTransaction?, Error?) -> Void)?) {
+        func purchaseProduct(_ product: any InAppProduct, _ callback: ((InAppTransaction?, Error?) -> Void)?) {
             callback?(MockTransaction(), nil)
         }
 

--- a/LocalPackages/PIAUI/Sources/PIAUIKit/Button/PIAButton.swift
+++ b/LocalPackages/PIAUI/Sources/PIAUIKit/Button/PIAButton.swift
@@ -60,7 +60,11 @@ public final class PIAButton: UIButton {
     }
 
     public var isLoading: Bool = false {
-        didSet { reloadButtonIsLoading(oldValue: oldValue) }
+        didSet {
+            DispatchQueue.main.async { [weak self] in
+                self?.reloadButtonIsLoading(oldValue: oldValue)
+            }
+        }
     }
 
     override init(frame: CGRect) {

--- a/PIA VPN-tvOSTests/Login/Helpers/Stubs+PIALibrary.swift
+++ b/PIA VPN-tvOSTests/Login/Helpers/Stubs+PIALibrary.swift
@@ -91,14 +91,14 @@ extension InAppProductMock {
                 identifier: "001",
                 price: 10.99,
                 priceLocale: .current,
-                native: nil,
+                native: .none,
                 description: "monthly"
             ),
             Plan.yearly: InAppProductMock(
                 identifier: "002",
                 price: 100.99,
                 priceLocale: .current,
-                native: nil,
+                native: .none,
                 description: "yearly"
             )
         ]
@@ -113,7 +113,7 @@ extension SubscriptionProduct {
                     identifier: "001",
                     price: 10.99,
                     priceLocale: .current,
-                    native: nil,
+                    native: .none,
                     description: "monthly"
                 ),
                 type: .monthly
@@ -123,7 +123,7 @@ extension SubscriptionProduct {
                     identifier: "002",
                     price: 100.99,
                     priceLocale: .current,
-                    native: nil,
+                    native: .none,
                     description: "yearly"
                 ),
                 type: .yearly

--- a/PIA VPN-tvOSTests/Signup/Data/DecoratorProductsProviderTests.swift
+++ b/PIA VPN-tvOSTests/Signup/Data/DecoratorProductsProviderTests.swift
@@ -104,7 +104,7 @@ final class DecoratorProductsProviderTests: XCTestCase {
             productsProviderResult: (productsStub, error),
             subscriptionInformationProviderResult: subscriptionInformationProviderResult)
 
-        var capturedProducts: [Plan: InAppProduct]?
+        var capturedProducts: [Plan: any InAppProduct]?
         var capturedError: Error?
         let expectation = expectation(description: "Waiting for listPlanProducts to finish")
 
@@ -123,13 +123,13 @@ final class DecoratorProductsProviderTests: XCTestCase {
         XCTAssertEqual(capturedProducts?[.monthly]?.price, productsStub[.monthly]?.price)
         XCTAssertEqual(capturedProducts?[.monthly]?.priceLocale, productsStub[.monthly]?.priceLocale)
         XCTAssertEqual(capturedProducts?[.monthly]?.description, productsStub[.monthly]?.description)
-        XCTAssertNil(capturedProducts?[.monthly]?.native)
+        XCTAssertEqual(capturedProducts?[.monthly]?.native as! InAppProductMock.Native, productsStub[.monthly]?.native)
 
         XCTAssertEqual(capturedProducts?[.yearly]?.identifier, productsStub[.yearly]?.identifier)
         XCTAssertEqual(capturedProducts?[.yearly]?.price, productsStub[.yearly]?.price)
         XCTAssertEqual(capturedProducts?[.yearly]?.priceLocale, productsStub[.yearly]?.priceLocale)
         XCTAssertEqual(capturedProducts?[.yearly]?.description, productsStub[.yearly]?.description)
-        XCTAssertNil(capturedProducts?[.yearly]?.native)
+        XCTAssertEqual(capturedProducts?[.yearly]?.native as! InAppProductMock.Native, productsStub[.yearly]?.native)
     }
 
     func test_listPlanProducts_complets_with_error_when_decoratee_complets_with_error() throws {

--- a/PIA VPN-tvOSTests/Signup/Domain/GetAvailableProductsUseCaseTests.swift
+++ b/PIA VPN-tvOSTests/Signup/Domain/GetAvailableProductsUseCaseTests.swift
@@ -43,25 +43,25 @@ final class GetAvailableProductsUseCaseTests: XCTestCase {
 
         // THEN getAllProducts returns the provided mohtly and yearly products
         XCTAssertEqual(result.count, stub.count)
-        let monthlyProduct: InAppProduct = result[0].type == .monthly ? result[0].product : result[1].product
-        let yearlyProduct: InAppProduct = result[1].type == .yearly ? result[1].product : result[0].product
+        let monthlyProduct: any InAppProduct = result[0].type == .monthly ? result[0].product : result[1].product
+        let yearlyProduct: any InAppProduct = result[1].type == .yearly ? result[1].product : result[0].product
 
         XCTAssertEqual(monthlyProduct.identifier, stub[.monthly]?.identifier)
         XCTAssertEqual(monthlyProduct.price, stub[.monthly]?.price)
         XCTAssertEqual(monthlyProduct.priceLocale, stub[.monthly]?.priceLocale)
         XCTAssertEqual(monthlyProduct.description, stub[.monthly]?.description)
-        XCTAssertNil(monthlyProduct.native)
+        XCTAssertEqual(monthlyProduct.native as! InAppProductMock.Native, stub[.monthly]?.native)
 
         XCTAssertEqual(yearlyProduct.identifier, stub[.yearly]?.identifier)
         XCTAssertEqual(yearlyProduct.price, stub[.yearly]?.price)
         XCTAssertEqual(yearlyProduct.priceLocale, stub[.yearly]?.priceLocale)
         XCTAssertEqual(yearlyProduct.description, stub[.yearly]?.description)
-        XCTAssertNil(yearlyProduct.native)
+        XCTAssertEqual(yearlyProduct.native as! InAppProductMock.Native, stub[.yearly]?.native)
     }
 
     func test_getAllProducts_throws_error_when_productsProvider_returns_an_error() async throws {
         // GIVEN productsProvider completes completes with an error
-        let stub: [Plan: InAppProduct]? = nil
+        let stub: [Plan: any InAppProduct]? = nil
         let error = NSError(domain: "any error", code: 0)
         instantiateSut(productsProviderResult: (stub, error))
 

--- a/PIA VPN-tvOSTests/Signup/Mocks/InAppProductMock.swift
+++ b/PIA VPN-tvOSTests/Signup/Mocks/InAppProductMock.swift
@@ -9,14 +9,17 @@
 import Foundation
 import PIALibrary
 
-class InAppProductMock: InAppProduct {
+final class InAppProductMock: InAppProduct {
+    enum Native: Sendable { case none }
+
     let identifier: String
     let price: NSNumber
     let priceLocale: Locale
-    let native: Any?
-    var description: String
+    let native: Native
+    let hasIntroOffer: Bool = false
+    let description: String
 
-    init(identifier: String, price: NSNumber, priceLocale: Locale, native: Any?, description: String) {
+    init(identifier: String, price: NSNumber, priceLocale: Locale, native: Native, description: String) {
         self.identifier = identifier
         self.price = price
         self.priceLocale = priceLocale

--- a/PIA VPN/UI/Autolayout/AutolayoutViewController.swift
+++ b/PIA VPN/UI/Autolayout/AutolayoutViewController.swift
@@ -44,7 +44,8 @@ public protocol ModalController: AnyObject {
     func dismissModal(completion: (() -> Void)?)
 }
 
-public protocol AnimatingLoadingDelegate: AnyObject {
+protocol AnimatingLoadingDelegate: AnyObject {
+    var mainLoadingButton: PIAButton? { get }
     func showLoadingAnimation()
     func hideLoadingAnimation()
 }
@@ -79,6 +80,8 @@ open class AutolayoutViewController: UIViewController, ModalController, Restylab
 
     /// Loading view controller for showing animations
     private var loadingViewController: LoadingViewController?
+
+    var mainLoadingButton: PIAButton? { nil }
 
     deinit {
         NotificationCenter.default.removeObserver(self)
@@ -233,6 +236,11 @@ open class AutolayoutViewController: UIViewController, ModalController, Restylab
 extension AutolayoutViewController: AnimatingLoadingDelegate {
 
     @objc public func showLoadingAnimation() {
+        if let mainLoadingButton {
+            mainLoadingButton.isLoading = true
+            return
+        }
+
         // If already showing, keep it
         guard loadingViewController == nil else { return }
 
@@ -259,6 +267,13 @@ extension AutolayoutViewController: AnimatingLoadingDelegate {
     }
 
     @objc public func hideLoadingAnimation() {
+        if let mainLoadingButton {
+            mainLoadingButton.isLoading = false
+            // we fall through on purpose
+        }
+
+        guard loadingViewController != nil else { return }
+
         // Unlock UI
         let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene
         let window = windowScene?.windows.first

--- a/PIA VPN/UI/GetStartedViewController.swift
+++ b/PIA VPN/UI/GetStartedViewController.swift
@@ -55,6 +55,7 @@ final class GetStartedViewController: PIAWelcomeViewController {
 
     @IBOutlet private weak var collectionPlans: UICollectionView!
     @IBOutlet private weak var subscribeNowButton: PIAButton!
+    override var mainLoadingButton: PIAButton? { subscribeNowButton }
     @IBOutlet private weak var loginButton: PIAButton!
     @IBOutlet private weak var restorePurchaseButton: UIButton!
     @IBOutlet private weak var textAgreement: UITextView!
@@ -121,9 +122,8 @@ final class GetStartedViewController: PIAWelcomeViewController {
     // MARK: Actions
 
     @IBAction func confirmPlan() {
-        if selectedPlanIndex < plans.count {
-            let plan = plans[selectedPlanIndex]
-            self.startPurchaseProcessWithEmail("", andPlan: plan)
+        if let plan = plans[safeAt: selectedPlanIndex] {
+            startPurchaseProcessWithEmail("", andPlan: plan)
         }
     }
 
@@ -171,14 +171,12 @@ final class GetStartedViewController: PIAWelcomeViewController {
         andPlan plan: PurchasePlan
     ) {
         isPurchasing = true
-        disableInteractions()
-        self.showLoadingAnimation()
+        self.handleLoadingState()
 
         config.accountProvider.purchase(plan: plan.plan) { [weak self] transaction, error in
             guard let self else { return }
             self.isPurchasing = false
-            self.enableInteractions()
-            self.hideLoadingAnimation()
+            self.handleLoadingState()
 
             guard let transaction = transaction else {
                 if let error = error {
@@ -252,42 +250,24 @@ final class GetStartedViewController: PIAWelcomeViewController {
     }
 
     public func handleInitialStatus() {
-        if config.accountProvider.planProducts != nil {
-            isFetchingProducts = false
-        }
-
-        if !isFetchingProducts {
-            self.handleVisibilityOfVIews()
-        }
+        isFetchingProducts = config.accountProvider.planProducts == nil
     }
 
     // MARK: Notifications
 
     @objc private func productsDidFetch(notification: Notification) {
+        let products: [Plan: any InAppProduct] = notification.userInfo(for: .products)
+        refreshPlans(products)
+
         isFetchingProducts = false
-        let products: [Plan: InAppProduct] = notification.userInfo(for: .products)
-        DispatchQueue.main.async {
-            self.handleVisibilityOfVIews()
-            Task { [weak self] in
-                await self?.refreshPlans(products)
-            }
-            self.enableInteractions()
-        }
+        handleLoadingState()
     }
 
-    private func handleVisibilityOfVIews() {
-        if !isFetchingProducts {
-            if !isPurchasing {
-                self.hideLoadingAnimation()
-            }
-
-            DispatchQueue.main.async {
-                if let products = self.config.accountProvider.planProducts {
-                    Task { [weak self] in
-                        await self?.refreshPlans(products)
-                    }
-                }
-            }
+    private func handleLoadingState() {
+        if isFetchingProducts || isPurchasing {
+            showLoadingAnimation()
+        } else {
+            hideLoadingAnimation()
         }
     }
 
@@ -297,12 +277,9 @@ final class GetStartedViewController: PIAWelcomeViewController {
         setupNavigationBarButtons()
 
         if let products = config.accountProvider.planProducts {
-            Task { [weak self] in
-                await self?.refreshPlans(products)
-            }
+            refreshPlans(products)
         } else {
             showLoadingAnimation()
-            disableInteractions()
         }
     }
 
@@ -329,16 +306,6 @@ final class GetStartedViewController: PIAWelcomeViewController {
     }
 
     // MARK: Helpers
-
-    private func disableInteractions() {
-        self.subscribeNowButton.isEnabled = false
-    }
-
-    private func enableInteractions() {
-        if !isPurchasing {
-            self.subscribeNowButton.isEnabled = true
-        }
-    }
 
     public func navigateToLoginView() {
         self.performSegue(
@@ -371,9 +338,11 @@ final class GetStartedViewController: PIAWelcomeViewController {
     }
 
     // MARK: InApp refresh plan
-    private func refreshPlans(_ plans: [Plan: InAppProduct]) async {
+
+    @MainActor
+    private func refreshPlans(_ plans: [Plan: any InAppProduct]) {
         if let yearly = plans[.yearly] {
-            let purchase = await PurchasePlan(
+            let purchase = PurchasePlan(
                 plan: .yearly,
                 product: yearly,
                 monthlyFactor: 12.0
@@ -389,7 +358,7 @@ final class GetStartedViewController: PIAWelcomeViewController {
             DispatchQueue.main.async { [weak self] in
                 if let label = self?.walkthroughDescription {
                     label.text =
-                        if purchase.hasIntroOffer {
+                        if purchase.product.hasIntroOffer {
                             L10n.Signup.Walkthrough.Page._2.description
                                 + "\n"
                                 + L10n.Signup.Purchase.Trials.intro
@@ -418,7 +387,7 @@ final class GetStartedViewController: PIAWelcomeViewController {
         }
 
         if let monthly = plans[.monthly] {
-            let purchase = await PurchasePlan(
+            let purchase = PurchasePlan(
                 plan: .monthly,
                 product: monthly,
                 monthlyFactor: 1.0
@@ -429,12 +398,13 @@ final class GetStartedViewController: PIAWelcomeViewController {
             self.plans[1] = purchase
         }
 
-        collectionPlans.isUserInteractionEnabled = true
-        collectionPlans.reloadData()
-        collectionPlans.selectItem(at: IndexPath(row: selectedPlanIndex, section: 0), animated: false, scrollPosition: [])
-
+        DispatchQueue.main.async { [weak collectionPlans, selectedPlanIndex] in
+            guard let collectionPlans else { return }
+            collectionPlans.isUserInteractionEnabled = true
+            collectionPlans.reloadData()
+            collectionPlans.selectItem(at: IndexPath(row: selectedPlanIndex, section: 0), animated: false, scrollPosition: [])
+        }
     }
-
 }
 
 extension GetStartedViewController: UICollectionViewDataSource, UICollectionViewDelegate {

--- a/PIA VPN/UI/LoginViewController.swift
+++ b/PIA VPN/UI/LoginViewController.swift
@@ -51,6 +51,7 @@ final class LoginViewController: AutolayoutViewController, PIAWelcomeViewControl
     @IBOutlet private weak var textPassword: BorderedTextField!
 
     @IBOutlet private weak var buttonLogin: PIAButton!
+    override var mainLoadingButton: PIAButton? { buttonLogin }
 
     @IBOutlet private weak var couldNotGetPlanButton: UIButton!
 
@@ -455,16 +456,6 @@ final class LoginViewController: AutolayoutViewController, PIAWelcomeViewControl
 
     func welcomeController(_ welcomeController: PIAWelcomeViewController, didLoginWith user: UserAccount, topViewController: UIViewController) {
         config.completionDelegate?.welcomeDidLogin(withUser: user, topViewController: topViewController)
-    }
-
-    override func showLoadingAnimation() {
-        // Don't call parent class
-        buttonLogin.isLoading = true
-    }
-
-    override func hideLoadingAnimation() {
-        // Don't call parent class
-        buttonLogin.isLoading = false
     }
 }
 

--- a/PIA VPN/UI/PurchasePlanCell.swift
+++ b/PIA VPN/UI/PurchasePlanCell.swift
@@ -66,11 +66,11 @@ final class PurchasePlanCell: UICollectionViewCell, Restylable {
         log.debug(
             #function,
             metadata: [
-                "isEligibleForIntroOffer": .stringConvertible(plan.hasIntroOffer),
+                "isEligibleForIntroOffer": .stringConvertible(plan.product.hasIntroOffer),
                 "eligibleForTrial": .stringConvertible(Client.configuration.eligibleForTrial),
                 "plan": .stringConvertible(plan)
             ])
-        let showFreeTrialLabel = plan.hasIntroOffer && Client.configuration.eligibleForTrial
+        let showFreeTrialLabel = plan.product.hasIntroOffer && Client.configuration.eligibleForTrial
         labelBestValue.text =
             showFreeTrialLabel
             ? "\(L10n.Welcome.Plan.bestValue.uppercased()) - FREE TRIAL"

--- a/PIA VPN/UI/PurchaseViewController.swift
+++ b/PIA VPN/UI/PurchaseViewController.swift
@@ -109,9 +109,7 @@ final class PurchaseViewController: AutolayoutViewController, BrandableNavigatio
         super.viewWillAppear(animated)
 
         if let products = config.accountProvider.planProducts {
-            Task { [weak self] in
-                await self?.refreshPlans(products)
-            }
+            refreshPlans(products)
         } else {
             disableInteractions(fully: false)
         }
@@ -198,9 +196,9 @@ final class PurchaseViewController: AutolayoutViewController, BrandableNavigatio
 
     }
 
-    private func refreshPlans(_ plans: [Plan: InAppProduct]) async {
+    private func refreshPlans(_ plans: [Plan: any InAppProduct]) {
         if let yearly = plans[.yearly] {
-            let purchase = await PurchasePlan(
+            let purchase = PurchasePlan(
                 plan: .yearly,
                 product: yearly,
                 monthlyFactor: 12.0
@@ -220,10 +218,9 @@ final class PurchaseViewController: AutolayoutViewController, BrandableNavigatio
                 privacy: L10n.Welcome.Agreement.Message.privacy,
                 privacyUrl: Client.configuration.privacyUrl
             )
-
         }
         if let monthly = plans[.monthly] {
-            let purchase = await PurchasePlan(
+            let purchase = PurchasePlan(
                 plan: .monthly,
                 product: monthly,
                 monthlyFactor: 1.0
@@ -234,9 +231,12 @@ final class PurchaseViewController: AutolayoutViewController, BrandableNavigatio
             allPlans[1] = purchase
         }
 
-        collectionPlans.isUserInteractionEnabled = true
-        collectionPlans.reloadData()
-        collectionPlans.selectItem(at: IndexPath(row: selectedPlanIndex, section: 0), animated: false, scrollPosition: [])
+        DispatchQueue.main.async { [weak collectionPlans, selectedPlanIndex] in
+            guard let collectionPlans else { return }
+            collectionPlans.isUserInteractionEnabled = true
+            collectionPlans.reloadData()
+            collectionPlans.selectItem(at: IndexPath(row: selectedPlanIndex, section: 0), animated: false, scrollPosition: [])
+        }
     }
 
     private func disableInteractions(fully: Bool) {
@@ -262,10 +262,8 @@ final class PurchaseViewController: AutolayoutViewController, BrandableNavigatio
     // MARK: Notifications
 
     @objc private func productsDidFetch(notification: Notification) {
-        let products: [Plan: InAppProduct] = notification.userInfo(for: .products)
-        Task { [weak self] in
-            await self?.refreshPlans(products)
-        }
+        let products: [Plan: any InAppProduct] = notification.userInfo(for: .products)
+        refreshPlans(products)
         enableInteractions()
     }
 


### PR DESCRIPTION
- Rework loading states in `GetStartedViewController`.
- Add the spinner to the subscribe button, instead of blocking the whole UI.
- Calculate `hasIntroOffer` just once, reducing wait time.
- Make `InAppProduct` sendable and type safe.