### PR TITLE
KM-16547: keep reconnecting when no internet

### DIFF
--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Client+Daemons.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Client+Daemons.swift
@@ -33,11 +33,6 @@ extension Client {
             return accessedDatabase.transient.isNetworkReachable
         }
 
-        /// It's `true` when the Internet is reachable.
-        public var isInternetReachable: Bool {
-            return accessedDatabase.transient.isInternetReachable
-        }
-
         /// The public IP address while not on VPN.
         public var publicIP: String? {
             return accessedDatabase.plain.publicIP

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Daemons/ConnectivityDaemon.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Daemons/ConnectivityDaemon.swift
@@ -72,8 +72,9 @@ final class ConnectivityDaemon: Daemon, ConfigurationAccess, DatabaseAccess, Pre
         accessedDatabase.transient.isNetworkReachable = (reachability.connection != .unavailable)
         log.debug("Initial network state is \(accessedDatabase.transient.isNetworkReachable ? "REACHABLE" : "NOT REACHABLE")")
 
-        reachability.whenReachable = { (reach) in
+        reachability.whenReachable = { [weak self] reach in
             DispatchQueue.main.async {
+                guard let self else { return }
                 guard !self.accessedDatabase.transient.isNetworkReachable else {
                     if (self.accessedDatabase.transient.vpnStatus != .connected) {
                         self.checkConnectivityOrRetry()
@@ -85,8 +86,9 @@ final class ConnectivityDaemon: Daemon, ConfigurationAccess, DatabaseAccess, Pre
                 Macros.postNotification(.ConnectivityDaemonDidGetReachable)
             }
         }
-        reachability.whenUnreachable = { (reach) in
+        reachability.whenUnreachable = { [weak self] reach in
             DispatchQueue.main.async {
+                guard let self else { return }
                 guard self.accessedDatabase.transient.isNetworkReachable else {
                     return
                 }

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Daemons/ConnectivityDaemon.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Daemons/ConnectivityDaemon.swift
@@ -128,7 +128,7 @@ final class ConnectivityDaemon: Daemon, ConfigurationAccess, DatabaseAccess, Pre
                 guard (self.failedConnectivityAttempts < self.accessedConfiguration.connectivityMaxAttempts) else {
                     log.debug("Giving up, network is unreachable")
                     self.failedConnectivityAttempts = 0
-                    self.accessedDatabase.transient.isInternetReachable = false
+                    self.accessedDatabase.transient.isNetworkReachable = false
                     Macros.postNotification(.PIADaemonsDidUpdateConnectivity)
                     return
                 }
@@ -141,7 +141,7 @@ final class ConnectivityDaemon: Daemon, ConfigurationAccess, DatabaseAccess, Pre
 
             case .success(let connectivity):
                 self.failedConnectivityAttempts = 0
-                self.accessedDatabase.transient.isInternetReachable = true
+                self.accessedDatabase.transient.isNetworkReachable = true
                 log.debug("Saving new info about network connectivity: \(connectivity)")
 
                 let ipAddress = connectivity.ipAddress

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Daemons/VPNDaemon.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Daemons/VPNDaemon.swift
@@ -263,9 +263,14 @@ final class VPNDaemon: Daemon, DatabaseAccess, ProvidersAccess {
                 }
             }
 
+            let wholeInternetIsReachable = accessedDatabase.transient.isNetworkReachable
+            if !wholeInternetIsReachable {
+                log.debug("There's no internet!")
+            }
+
             log.debug("[VPNDaemon] connectivityCheckFailed=\(connectivityCheckFailed) previousStatus=\(previousStatus)")
 
-            if connectivityCheckFailed {
+            if connectivityCheckFailed && wholeInternetIsReachable {
                 log.debug("[VPNDaemon] connectivityCheckFailed — marking current server as unavailable and triggering reconnect")
 
                 if let lastConnectedCN = accessedDatabase.plain.lastServerCN {

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Daemons/VPNDaemon.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Daemons/VPNDaemon.swift
@@ -154,12 +154,22 @@ final class VPNDaemon: Daemon, DatabaseAccess, ProvidersAccess {
                     address?.markServerAsUnavailable()
 
                     self.numberOfAttempts += 1
-                    if self.numberOfAttempts < Client.configuration.vpnConnectivityMaxAttempts || self.isReconnectingAfterConnectivityFailure {
+
+                    let shouldKeepTrying =
+                        numberOfAttempts < Client.configuration.vpnConnectivityMaxAttempts
+                        || !accessedDatabase.transient.isNetworkReachable
+                        || isReconnectingAfterConnectivityFailure
+
+                    if shouldKeepTrying {
                         log.debug("NEVPNManager is still connecting. Reconnecting with a different server...")
                         self.updateUIWithAttemptNumber(self.numberOfAttempts)
                         self.isReconnecting = true
-                        Client.providers.vpnProvider.reconnect(after: 0, forceDisconnect: true) { error in
-                            if error != nil {
+                        Client.providers.vpnProvider.reconnect(forceDisconnect: true) { error in
+                            if let clientError = error as? ClientError, clientError == .internetUnreachable {
+                                self.isReconnecting = true
+                                self.isReconnectingAfterConnectivityFailure = true
+
+                            } else if error != nil {
                                 // Reconnect initiation failed — clear flag immediately so the
                                 // subsequent .disconnected status change can clean up normally.
                                 self.isReconnecting = false
@@ -178,7 +188,6 @@ final class VPNDaemon: Daemon, DatabaseAccess, ProvidersAccess {
                         }
                     }
                 }
-
             }
 
         case .disconnecting:
@@ -263,24 +272,21 @@ final class VPNDaemon: Daemon, DatabaseAccess, ProvidersAccess {
                 }
             }
 
-            let wholeInternetIsReachable = accessedDatabase.transient.isNetworkReachable
-            if !wholeInternetIsReachable {
-                log.debug("There's no internet!")
-            }
+            log.debug("connectivityCheckFailed=\(connectivityCheckFailed) previousStatus=\(previousStatus)")
 
-            log.debug("[VPNDaemon] connectivityCheckFailed=\(connectivityCheckFailed) previousStatus=\(previousStatus)")
-
-            if connectivityCheckFailed && wholeInternetIsReachable {
-                log.debug("[VPNDaemon] connectivityCheckFailed — marking current server as unavailable and triggering reconnect")
-
-                if let lastConnectedCN = accessedDatabase.plain.lastServerCN {
+            if connectivityCheckFailed {
+                let wholeInternetIsReachable = accessedDatabase.transient.isNetworkReachable
+                if wholeInternetIsReachable, let lastConnectedCN = accessedDatabase.plain.lastServerCN {
+                    log.debug("connectivityCheckFailed — marking current server as unavailable and triggering reconnect")
                     let targetRegion = try? Client.providers.serverProvider.targetServer
                     let lastConnectedServer = targetRegion?.addresses().first(where: { $0.cn == lastConnectedCN })
                     lastConnectedServer?.markServerAsUnavailable()
+                } else if !wholeInternetIsReachable {
+                    log.debug("There's no internet!")
                 }
 
                 isReconnectingAfterConnectivityFailure = true
-                Client.providers.vpnProvider.reconnect(after: nil, forceDisconnect: true, nil)
+                Client.providers.vpnProvider.reconnect(forceDisconnect: true, nil)
             } else {
                 if previousStatus == .connecting {
                     log.error("The VPN did fail \(lastDisconnectError)")

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Daemons/VPNDaemon.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Daemons/VPNDaemon.swift
@@ -143,52 +143,7 @@ final class VPNDaemon: Daemon, DatabaseAccess, ProvidersAccess {
                 ServiceQualityManager.shared.connectionAttemptEvent()
             }
 
-            if fallbackTimer == nil {
-                log.debug("Setting up fallbackTimer...")
-
-                fallbackTimer = Timer.scheduledTimer(withTimeInterval: Client.configuration.vpnConnectivityRetryDelay, repeats: true) { [weak self] timer in
-                    guard let self else { return }
-                    log.debug("Executing fallbackTimer...")
-
-                    let address = try? Client.providers.serverProvider.targetServer.bestAddress()
-                    address?.markServerAsUnavailable()
-
-                    self.numberOfAttempts += 1
-
-                    let shouldKeepTrying =
-                        numberOfAttempts < Client.configuration.vpnConnectivityMaxAttempts
-                        || !accessedDatabase.transient.isNetworkReachable
-                        || isReconnectingAfterConnectivityFailure
-
-                    if shouldKeepTrying {
-                        log.debug("NEVPNManager is still connecting. Reconnecting with a different server...")
-                        self.updateUIWithAttemptNumber(self.numberOfAttempts)
-                        self.isReconnecting = true
-                        Client.providers.vpnProvider.reconnect(forceDisconnect: true) { error in
-                            if let clientError = error as? ClientError, clientError == .internetUnreachable {
-                                self.isReconnecting = true
-                                self.isReconnectingAfterConnectivityFailure = true
-
-                            } else if error != nil {
-                                // Reconnect initiation failed — clear flag immediately so the
-                                // subsequent .disconnected status change can clean up normally.
-                                self.isReconnecting = false
-                            }
-                            // On success: leave isReconnecting=true. It will be cleared in
-                            // tryUpdateStatus when .connecting status arrives, ensuring that
-                            // the intermediate .disconnecting → .disconnected transitions do
-                            // not briefly expose vpnStatus = .disconnected to the rest of the app.
-                        }
-                    } else {
-                        log.debug("Max number of VPN reconnections. Disconnecting...")
-                        Client.providers.vpnProvider.disconnect { error in
-                            Macros.postNotification(.PIAVPNDidFail)
-                            self.reset()
-                            self.invalidateTimer()
-                        }
-                    }
-                }
-            }
+            scheduleFallbackTimerIfNeeded()
 
         case .disconnecting:
             nextStatus = .disconnecting
@@ -202,7 +157,31 @@ final class VPNDaemon: Daemon, DatabaseAccess, ProvidersAccess {
                 return
             }
 
-            if !isReconnecting {
+            // No internet while a connection was already in progress: keep trying
+            // indefinitely instead of giving up. Reaching this point means the previous
+            // status was not .disconnected, so a connection attempt (or an established
+            // connection) was underway. Force the status back to .connecting and keep
+            // the fallback timer alive — recreating it if it was already invalidated —
+            // so we reconnect as soon as the network becomes reachable again.
+            // Skipped when the user disconnected manually.
+            if !accessedDatabase.transient.isNetworkReachable,
+                !Client.configuration.disconnectedManually
+            {
+                log.debug("No internet while connecting — staying in .connecting and keeping the retry timer alive")
+                isReconnecting = true
+                scheduleFallbackTimerIfNeeded()
+
+                accessedDatabase.plain.lastKnownVpnStatus = .connecting
+                if previousStatus != .connecting {
+                    accessedDatabase.transient.vpnStatus = .connecting
+                }
+                return
+            }
+
+            // A manual disconnect must always tear down the retry loop, even mid-reconnect
+            // (isReconnecting == true), otherwise the fallback timer would keep firing and
+            // force the status back to .connecting after the user asked to disconnect.
+            if !isReconnecting || Client.configuration.disconnectedManually {
                 invalidateTimer()
                 reset()
             }
@@ -295,6 +274,61 @@ final class VPNDaemon: Daemon, DatabaseAccess, ProvidersAccess {
             }
         } else {
             log.debug("[VPNDaemon] fetchLastDisconnectError — no error reported (clean disconnect)")
+        }
+    }
+
+    // MARK: Fallback timer
+
+    /// Schedules the repeating reconnection timer if it is not already running.
+    /// The timer fires every `vpnConnectivityRetryDelay` seconds, marking the current
+    /// server as unavailable and attempting a reconnect. It keeps retrying while there
+    /// are attempts left, while there is no internet, or while recovering from a
+    /// connectivity failure; otherwise it gives up and disconnects.
+    private func scheduleFallbackTimerIfNeeded() {
+        guard fallbackTimer == nil else { return }
+        log.debug("Setting up fallbackTimer...")
+
+        fallbackTimer = Timer.scheduledTimer(withTimeInterval: Client.configuration.vpnConnectivityRetryDelay, repeats: true) { [weak self] timer in
+            guard let self else { return }
+            log.debug("Executing fallbackTimer...")
+
+            let address = try? Client.providers.serverProvider.targetServer.bestAddress()
+            address?.markServerAsUnavailable()
+
+            self.numberOfAttempts += 1
+
+            let shouldKeepTrying =
+                numberOfAttempts < Client.configuration.vpnConnectivityMaxAttempts
+                || !accessedDatabase.transient.isNetworkReachable
+                || isReconnectingAfterConnectivityFailure
+
+            if shouldKeepTrying {
+                log.debug("NEVPNManager is still connecting. Reconnecting with a different server...")
+                self.updateUIWithAttemptNumber(self.numberOfAttempts)
+                self.isReconnecting = true
+                Client.providers.vpnProvider.reconnect(forceDisconnect: true) { error in
+                    if let clientError = error as? ClientError, clientError == .internetUnreachable {
+                        self.isReconnecting = true
+                        self.isReconnectingAfterConnectivityFailure = true
+
+                    } else if error != nil {
+                        // Reconnect initiation failed — clear flag immediately so the
+                        // subsequent .disconnected status change can clean up normally.
+                        self.isReconnecting = false
+                    }
+                    // On success: leave isReconnecting=true. It will be cleared in
+                    // tryUpdateStatus when .connecting status arrives, ensuring that
+                    // the intermediate .disconnecting → .disconnected transitions do
+                    // not briefly expose vpnStatus = .disconnected to the rest of the app.
+                }
+            } else {
+                log.debug("Max number of VPN reconnections. Disconnecting...")
+                Client.providers.vpnProvider.disconnect { error in
+                    Macros.postNotification(.PIAVPNDidFail)
+                    self.reset()
+                    self.invalidateTimer()
+                }
+            }
         }
     }
 

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Mock/MockVPNProvider.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Mock/MockVPNProvider.swift
@@ -111,7 +111,7 @@ public final class MockVPNProvider: VPNProvider, ConfigurationAccess, DatabaseAc
     }
 
     /// :nodoc:
-    public func reconnect(after delay: Int?, forceDisconnect: Bool = false, _ callback: SuccessLibraryCallback?) {
+    public func reconnect(forceDisconnect: Bool = false, _ callback: SuccessLibraryCallback?) {
         let disconnectionDelay: Int
         //        if (vpnStatus == .changingServer) {
         //            disconnectionDelay = 1000
@@ -124,7 +124,7 @@ public final class MockVPNProvider: VPNProvider, ConfigurationAccess, DatabaseAc
             self.vpnStatus = .disconnected
             Macros.postNotification(.PIADaemonsDidUpdateConnectivity)
 
-            Macros.dispatch(after: .milliseconds(delay ?? self.accessedConfiguration.vpnReconnectionDelay)) {
+            Macros.dispatch(after: .milliseconds(self.accessedConfiguration.vpnReconnectionDelay)) {
                 self.vpnStatus = .connected
                 Macros.postNotification(.PIADaemonsDidUpdateConnectivity)
                 callback?(nil)

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Mock/MockVPNProvider.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Mock/MockVPNProvider.swift
@@ -63,7 +63,6 @@ public final class MockVPNProvider: VPNProvider, ConfigurationAccess, DatabaseAc
     /// :nodoc:
     public func prepare() {
         accessedDatabase.transient.isNetworkReachable = true
-        accessedDatabase.transient.isInternetReachable = true
         accessedDatabase.plain.publicIP = mockPublicIP
         accessedDatabase.transient.vpnIP = mockVpnIP
 

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Persistence/MemoryStore.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Persistence/MemoryStore.swift
@@ -61,8 +61,6 @@ final class MemoryStore: TransientStore, ConfigurationAccess {
 
     var isNetworkReachable = false
 
-    var isInternetReachable = true
-
     var vpnIP: String? {
         didSet {
             log.debug("Did set \(#function): \(vpnIP ?? "nil")")

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Persistence/TransientStore.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Persistence/TransientStore.swift
@@ -38,8 +38,6 @@ protocol TransientStore: AnyObject {
 
     var isNetworkReachable: Bool { get set }
 
-    var isInternetReachable: Bool { get set }
-
     /// Currently connected VPN IP, if any.
     /// Implementors should post ``Notification.Name.PIADaemonsDidUpdateConnectivity``
     var vpnIP: String? { get set }

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/VPN/DefaultVPNProvider.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/VPN/DefaultVPNProvider.swift
@@ -235,6 +235,12 @@ public final class DefaultVPNProvider: VPNProvider, ConfigurationAccess, Databas
     }
 
     public func connect(_ callback: SuccessLibraryCallback?) {
+        guard accessedDatabase.transient.isNetworkReachable else {
+            log.warning("Skip connect, internet is unreachable")
+            callback?(ClientError.internetUnreachable)
+            return
+        }
+
         guard accessedProviders.accountProvider.isLoggedIn else {
             callback?(ClientError.unauthorized)
             return
@@ -288,6 +294,12 @@ public final class DefaultVPNProvider: VPNProvider, ConfigurationAccess, Databas
     }
 
     public func reconnect(after delay: Int?, forceDisconnect: Bool = false, _ callback: SuccessLibraryCallback?) {
+        guard accessedDatabase.transient.isNetworkReachable else {
+            log.warning("Skip reconnect, internet is unreachable")
+            callback?(ClientError.internetUnreachable)
+            return
+        }
+
         guard accessedProviders.accountProvider.isLoggedIn else {
             callback?(ClientError.unauthorized)
             return

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/VPN/DefaultVPNProvider.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/VPN/DefaultVPNProvider.swift
@@ -293,7 +293,7 @@ public final class DefaultVPNProvider: VPNProvider, ConfigurationAccess, Databas
         activeProfile.updatePreferences(callback)
     }
 
-    public func reconnect(after delay: Int?, forceDisconnect: Bool = false, _ callback: SuccessLibraryCallback?) {
+    public func reconnect(forceDisconnect: Bool, _ callback: SuccessLibraryCallback?) {
         guard accessedDatabase.transient.isNetworkReachable else {
             log.warning("Skip reconnect, internet is unreachable")
             callback?(ClientError.internetUnreachable)

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/VPN/VPNAction.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/VPN/VPNAction.swift
@@ -51,7 +51,7 @@ final class VPNActionReconnect: VPNAction, ProvidersAccess {
             callback?(nil)
             return
         }
-        vpn.reconnect(after: nil, callback)
+        vpn.reconnect(callback)
     }
 }
 

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/VPN/VPNProvider.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/VPN/VPNProvider.swift
@@ -97,11 +97,10 @@ public protocol VPNProvider: AnyObject {
     /**
      Reconnects to the VPN.
 
-     - Parameter delay: The delay in milliseconds after which the reconnection is issue.
      - Parameter forceDisconnect: Boolean to indicate if we want to disconnect the VPN before reconnect..
      - Parameter callback: Returns `nil` on success.
      */
-    func reconnect(after delay: Int?, forceDisconnect: Bool, _ callback: SuccessLibraryCallback?)
+    func reconnect(forceDisconnect: Bool, _ callback: SuccessLibraryCallback?)
 
     /**
      Submits the debug report containing all relevant information for the current session.
@@ -127,8 +126,8 @@ public protocol VPNProvider: AnyObject {
 }
 
 public extension VPNProvider {
-    func reconnect(after delay: Int?, forceDisconnect: Bool = false, _ callback: SuccessLibraryCallback?) {
-        return reconnect(after: delay, forceDisconnect: forceDisconnect, callback)
+    func reconnect(forceDisconnect: Bool = false, _ callback: SuccessLibraryCallback?) {
+        return reconnect(forceDisconnect: forceDisconnect, callback)
     }
 }
 

--- a/PIA VPN.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/PIA VPN.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -68,8 +68,8 @@
       "kind" : "remoteSourceControl",
       "location" : "git@github.com:pia-foss/mobile-ios-openvpn.git",
       "state" : {
-        "revision" : "dc67b1b60593c37916bf79c940f258f253af87e7",
-        "version" : "2.2.5"
+        "revision" : "f2c8825f61a57ba664971e72c37efd92ebc366c9",
+        "version" : "2.2.6"
       }
     },
     {
@@ -77,8 +77,8 @@
       "kind" : "remoteSourceControl",
       "location" : "git@github.com:pia-foss/mobile-ios-wireguard.git",
       "state" : {
-        "revision" : "a6064cd31f10f35785049fa6dd4693adeb68bf26",
-        "version" : "1.0.4"
+        "revision" : "ad06393c8ae856085efcf2f6a159c7f641f7247a",
+        "version" : "1.0.5"
       }
     },
     {

--- a/PIA VPN/AppDelegate.swift
+++ b/PIA VPN/AppDelegate.swift
@@ -85,8 +85,9 @@ class AppDelegate: NSObject, UIApplicationDelegate {
 
     func applicationWillTerminate(_ application: UIApplication) {
         Bootstrapper.shared.dispose()
-
-        liveActivityManager?.endLiveActivities()
+        Task { [weak self] in
+            await self?.liveActivityManager?.endLiveActivities()
+        }
     }
 
     // MARK: Orientations

--- a/PIA VPN/Bootstrapper.swift
+++ b/PIA VPN/Bootstrapper.swift
@@ -172,10 +172,7 @@ final class Bootstrapper {
                     name: .PIAThemeDidChange,
                     object: self,
                     userInfo: nil)
-                Client.providers.vpnProvider.reconnect(
-                    after: 200, forceDisconnect: true,
-                    { _ in
-                    })
+                Client.providers.vpnProvider.reconnect(forceDisconnect: true, nil)
             }
         #endif
         Client.providers.accountProvider.subscriptionInformation { [weak self] (info, error) in

--- a/PIA VPN/Core/Extensions/ServerProvider+UI.swift
+++ b/PIA VPN/Core/Extensions/ServerProvider+UI.swift
@@ -64,11 +64,11 @@ extension Client.Preferences {
                 // Before reconnecting, notify that the user is changing server
                 Macros.postNotification(.PIAVPNIsChangingServer)
                 if shouldReconnect {
-                    vpn.reconnect(after: nil, forceDisconnect: true, nil)
+                    vpn.reconnect(forceDisconnect: true, nil)
                 }
             default:
                 if shouldReconnect {
-                    vpn.reconnect(after: nil, forceDisconnect: true, nil)
+                    vpn.reconnect(forceDisconnect: true, nil)
                 }
             }
         #endif

--- a/PIA VPN/Core/Utils/PIAHotspotHelper.swift
+++ b/PIA VPN/Core/Utils/PIAHotspotHelper.swift
@@ -151,7 +151,7 @@ class PIAHotspotHelper {
 
                                 if Client.providers.vpnProvider.isVPNConnected {
                                     log.info("HotspotHelper: VPN already connected, reconnecting")
-                                    Client.providers.vpnProvider.reconnect(after: 0, forceDisconnect: true, nil)
+                                    Client.providers.vpnProvider.reconnect(forceDisconnect: true, nil)
                                 } else {
                                     log.info("HotspotHelper: VPN disconnected, connecting")
                                     Client.providers.vpnProvider.connect(nil)

--- a/PIA VPN/UI/Dashboard/DashboardViewController.swift
+++ b/PIA VPN/UI/Dashboard/DashboardViewController.swift
@@ -484,8 +484,11 @@ final class DashboardViewController: AutolayoutViewController {
 
     @objc private func checkVPNConnectingStatus(notification: Notification) {
         if let attempt = notification.object as? Int {
+            let oldStatus = connectingStatus
             connectingStatus = DashboardVPNConnectingStatus(rawValue: attempt) ?? .stillLoading
-            updateCurrentStatus()
+            if connectingStatus != oldStatus {
+                updateCurrentStatus()
+            }
         }
     }
 
@@ -727,10 +730,7 @@ final class DashboardViewController: AutolayoutViewController {
 
             // reconnect -> reconnect VPN and close
             alert.addActionWithTitle(L10n.Settings.Commit.Buttons.reconnect) {
-                Client.providers.vpnProvider.reconnect(
-                    after: nil, forceDisconnect: true,
-                    { error in
-                    })
+                Client.providers.vpnProvider.reconnect(forceDisconnect: true, nil)
             }
 
             // later -> close

--- a/PIA VPN/UI/Dashboard/DashboardViewController.swift
+++ b/PIA VPN/UI/Dashboard/DashboardViewController.swift
@@ -1468,7 +1468,10 @@ extension DashboardViewController {
             let liveActivityManager = appDelegate.liveActivityManager
         else { return }
         let connState = makeLiveActivityStateForCurrentConnection()
-        liveActivityManager.startLiveActivity(with: connState)
+
+        Task {
+            await liveActivityManager.startLiveActivity(with: connState)
+        }
     }
 
     @available(iOS 16.2, *)
@@ -1476,6 +1479,8 @@ extension DashboardViewController {
         guard let appDelegate = UIApplication.shared.delegate as? AppDelegate,
             let liveActivityManager = appDelegate.liveActivityManager
         else { return }
-        liveActivityManager.endLiveActivities()
+        Task {
+            await liveActivityManager.endLiveActivities()
+        }
     }
 }

--- a/PIA VPN/UI/Settings/SettingsViewController.swift
+++ b/PIA VPN/UI/Settings/SettingsViewController.swift
@@ -312,7 +312,7 @@ final class SettingsViewController: AutolayoutViewController, SettingsDelegate {
                 self.pendingVPNAction = nil
 
                 if shouldReconnect && !isDisconnected {
-                    Client.providers.vpnProvider.reconnect(after: nil, forceDisconnect: true) { (error) in
+                    Client.providers.vpnProvider.reconnect(forceDisconnect: true) { _ in
                         completionHandler()
                         self.hideLoadingAnimation()
                     }

--- a/PIAWidget/Domain/Widget/PIAConnectionLiveActivityManager.swift
+++ b/PIAWidget/Domain/Widget/PIAConnectionLiveActivityManager.swift
@@ -1,84 +1,63 @@
 import ActivityKit
 import Foundation
+import PIALibrary
 
-public protocol PIAConnectionLiveActivityManagerType {
-    func startLiveActivity(with state: PIAConnectionAttributes.ContentState)
-    func endLiveActivities()
+public protocol PIAConnectionLiveActivityManagerType: Sendable {
+    func startLiveActivity(with state: PIAConnectionAttributes.ContentState) async
+    func endLiveActivities() async
 }
 
 @available(iOS 16.2, *)
-public final class PIAConnectionLiveActivityManager: PIAConnectionLiveActivityManagerType {
+private let log = PIALogger.logger(for: PIAConnectionLiveActivityManager.self)
 
-    private var activity: Activity<PIAConnectionAttributes>?
-    private var currentActivityPriority = 0
+@available(iOS 16.2, *)
+public final actor PIAConnectionLiveActivityManager: PIAConnectionLiveActivityManagerType {
+    private typealias Activity = ActivityKit.Activity<PIAConnectionAttributes>
+    public typealias State = PIAConnectionAttributes.ContentState
 
     static let shared = PIAConnectionLiveActivityManager()
-
     private init() {}
 
-    deinit {
-        endLiveActivities()
-    }
-
-    public func startLiveActivity(with state: PIAConnectionAttributes.ContentState) {
-        guard activity == nil else {
-            updateLiveActivity(with: state)
-            return
+    public func startLiveActivity(with state: State) async {
+        if let activity = Activity.activities.first(where: { $0.activityState == .active }) {
+            await updateLiveActivity(activity: activity, with: state)
+        } else {
+            await createNewLiveActivity(with: state)
         }
-
-        createNewLiveActivity(with: state)
-
     }
 
-    public func endLiveActivities() {
-        let currentActivities = Activity<PIAConnectionAttributes>.activities
-
+    public func endLiveActivities() async {
+        let currentActivities = Activity.activities
         guard !currentActivities.isEmpty else { return }
-
-        let semaphore = DispatchSemaphore(value: 0)
-
-        Task {
+        await withTaskGroup(of: Void.self) { group in
             for act in currentActivities {
-                await act.end(dismissalPolicy: .immediate)
-
-                semaphore.signal()
+                group.addTask {
+                    await act.end(dismissalPolicy: .immediate)
+                }
             }
         }
-        semaphore.wait()
-
     }
 
-    public func endPreviousActivities() {
-        let currentActivities = Activity<PIAConnectionAttributes>.activities
-        for act in currentActivities {
-            Task {
-                await act.end(dismissalPolicy: .immediate)
-            }
-        }
-        activity = nil
-    }
-
-    private func createNewLiveActivity(with state: PIAConnectionAttributes.ContentState) {
+    private func createNewLiveActivity(with state: PIAConnectionAttributes.ContentState) async {
         // Clear all the Live Activities before starting a new one
-        endPreviousActivities()
+        await endLiveActivities()
 
         let attributes = PIAConnectionAttributes()
-
-        activity = try? Activity<PIAConnectionAttributes>.request(attributes: attributes, contentState: state, pushType: nil)
+        do {
+            _ = try Activity.request(attributes: attributes, contentState: state, pushType: nil)
+        } catch {
+            log.error("Unable to create live activity: \(error.localizedDescription)")
+        }
     }
 
-    private func updateLiveActivity(with state: PIAConnectionAttributes.ContentState) {
-        guard activity?.activityState == .active else {
-            createNewLiveActivity(with: state)
+    private func updateLiveActivity(activity: Activity, with state: PIAConnectionAttributes.ContentState) async {
+        guard activity.activityState == .active else {
+            await createNewLiveActivity(with: state)
             return
         }
+
         // Only update the live activity if there is new content
-        guard state != activity?.content.state else { return }
-
-        Task {
-            await activity?.update(using: state)
-        }
-
+        guard state != activity.content.state else { return }
+        await activity.update(using: state)
     }
-
 }


### PR DESCRIPTION
- The `connect` and `reconnect` methods in `DefaultVPNProvider` fail instantly if there's no network.
- However, `VPNDaemon` will keep trying to reconnect while there's no internet connection until it's back online.
- Live activities are handled in a separate thread to avoid hangs on the main thread.