### PR TITLE
KM-15998 load subscription info

### DIFF
--- a/LocalPackages/PIAAccount/Sources/PIAAccount/Networking/EndpointManager.swift
+++ b/LocalPackages/PIAAccount/Sources/PIAAccount/Networking/EndpointManager.swift
@@ -31,6 +31,7 @@ actor EndpointManager {
     ///   - headers: Additional HTTP headers
     ///   - queryParameters: Optional query parameters to append to URL
     ///   - decoder: JSON decoder for response
+    ///   - timeout: Timeout for each endpoint independently. Measured in seconds.
     /// - Returns: The decoded response
     /// - Throws: PIAMultipleErrors if all endpoints fail, or PIAAccountError if only one endpoint
     func executeWithFailover<T: Decodable & Sendable>(
@@ -39,7 +40,8 @@ actor EndpointManager {
         bodyType: RequestBuilder.BodyType? = nil,
         headers: [String: String] = [:],
         queryParameters: [String: String]? = nil,
-        decoder: JSONDecoder = .piaCodable
+        decoder: JSONDecoder = .piaCodable,
+        timeout: TimeInterval? = nil
     ) async throws -> T {
         let endpoints = endpointProvider.accountEndpoints()
         var errors: [PIAAccountError] = []
@@ -61,7 +63,8 @@ actor EndpointManager {
                     url: url,
                     method: method,
                     bodyType: bodyType,
-                    headers: headers
+                    headers: headers,
+                    timeout: timeout
                 )
 
                 // Execute request

--- a/LocalPackages/PIAAccount/Sources/PIAAccount/Networking/RequestBuilder.swift
+++ b/LocalPackages/PIAAccount/Sources/PIAAccount/Networking/RequestBuilder.swift
@@ -19,12 +19,14 @@ struct RequestBuilder {
     ///   - method: The HTTP method
     ///   - bodyType: The body type (JSON or form-encoded), if any
     ///   - headers: Additional HTTP headers
+    ///   - timeout: Timeout interval measured in seconds.
     /// - Returns: A configured URLRequest
     static func build(
         url: URL,
         method: HTTPMethod,
         bodyType: BodyType? = nil,
-        headers: [String: String] = [:]
+        headers: [String: String] = [:],
+        timeout: TimeInterval? = nil
     ) -> URLRequest {
         var request = URLRequest(url: url)
         request.httpMethod = method.rawValue
@@ -46,6 +48,10 @@ struct RequestBuilder {
 
         case .none:
             break
+        }
+
+        if let timeout {
+            request.timeoutInterval = timeout
         }
 
         return request

--- a/LocalPackages/PIAAccount/Sources/PIAAccount/PIAAccountClient.swift
+++ b/LocalPackages/PIAAccount/Sources/PIAAccount/PIAAccountClient.swift
@@ -351,23 +351,29 @@ public actor PIAAccountClient: PIAAccountAPI {
     public func subscriptions(receipt: Data?) async throws -> IOSSubscriptionInformation {
         try await refreshTokensIfNeeded()
 
-        guard let apiToken = try await tokenManager.getAPITokenString() else {
-            throw PIAAccountError.unauthorized()
-        }
+        var headers: [String: String] = [:]
+        var method: RequestBuilder.HTTPMethod = .get
+        var bodyType: RequestBuilder.BodyType? = nil
 
-        let headers = ["Authorization": "Token \(apiToken)"]
-
-        var bodyDict: [String: String] = ["store": "apple_app_store"]
-        if let receipt = receipt {
-            bodyDict["receipt"] = receipt.base64EncodedString()
+        // when logged in, send POST to the endpoint
+        if let apiToken = try await tokenManager.getAPITokenString() {
+            headers = ["Authorization": "Token \(apiToken)"]
+            method = .post
+            var bodyDict: [String: String] = ["store": "apple_app_store"]
+            if let receipt = receipt {
+                bodyDict["receipt"] = receipt.base64EncodedString()
+            }
+            let bodyData = try JSONEncoder.piaCodable.encode(bodyDict)
+            bodyType = .json(bodyData)
         }
-        let bodyData = try JSONEncoder.piaCodable.encode(bodyDict)
 
         return try await endpointManager.executeWithFailover(
             path: .iosSubscriptions,
-            method: .post,
-            bodyType: .json(bodyData),
-            headers: headers
+            method: method,
+            bodyType: bodyType,
+            headers: headers,
+            queryParameters: ["type": "subscription"],
+            timeout: TimeInterval(4)
         )
     }
 

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/AppConstants.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/AppConstants.swift
@@ -41,12 +41,14 @@ public struct AppConstants {
         public static var bundleURL = Bundle.main.url(forResource: "Regions", withExtension: "json")
     }
 
-    public struct InApp {
-        public static let yearlyProductIdentifier = "com.privateinternetaccess.subscription.year.october.2020"
-        public static let monthlyProductIdentifier = "com.privateinternetaccess.subscription.month.october.2020"
+    public enum InApp {
+        public static let yearlyProductIdentifier = "com.privateinternetaccess.subscription.year.May2026"
+        public static let monthlyProductIdentifier = "com.privateinternetaccess.subscription.month.May2026"
     }
 
-    public struct LegacyInApp {
+    public enum LegacyInApp {
+        public static let yearlyOctober2020ProductIdentifier = "com.privateinternetaccess.subscription.year.october.2020"
+        public static let monthlyOctober2020ProductIdentifier = "com.privateinternetaccess.subscription.month.october.2020"
         public static let yearly2020ProductIdentifier = "com.privateinternetaccess.subscription.1year.2020"
         public static let monthly2020ProductIdentifier = "com.privateinternetaccess.subscription.1month.2020"
         public static let yearlySubscriptionProductIdentifier = "com.privateinternetaccess.subscription.1year"

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/WebServices/PIAWebServices.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/WebServices/PIAWebServices.swift
@@ -391,10 +391,16 @@ final class PIAWebServices: WebServices, ConfigurationAccess {
 
             return info
         } catch {
+            log.warning("Failed to fetch subscription information: \(error)")
             let code = (error as? PIAAccountError)?.code ?? (error as? PIAMultipleErrors)?.code
-            if code == 400 {
+            switch code {
+            case 400:
                 throw ClientError.badReceipt
-            } else {
+            case 401:
+                throw ClientError.unauthorized
+            case 600:
+                throw ClientError.libraryError(message: error.localizedDescription)
+            default:
                 throw ClientError.invalidParameter
             }
         }

--- a/PIA VPN/UI/Menu/MenuViewController.swift
+++ b/PIA VPN/UI/Menu/MenuViewController.swift
@@ -240,12 +240,14 @@ final class MenuViewController: AutolayoutViewController {
 
             switch productId {
             case AppConstants.InApp.monthlyProductIdentifier,
+                AppConstants.LegacyInApp.monthlyOctober2020ProductIdentifier,
                 AppConstants.LegacyInApp.monthly2020ProductIdentifier,
                 AppConstants.LegacyInApp.monthlySubscriptionProductIdentifier,
                 AppConstants.LegacyInApp.monthlyProductIdentifier,
                 AppConstants.LegacyInApp.oldMonthlyProductIdentifier:
                 uniquePlan = .monthly
             case AppConstants.InApp.yearlyProductIdentifier,
+                AppConstants.LegacyInApp.yearlyOctober2020ProductIdentifier,
                 AppConstants.LegacyInApp.yearly2020ProductIdentifier,
                 AppConstants.LegacyInApp.yearlySubscriptionProductIdentifier,
                 AppConstants.LegacyInApp.yearlyProductIdentifier,


### PR DESCRIPTION
- Add timeout to the subscription info endpoint, so it doesn't load indefinitely.
- Update the endpoint with the missing `?type=subscription` parameter.
- Call the endpoint with `GET` when logged out to avoid 401 errors.