### PR TITLE
KM-17216: Fix WireGuard on iOS 15

### DIFF
--- a/LocalPackages/PIALibrary/Package.swift
+++ b/LocalPackages/PIALibrary/Package.swift
@@ -23,7 +23,7 @@ let package = Package(
         .package(path: "../PIARegions"),
         .package(url: "git@github.com:pia-foss/mobile-ios-networking.git", exact: "1.3.2"),
         .package(url: "git@github.com:pia-foss/mobile-ios-openvpn.git", exact: "2.2.6"),
-        .package(url: "git@github.com:pia-foss/mobile-ios-wireguard.git", exact: "1.0.5"),
+        .package(url: "git@github.com:pia-foss/mobile-ios-wireguard.git", exact: "1.0.6"),
         .package(url: "https://github.com/apple/swift-algorithms", exact: "1.2.1"),
         .package(url: "https://github.com/apple/swift-log", exact: "1.13.1"),
         .package(url: "https://github.com/ashleymills/Reachability.swift.git", exact: "5.2.4")

--- a/PIA VPN.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/PIA VPN.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -77,8 +77,8 @@
       "kind" : "remoteSourceControl",
       "location" : "git@github.com:pia-foss/mobile-ios-wireguard.git",
       "state" : {
-        "revision" : "ad06393c8ae856085efcf2f6a159c7f641f7247a",
-        "version" : "1.0.5"
+        "revision" : "59e5e7a0c5cb05d2f701ce48458e4f7ab16086ab",
+        "version" : "1.0.6"
       }
     },
     {


### PR DESCRIPTION
## Summary

Fixes WireGuard connectivity on iOS 15.

- **Pin WireGuard dependency to `1.0.6`** (`Package.swift` + `Package.resolved`). This release carries the xcframework platform-target fix.