### PR TITLE
KM-16992: make sure to disconnect when user taps disconnect

### DIFF
--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Daemons/VPNDaemon.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Daemons/VPNDaemon.swift
@@ -92,6 +92,12 @@ final class VPNDaemon: Daemon, DatabaseAccess, ProvidersAccess {
 
         var nextStatus: VPNStatus = .disconnected
 
+        // Captured before the switch below, which resets the flag when the
+        // .disconnected transition of a manual disconnect is processed. The
+        // last-disconnect-error handling further down must still know that the
+        // disconnect was user-initiated.
+        let disconnectedManually = Client.configuration.disconnectedManually
+
         switch connection.status {
         case .connected:
             nextStatus = .connected
@@ -253,7 +259,11 @@ final class VPNDaemon: Daemon, DatabaseAccess, ProvidersAccess {
 
             log.debug("connectivityCheckFailed=\(connectivityCheckFailed) previousStatus=\(previousStatus)")
 
-            if connectivityCheckFailed {
+            if disconnectedManually {
+                // The user asked to disconnect — never reconnect on their behalf,
+                // whatever error the tunnel died with.
+                log.debug("Manual disconnect — ignoring last disconnect error")
+            } else if connectivityCheckFailed {
                 let wholeInternetIsReachable = accessedDatabase.transient.isNetworkReachable
                 if wholeInternetIsReachable, let lastConnectedCN = accessedDatabase.plain.lastServerCN {
                     log.debug("connectivityCheckFailed — marking current server as unavailable and triggering reconnect")
@@ -291,6 +301,17 @@ final class VPNDaemon: Daemon, DatabaseAccess, ProvidersAccess {
         fallbackTimer = Timer.scheduledTimer(withTimeInterval: Client.configuration.vpnConnectivityRetryDelay, repeats: true) { [weak self] timer in
             guard let self else { return }
             log.debug("Executing fallbackTimer...")
+
+            // The user disconnected manually: stop retrying. Without this check
+            // the timer keeps reconnecting when no NEVPNStatusDidChange arrives
+            // to tear it down (e.g. the tunnel was already dead when the user
+            // tapped disconnect during a network change).
+            guard !Client.configuration.disconnectedManually else {
+                log.debug("Manual disconnect — stopping the reconnection retry timer")
+                self.invalidateTimer()
+                self.reset()
+                return
+            }
 
             let address = try? Client.providers.serverProvider.targetServer.bestAddress()
             address?.markServerAsUnavailable()

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/VPN/DefaultVPNProvider.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/VPN/DefaultVPNProvider.swift
@@ -255,6 +255,11 @@ public final class DefaultVPNProvider: VPNProvider, ConfigurationAccess, Databas
             callback?(ClientError.vpnClientConfigurationUnavailable)
             return
         }
+
+        // A new connection attempt supersedes any prior manual-disconnect
+        // intent; clear the flag so the daemon's retry logic is not suppressed.
+        accessedConfiguration.disconnectedManually = false
+
         activeProfile.connect(withConfiguration: configuration, callback)
     }
 
@@ -269,16 +274,19 @@ public final class DefaultVPNProvider: VPNProvider, ConfigurationAccess, Databas
             return
         }
 
-        guard let configuration = vpnClientConfiguration() else {
-            callback?(ClientError.vpnProfileUnavailable)
-            return
-        }
-        activeProfile.requestLog(withCustomConfiguration: configuration.customConfiguration) { (content, error) in
-            let log = self.accessedDatabase.transient.vpnLog + "\n\n" + (content ?? "Unknown Protocol Logs \(error.debugDescription)")
-            self.accessedDatabase.transient.vpnLog = log
-            activeProfile.disconnect(callback)
+        // Capture the tunnel log best-effort, in parallel: the provider message
+        // never gets a reply when the tunnel process is wedged (e.g. after a
+        // network change), so the disconnect below must not wait on it.
+        if let configuration = vpnClientConfiguration() {
+            activeProfile.requestLog(withCustomConfiguration: configuration.customConfiguration) { (content, error) in
+                guard let content, !content.isEmpty else {
+                    return
+                }
+                self.accessedDatabase.transient.vpnLog += "\n\n" + content
+            }
         }
 
+        activeProfile.disconnect(callback)
     }
 
     public func updatePreferences(_ callback: SuccessLibraryCallback?) {
@@ -318,6 +326,13 @@ public final class DefaultVPNProvider: VPNProvider, ConfigurationAccess, Databas
                     callback?(error)
                     return
                 }
+                // The user may have manually disconnected while this reconnect
+                // cycle was in flight — never override that intent.
+                guard !self.accessedConfiguration.disconnectedManually else {
+                    log.debug("reconnect aborted — the user disconnected manually")
+                    callback?(nil)
+                    return
+                }
                 guard let configuration = self.vpnClientConfiguration() else {
                     callback?(ClientError.vpnProfileUnavailable)
                     return
@@ -328,6 +343,13 @@ public final class DefaultVPNProvider: VPNProvider, ConfigurationAccess, Databas
             activeProfile.updatePreferences { (error) in
                 if let _ = error {
                     callback?(error)
+                    return
+                }
+                // The user may have manually disconnected while this reconnect
+                // cycle was in flight — never override that intent.
+                guard !self.accessedConfiguration.disconnectedManually else {
+                    log.debug("reconnect aborted — the user disconnected manually")
+                    callback?(nil)
                     return
                 }
                 guard let configuration = self.vpnClientConfiguration() else {

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/VPN/IKEv2Profile.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/VPN/IKEv2Profile.swift
@@ -140,23 +140,47 @@ public final class IKEv2Profile: NetworkExtensionProfile {
 
     /// :nodoc:
     public func disconnect(_ callback: SuccessLibraryCallback?) {
+        // A disconnect supersedes any pending connect-after-disconnect wait:
+        // without this, a connect() left waiting for .disconnected would
+        // restart the tunnel right after the user stops it.
+        if let existing = waitObserver {
+            NotificationCenter.default.removeObserver(existing)
+            waitObserver = nil
+        }
+
         currentVPN.loadFromPreferences { (error) in
             if let error = error {
+                // Preferences could not be loaded — still stop the session so a
+                // disconnect always kills the tunnel.
+                self.currentVPN.connection.stopVPNTunnel()
                 callback?(error)
                 return
+            }
+
+            // Stop the tunnel before the preferences round-trip below: saving
+            // can hang or fail while the network is flapping, and the tunnel
+            // must die regardless.
+            self.currentVPN.connection.stopVPNTunnel()
+
+            // If the tunnel was already dead, no NEVPNStatusDidChange follows
+            // the stop above; sync the app status so the UI does not stay
+            // stuck on a stale "connecting" state.
+            if self.currentVPN.connection.status == .disconnected || self.currentVPN.connection.status == .invalid {
+                DispatchQueue.main.async {
+                    Client.database.plain.lastKnownVpnStatus = .disconnected
+                    Client.database.transient.vpnStatus = .disconnected
+                }
             }
 
             // prevent reconnection
             self.currentVPN.isOnDemandEnabled = false
 
             self.currentVPN.saveToPreferences { (error) in
-                if let error = error {
-                    self.currentVPN.connection.stopVPNTunnel()
-                    callback?(error)
-                    return
-                }
+                // On-demand rules may have resurrected the tunnel between the
+                // stop above and this save landing — stop again now that
+                // on-demand is disabled.
                 self.currentVPN.connection.stopVPNTunnel()
-                callback?(nil)
+                callback?(error)
             }
         }
     }

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/VPN/PIATunnelProfile.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/VPN/PIATunnelProfile.swift
@@ -148,23 +148,47 @@
 
         /// :nodoc:
         public func disconnect(_ callback: SuccessLibraryCallback?) {
+            // A disconnect supersedes any pending connect-after-disconnect wait:
+            // without this, a connect() left waiting for .disconnected would
+            // restart the tunnel right after the user stops it.
+            if let existing = waitObserver {
+                NotificationCenter.default.removeObserver(existing)
+                waitObserver = nil
+            }
+
             find { (vpn, error) in
                 guard let vpn = vpn else {
+                    // Preferences could not be loaded — still stop the last known
+                    // session so a disconnect always kills the tunnel.
+                    (self.native as? NETunnelProviderManager)?.connection.stopVPNTunnel()
                     callback?(error)
                     return
+                }
+
+                // Stop the tunnel before the preferences round-trip below: saving
+                // can hang or fail while the network is flapping, and the tunnel
+                // must die regardless.
+                vpn.connection.stopVPNTunnel()
+
+                // If the tunnel was already dead, no NEVPNStatusDidChange follows
+                // the stop above; sync the app status so the UI does not stay
+                // stuck on a stale "connecting" state.
+                if vpn.connection.status == .disconnected || vpn.connection.status == .invalid {
+                    DispatchQueue.main.async {
+                        Client.database.plain.lastKnownVpnStatus = .disconnected
+                        Client.database.transient.vpnStatus = .disconnected
+                    }
                 }
 
                 // prevent reconnection
                 vpn.isOnDemandEnabled = false
 
                 vpn.saveToPreferences { (error) in
-                    if let error = error {
-                        vpn.connection.stopVPNTunnel()
-                        callback?(error)
-                        return
-                    }
+                    // On-demand rules may have resurrected the tunnel between the
+                    // stop above and this save landing — stop again now that
+                    // on-demand is disabled.
                     vpn.connection.stopVPNTunnel()
-                    callback?(nil)
+                    callback?(error)
                 }
             }
         }

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/VPN/PIAWGTunnelProfile.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/VPN/PIAWGTunnelProfile.swift
@@ -218,23 +218,47 @@ import Foundation
 
         /// :nodoc:
         public func disconnect(_ callback: SuccessLibraryCallback?) {
+            // A disconnect supersedes any pending connect-after-disconnect wait:
+            // without this, a connect() left waiting for .disconnected would
+            // restart the tunnel right after the user stops it.
+            if let existing = waitObserver {
+                NotificationCenter.default.removeObserver(existing)
+                waitObserver = nil
+            }
+
             find { (vpn, error) in
                 guard let vpn = vpn else {
+                    // Preferences could not be loaded — still stop the last known
+                    // session so a disconnect always kills the tunnel.
+                    (self.native as? NETunnelProviderManager)?.connection.stopVPNTunnel()
                     callback?(error)
                     return
+                }
+
+                // Stop the tunnel before the preferences round-trip below: saving
+                // can hang or fail while the network is flapping, and the tunnel
+                // must die regardless.
+                vpn.connection.stopVPNTunnel()
+
+                // If the tunnel was already dead, no NEVPNStatusDidChange follows
+                // the stop above; sync the app status so the UI does not stay
+                // stuck on a stale "connecting" state.
+                if vpn.connection.status == .disconnected || vpn.connection.status == .invalid {
+                    DispatchQueue.main.async {
+                        Client.database.plain.lastKnownVpnStatus = .disconnected
+                        Client.database.transient.vpnStatus = .disconnected
+                    }
                 }
 
                 // prevent reconnection
                 vpn.isOnDemandEnabled = false
 
                 vpn.saveToPreferences { (error) in
-                    if let error = error {
-                        vpn.connection.stopVPNTunnel()
-                        callback?(error)
-                        return
-                    }
+                    // On-demand rules may have resurrected the tunnel between the
+                    // stop above and this save landing — stop again now that
+                    // on-demand is disabled.
                     vpn.connection.stopVPNTunnel()
-                    callback?(nil)
+                    callback?(error)
                 }
             }
         }


### PR DESCRIPTION
- disconnect() in all three tunnel profiles now stops the tunnel immediately, not only after saveToPreferences succeeds, and stops it again afterward (on-demand rules can resurrect it in between). Also clears a stale pending connect-wait observer and syncs UI status when the tunnel was already dead.
- DefaultVPNProvider.disconnect() no longer blocks on fetching the tunnel log before disconnecting (it's now fire-and-forget, since a wedged tunnel may never reply).
- VPNDaemon and DefaultVPNProvider's reconnect/retry logic now check disconnectedManually so they never auto-reconnect after the user has explicitly disconnected — including mid-flight reconnects and the fallback retry timer.
- connect() clears disconnectedManually since a new connection attempt supersedes the prior manual-disconnect intent.