### PR TITLE
KM-17276: Stabilize VPN reconnect fallback

### DIFF
--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Client+Configuration.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Client+Configuration.swift
@@ -110,11 +110,18 @@ extension Client {
         /// Sets the maximum number of failed connectivity checks before giving up.
         public var connectivityMaxAttempts: Int
 
-        /// Sets the delay after which to retry VPN connectivity checks.
+        /// Sets the initial connection-attempt budget. Later retries back off from this value.
         public var vpnConnectivityRetryDelay: TimeInterval
 
         /// Sets the maximum number of failed VPN connectivity attempts before giving up.
         public var vpnConnectivityMaxAttempts: Int
+
+        /// The maximum delay between VPN reconnection attempts when backing off.
+        public var vpnConnectivityMaximumRetryDelay: TimeInterval
+
+        /// The maximum time to wait for a clean `.disconnected` state before
+        /// (re)starting a tunnel. Guards against hanging if the status never arrives.
+        public var vpnDisconnectWaitTimeout: TimeInterval
 
         /// Sets the rsa certificate to use for pinning puposes.
         public var rsa4096Certificate: String?
@@ -208,8 +215,10 @@ extension Client {
             connectivityRetryDelay = 10000
             connectivityMaxAttempts = 3
 
-            vpnConnectivityRetryDelay = 5.0
+            vpnConnectivityRetryDelay = 20.0
             vpnConnectivityMaxAttempts = 3
+            vpnConnectivityMaximumRetryDelay = 60.0
+            vpnDisconnectWaitTimeout = 10.0
 
             rsa4096Certificate = nil
 

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/ClientError.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/ClientError.swift
@@ -55,6 +55,9 @@ public enum ClientError: Error, Equatable {
     /// VPN client configuration could not be built (e.g. missing password reference).
     case vpnClientConfigurationUnavailable
 
+    /// The previous VPN session did not finish disconnecting before the restart deadline.
+    case vpnDisconnectTimedOut
+
     /// Error while checking the dip token renewal.
     case dipTokenRenewalError
 

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Daemons/VPNDaemon.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Daemons/VPNDaemon.swift
@@ -30,6 +30,52 @@ import NetworkExtension
 
 private let log = PIALogger.logger(for: VPNDaemon.self)
 
+struct VPNFallbackPolicy {
+    let initialDelay: TimeInterval
+    let maximumDelay: TimeInterval
+    let maximumAttempts: Int
+
+    func delay(afterFailedAttempts failedAttempts: Int) -> TimeInterval {
+        let multiplier = pow(2.0, Double(max(0, failedAttempts)))
+        return min(initialDelay * multiplier, maximumDelay)
+    }
+
+    func shouldRetry(afterFailedAttempts failedAttempts: Int) -> Bool {
+        failedAttempts < maximumAttempts
+    }
+}
+
+struct VPNGiveUpState {
+    private(set) var isActive = false
+    private(set) var disconnectCompleted = false
+    private(set) var reachedDisconnected = false
+
+    var isComplete: Bool {
+        isActive && disconnectCompleted && reachedDisconnected
+    }
+
+    mutating func begin(connectionIsDisconnected: Bool) {
+        isActive = true
+        disconnectCompleted = false
+        reachedDisconnected = connectionIsDisconnected
+    }
+
+    mutating func recordDisconnectCompletion(connectionIsSettled: Bool) {
+        disconnectCompleted = true
+        reachedDisconnected = reachedDisconnected || connectionIsSettled
+    }
+
+    mutating func recordDisconnected() {
+        reachedDisconnected = true
+    }
+
+    mutating func reset() {
+        isActive = false
+        disconnectCompleted = false
+        reachedDisconnected = false
+    }
+}
+
 final class VPNDaemon: Daemon, DatabaseAccess, ProvidersAccess {
     static let shared = VPNDaemon()
 
@@ -37,8 +83,12 @@ final class VPNDaemon: Daemon, DatabaseAccess, ProvidersAccess {
     private var fallbackTimer: Timer!
     private var numberOfAttempts: Int
     private var isReconnecting: Bool
-    private var isReconnectingAfterConnectivityFailure: Bool = false
     private var lastKnownVpnStatus: VPNStatus = .disconnected
+    private var giveUpState = VPNGiveUpState()
+
+    private var isGivingUp: Bool {
+        giveUpState.isActive
+    }
 
     private init() {
         hasEnabledUpdates = false
@@ -91,9 +141,18 @@ final class VPNDaemon: Daemon, DatabaseAccess, ProvidersAccess {
         }
 
         var nextStatus: VPNStatus = .disconnected
+        var shouldGiveUpAfterStatusUpdate = false
+        var observedGiveUpDisconnect = false
+        var wasDisconnectedManually = false
 
         switch connection.status {
         case .connected:
+            guard !isGivingUp else {
+                log.debug("Stopping tunnel that connected while terminal disconnect was in progress")
+                connection.stopVPNTunnel()
+                return
+            }
+
             nextStatus = .connected
             Client.preferences.timeToConnectVPN = Date().timeIntervalSince1970 - Client.preferences.lastVPNConnectionAttempt
 
@@ -103,7 +162,6 @@ final class VPNDaemon: Daemon, DatabaseAccess, ProvidersAccess {
                 return
             }
 
-            isReconnectingAfterConnectivityFailure = false
             Client.preferences.lastVPNConnectionSuccess = Date().timeIntervalSince1970
             invalidateTimer()
             reset()
@@ -118,22 +176,32 @@ final class VPNDaemon: Daemon, DatabaseAccess, ProvidersAccess {
 
         case .connecting, .reasserting:
 
+            guard !isGivingUp else {
+                log.debug("Ignoring automatic reconnect while terminal disconnect is in progress")
+                connection.stopVPNTunnel()
+                return
+            }
+
             nextStatus = .connecting
+            // A fresh attempt is a genuine .disconnected → .connecting transition that we
+            // did not initiate as part of a reconnect storm (isReconnecting == false). Only
+            // then reset the storm-wide counter.
+            // Gating on previousStatus == .disconnected is important: IKEv2 can oscillate
+            // .connecting ⇄ .reasserting without passing through .disconnected, and
+            // isReconnecting is cleared on the first .connecting — so relying on
+            // isReconnecting alone would reset the counter mid-attempt and defeat the cap.
+            if accessedDatabase.transient.vpnStatus == .disconnected, !isReconnecting {
+                if numberOfAttempts > 0 {
+                    numberOfAttempts = 0
+                    updateUIWithAttemptNumber(0)
+                }
+            }
             // If a reconnect cycle was in progress, it has now successfully reached
             // .connecting — clear the flag here instead of in the reconnect callback so
             // that the intermediate .disconnecting → .disconnected status changes are
             // suppressed (isReconnecting=true) and vpnStatus never briefly touches
             // .disconnected between the two connecting states.
             isReconnecting = false
-            // Reset the attempt counter each time we enter .connecting so that each
-            // new connection attempt starts fresh. This preserves the retry-indefinitely
-            // behaviour for unreachable servers: the fallback timer fires every 5s,
-            // marking one IP unavailable per tick, so the counter resets when the next
-            // .connecting status arrives and the cycle can continue without hitting max.
-            if numberOfAttempts > 0 {
-                numberOfAttempts = 0
-                updateUIWithAttemptNumber(0)
-            }
             Client.preferences.lastVPNConnectionAttempt = Date().timeIntervalSince1970
 
             if accessedDatabase.transient.vpnStatus == .disconnected,
@@ -153,43 +221,42 @@ final class VPNDaemon: Daemon, DatabaseAccess, ProvidersAccess {
 
             let previousStatus = accessedDatabase.transient.vpnStatus
 
+            if isGivingUp {
+                observedGiveUpDisconnect = true
+                markGiveUpReachedDisconnected()
+            }
+
             guard (nextStatus != previousStatus) else {
                 return
             }
 
-            // No internet while a connection was already in progress: keep trying
-            // indefinitely instead of giving up. Reaching this point means the previous
-            // status was not .disconnected, so a connection attempt (or an established
-            // connection) was underway. Force the status back to .connecting and keep
-            // the fallback timer alive — recreating it if it was already invalidated —
-            // so we reconnect as soon as the network becomes reachable again.
-            // Skipped when the user disconnected manually.
-            if !accessedDatabase.transient.isNetworkReachable,
-                !Client.configuration.disconnectedManually
-            {
-                log.debug("No internet while connecting — staying in .connecting and keeping the retry timer alive")
-                isReconnecting = true
-                scheduleFallbackTimerIfNeeded()
+            wasDisconnectedManually = Client.configuration.disconnectedManually
 
-                accessedDatabase.plain.lastKnownVpnStatus = .connecting
-                if previousStatus != .connecting {
-                    accessedDatabase.transient.vpnStatus = .connecting
-                }
-                return
+            // Reachability is affected by the kill switch, so waiting for a reachable
+            // notification here can deadlock forever. Stop the actual tunnel and disable
+            // on-demand instead; a later user-initiated connection starts a fresh cycle.
+            if !accessedDatabase.transient.isNetworkReachable,
+                !wasDisconnectedManually,
+                !observedGiveUpDisconnect
+            {
+                log.debug("No internet while connecting — terminating the retry cycle")
+                shouldGiveUpAfterStatusUpdate = true
             }
 
             // A manual disconnect must always tear down the retry loop, even mid-reconnect
             // (isReconnecting == true), otherwise the fallback timer would keep firing and
             // force the status back to .connecting after the user asked to disconnect.
-            if !isReconnecting || Client.configuration.disconnectedManually {
+            if wasDisconnectedManually || previousStatus != .connecting {
                 invalidateTimer()
                 reset()
+            } else {
+                // Preserve the storm-wide attempt count until the disconnect error has
+                // been classified, but never leave a watchdog attached to a dead session.
+                invalidateTimer()
             }
 
             //triggered only when the user is manually aborting connection (before being established).
-            if Client.configuration.disconnectedManually {
-                isReconnectingAfterConnectivityFailure = false
-
+            if wasDisconnectedManually {
                 if self.lastKnownVpnStatus != .connected,
                     (previousStatus == .connecting || previousStatus == .disconnecting),
                     Client.preferences.shareServiceQualityData
@@ -218,6 +285,21 @@ final class VPNDaemon: Daemon, DatabaseAccess, ProvidersAccess {
 
         if !isReconnecting {
             accessedDatabase.transient.vpnStatus = nextStatus
+        }
+
+        if observedGiveUpDisconnect {
+            return
+        }
+
+        if shouldGiveUpAfterStatusUpdate {
+            giveUp(connectionIsDisconnected: true)
+            return
+        }
+
+        // `_lastDisconnectError` is sticky. Reading it while a new session is connecting
+        // can misclassify an old teardown error as a failure of the replacement session.
+        guard connection.status == .disconnected else {
+            return
         }
 
         log.debug("[VPNDaemon] Fetching last disconnect error...")
@@ -253,7 +335,12 @@ final class VPNDaemon: Daemon, DatabaseAccess, ProvidersAccess {
 
             log.debug("connectivityCheckFailed=\(connectivityCheckFailed) previousStatus=\(previousStatus)")
 
-            if connectivityCheckFailed {
+            if connectivityCheckFailed, isReconnecting {
+                // A forced reconnect is already in flight; this .disconnected carries a
+                // stale connectivity error from the session we just tore down. Ignore it
+                // so it is not double-counted against the attempt cap.
+                log.debug("connectivityCheckFailed ignored — reconnect already in progress")
+            } else if connectivityCheckFailed {
                 let wholeInternetIsReachable = accessedDatabase.transient.isNetworkReachable
                 if wholeInternetIsReachable, let lastConnectedCN = accessedDatabase.plain.lastServerCN {
                     log.debug("connectivityCheckFailed — marking current server as unavailable and triggering reconnect")
@@ -264,72 +351,170 @@ final class VPNDaemon: Daemon, DatabaseAccess, ProvidersAccess {
                     log.debug("There's no internet!")
                 }
 
-                isReconnectingAfterConnectivityFailure = true
-                Client.providers.vpnProvider.reconnect(forceDisconnect: true, nil)
+                numberOfAttempts += 1
+                if !wholeInternetIsReachable {
+                    giveUp(connectionIsDisconnected: true)
+                } else if fallbackPolicy.shouldRetry(afterFailedAttempts: numberOfAttempts) {
+                    isReconnecting = true
+                    Client.providers.vpnProvider.reconnect(forceDisconnect: true) { [weak self] error in
+                        DispatchQueue.main.async {
+                            guard let self else { return }
+                            if let error {
+                                log.error("Connectivity-failure reconnect could not start: \(error)")
+                                self.giveUp(connectionIsDisconnected: true)
+                            } else {
+                                self.scheduleFallbackTimerIfNeeded()
+                            }
+                        }
+                    }
+                } else {
+                    giveUp(connectionIsDisconnected: true)
+                }
             } else {
                 if previousStatus == .connecting {
                     log.error("The VPN did fail \(lastDisconnectError)")
-                    Macros.postNotification(.PIAVPNDidFail)
+                    giveUp(connectionIsDisconnected: true)
                 }
             }
         } else {
             log.debug("[VPNDaemon] fetchLastDisconnectError — no error reported (clean disconnect)")
+            if previousStatus == .connecting, !wasDisconnectedManually {
+                giveUp(connectionIsDisconnected: true)
+            }
         }
     }
 
     // MARK: Fallback timer
 
-    /// Schedules the repeating reconnection timer if it is not already running.
-    /// The timer fires every `vpnConnectivityRetryDelay` seconds, marking the current
-    /// server as unavailable and attempting a reconnect. It keeps retrying while there
-    /// are attempts left, while there is no internet, or while recovering from a
-    /// connectivity failure; otherwise it gives up and disconnects.
+    /// Delay before the next fallback tick. It grows with the number of attempts so the
+    /// app backs off during a sustained outage instead of hammering servers. The first
+    /// attempt gets the full `vpnConnectivityRetryDelay` budget so a slow-but-healthy
+    /// connection (e.g. a cold-starting extension on older hardware) is not killed
+    /// prematurely — which was the trigger for the reconnect storm.
+    private func nextFallbackDelay() -> TimeInterval {
+        fallbackPolicy.delay(afterFailedAttempts: numberOfAttempts)
+    }
+
+    private var fallbackPolicy: VPNFallbackPolicy {
+        VPNFallbackPolicy(
+            initialDelay: Client.configuration.vpnConnectivityRetryDelay,
+            maximumDelay: Client.configuration.vpnConnectivityMaximumRetryDelay,
+            maximumAttempts: Client.configuration.vpnConnectivityMaxAttempts
+        )
+    }
+
+    /// Schedules the single-shot reconnection watchdog if it is not already running. Each
+    /// replacement attempt receives a fresh, backed-off budget until `giveUp()` stops the loop.
     private func scheduleFallbackTimerIfNeeded() {
-        guard fallbackTimer == nil else { return }
-        log.debug("Setting up fallbackTimer...")
+        guard
+            fallbackTimer == nil,
+            !isGivingUp,
+            accessedDatabase.transient.vpnStatus == .connecting
+        else {
+            return
+        }
+        let delay = nextFallbackDelay()
+        log.debug("Setting up fallbackTimer (delay=\(delay)s, attempt=\(numberOfAttempts))...")
 
-        fallbackTimer = Timer.scheduledTimer(withTimeInterval: Client.configuration.vpnConnectivityRetryDelay, repeats: true) { [weak self] timer in
+        fallbackTimer = Timer.scheduledTimer(withTimeInterval: delay, repeats: false) { [weak self] _ in
             guard let self else { return }
-            log.debug("Executing fallbackTimer...")
+            // Single-shot: clear so the next attempt can reschedule with the next backoff step.
+            self.fallbackTimer = nil
+            self.handleFallbackTick()
+        }
+    }
 
-            let address = try? Client.providers.serverProvider.targetServer.bestAddress()
-            address?.markServerAsUnavailable()
+    /// Fired when a connection attempt has used up its budget without reaching `.connected`.
+    /// Marks the current server unavailable and either rotates to a different server (while
+    /// attempts remain) or gives up.
+    private func handleFallbackTick() {
+        guard !isGivingUp, accessedDatabase.transient.vpnStatus == .connecting else {
+            return
+        }
 
-            self.numberOfAttempts += 1
+        log.debug("Executing fallbackTimer...")
 
-            let shouldKeepTrying =
-                numberOfAttempts < Client.configuration.vpnConnectivityMaxAttempts
-                || !accessedDatabase.transient.isNetworkReachable
-                || isReconnectingAfterConnectivityFailure
+        numberOfAttempts += 1
 
-            if shouldKeepTrying {
-                log.debug("NEVPNManager is still connecting. Reconnecting with a different server...")
-                self.updateUIWithAttemptNumber(self.numberOfAttempts)
-                self.isReconnecting = true
-                Client.providers.vpnProvider.reconnect(forceDisconnect: true) { error in
-                    if let clientError = error as? ClientError, clientError == .internetUnreachable {
-                        self.isReconnecting = true
-                        self.isReconnectingAfterConnectivityFailure = true
+        guard accessedDatabase.transient.isNetworkReachable else {
+            log.debug("Connection attempt timed out without internet. Giving up.")
+            giveUp()
+            return
+        }
 
-                    } else if error != nil {
-                        // Reconnect initiation failed — clear flag immediately so the
-                        // subsequent .disconnected status change can clean up normally.
-                        self.isReconnecting = false
-                    }
-                    // On success: leave isReconnecting=true. It will be cleared in
-                    // tryUpdateStatus when .connecting status arrives, ensuring that
-                    // the intermediate .disconnecting → .disconnected transitions do
-                    // not briefly expose vpnStatus = .disconnected to the rest of the app.
-                }
-            } else {
-                log.debug("Max number of VPN reconnections. Disconnecting...")
-                Client.providers.vpnProvider.disconnect { error in
-                    Macros.postNotification(.PIAVPNDidFail)
-                    self.reset()
-                    self.invalidateTimer()
+        let address = try? Client.providers.serverProvider.targetServer.bestAddress()
+        address?.markServerAsUnavailable()
+
+        guard fallbackPolicy.shouldRetry(afterFailedAttempts: numberOfAttempts) else {
+            giveUp()
+            return
+        }
+
+        log.debug("NEVPNManager is still connecting. Reconnecting with a different server (attempt \(numberOfAttempts))...")
+        updateUIWithAttemptNumber(numberOfAttempts)
+        isReconnecting = true
+        Client.providers.vpnProvider.reconnect(forceDisconnect: true) { [weak self] error in
+            DispatchQueue.main.async {
+                guard let self else { return }
+                if let error {
+                    log.error("Fallback reconnect could not start: \(error)")
+                    self.giveUp()
+                } else {
+                    // Start the next budget only after disconnect/save/start has completed.
+                    self.scheduleFallbackTimerIfNeeded()
                 }
             }
         }
+    }
+
+    /// Stops the retry loop, disables on-demand, and tears down the real Network Extension
+    /// session. Completion is tracked separately from the `.disconnected` status event so
+    /// neither callback ordering nor a sticky kill switch can restart the cycle.
+    private func giveUp(connectionIsDisconnected: Bool = false) {
+        if isGivingUp {
+            if connectionIsDisconnected {
+                markGiveUpReachedDisconnected()
+            }
+            return
+        }
+
+        log.debug("Giving up active VPN reconnection cycle...")
+        invalidateTimer()
+        isReconnecting = false
+        giveUpState.begin(connectionIsDisconnected: connectionIsDisconnected || activeConnectionIsSettled)
+
+        Client.providers.vpnProvider.disconnect { [weak self] error in
+            DispatchQueue.main.async {
+                guard let self else { return }
+                if let error {
+                    log.error("Terminal VPN disconnect completed with error: \(error)")
+                }
+                self.giveUpState.recordDisconnectCompletion(connectionIsSettled: self.activeConnectionIsSettled)
+                Macros.postNotification(.PIAVPNDidFail)
+                self.finishGivingUpIfPossible()
+            }
+        }
+    }
+
+    private var activeConnectionIsSettled: Bool {
+        guard
+            let profile = accessedDatabase.transient.activeVPNProfile,
+            let manager = profile.native as? NEVPNManager
+        else {
+            return false
+        }
+        return TunnelRestartPolicy.canStartTunnel(from: manager.connection.status)
+    }
+
+    private func markGiveUpReachedDisconnected() {
+        giveUpState.recordDisconnected()
+        finishGivingUpIfPossible()
+    }
+
+    private func finishGivingUpIfPossible() {
+        guard giveUpState.isComplete else { return }
+        giveUpState.reset()
+        reset()
     }
 
     // MARK: Invalidate

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Daemons/VPNDaemon.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Daemons/VPNDaemon.swift
@@ -30,6 +30,8 @@ import NetworkExtension
 
 private let log = PIALogger.logger(for: VPNDaemon.self)
 
+// MARK: - Retry policy
+
 struct VPNFallbackPolicy {
     let initialDelay: TimeInterval
     let maximumDelay: TimeInterval
@@ -43,7 +45,34 @@ struct VPNFallbackPolicy {
     func shouldRetry(afterFailedAttempts failedAttempts: Int) -> Bool {
         failedAttempts < maximumAttempts
     }
+
+    /// Whether to reconnect or give up after a failed/dropped attempt.
+    ///
+    /// - No internet → give up. There is nothing to leak while fully offline, and waiting for a
+    ///   reachability signal can deadlock behind the kill switch (the bug this work fixes).
+    /// - Internet reachable + the user already had an established connection to preserve
+    ///   (`hasEstablishedConnection`) → keep reconnecting indefinitely. Abandoning a connection the
+    ///   user chose would silently expose them to leaks; the delay is already capped, so retrying
+    ///   forever does not storm.
+    /// - Internet reachable + no established connection yet (a cold connect) → bounded by the
+    ///   attempt cap, then give up.
+    func decision(
+        afterFailedAttempts failedAttempts: Int,
+        internetIsReachable: Bool,
+        hasEstablishedConnection: Bool
+    ) -> VPNRetryDecision {
+        guard internetIsReachable else { return .giveUp }
+        if hasEstablishedConnection { return .reconnect }
+        return shouldRetry(afterFailedAttempts: failedAttempts) ? .reconnect : .giveUp
+    }
 }
+
+enum VPNRetryDecision: Equatable {
+    case reconnect
+    case giveUp
+}
+
+// MARK: - Terminal-disconnect policy
 
 /// Decides whether an observed `.disconnected` should terminate the retry cycle.
 ///
@@ -71,6 +100,8 @@ enum TerminalDisconnectPolicy {
         previousStatus == .connecting && !isReconnecting
     }
 }
+
+// MARK: - Give-up state
 
 struct VPNGiveUpState {
     private(set) var isActive = false
@@ -104,6 +135,9 @@ struct VPNGiveUpState {
 }
 
 final class VPNDaemon: Daemon, DatabaseAccess, ProvidersAccess {
+
+    // MARK: - Properties
+
     static let shared = VPNDaemon()
 
     private(set) var hasEnabledUpdates: Bool
@@ -114,9 +148,20 @@ final class VPNDaemon: Daemon, DatabaseAccess, ProvidersAccess {
     private var lastKnownVpnStatus: VPNStatus = .disconnected
     private var giveUpState = VPNGiveUpState()
 
+    /// True once the current VPN session has actually reached `.connected` — i.e. the user has an
+    /// established connection they expect to keep. While this holds and the internet is reachable,
+    /// a dropped tunnel is retried indefinitely (with backoff) instead of giving up: abandoning it
+    /// would silently expose the user to leaks after they chose to be protected. It is a session
+    /// latch on purpose — it survives the intermediate teardowns of recovery reconnects (so it is
+    /// NOT cleared in `reset()`) and is cleared only when we truly stop: a manual disconnect or a
+    /// terminal give-up.
+    private var didReachConnected = false
+
     private var isGivingUp: Bool {
         giveUpState.isActive
     }
+
+    // MARK: - Lifecycle
 
     private init() {
         hasEnabledUpdates = false
@@ -136,8 +181,12 @@ final class VPNDaemon: Daemon, DatabaseAccess, ProvidersAccess {
 
         if Client.providers.vpnProvider.isVPNConnected {
             self.lastKnownVpnStatus = .connected
+            // The app relaunched onto an already-established session the user expects to keep.
+            self.didReachConnected = true
         }
     }
+
+    // MARK: - Status updates
 
     private func tryUpdateStatus(via connection: NEVPNConnection) {
         guard let profile = accessedDatabase.transient.activeVPNProfile else {
@@ -193,6 +242,9 @@ final class VPNDaemon: Daemon, DatabaseAccess, ProvidersAccess {
             Client.preferences.lastVPNConnectionSuccess = Date().timeIntervalSince1970
             invalidateTimer()
             reset()
+            // Latch that the user now has a connection to preserve. Set after reset() (reset()
+            // does not touch it) so it stays true across any later recovery reconnects.
+            didReachConnected = true
 
             if self.lastKnownVpnStatus == .disconnected, Client.preferences.shareServiceQualityData {
                 ServiceQualityManager.shared.connectionEstablishedEvent()
@@ -238,8 +290,6 @@ final class VPNDaemon: Daemon, DatabaseAccess, ProvidersAccess {
             {
                 ServiceQualityManager.shared.connectionAttemptEvent()
             }
-
-            scheduleFallbackTimerIfNeeded()
 
         case .disconnecting:
             nextStatus = .disconnecting
@@ -295,6 +345,8 @@ final class VPNDaemon: Daemon, DatabaseAccess, ProvidersAccess {
                 //VPN disconnected, the user interaction finished. Only reset the value when the source was manual.
                 Client.configuration.disconnectedManually = false
 
+                // The user chose to disconnect — there is no longer a connection to preserve.
+                didReachConnected = false
             }
 
             Client.preferences.lastVPNConnectionSuccess = nil
@@ -315,6 +367,15 @@ final class VPNDaemon: Daemon, DatabaseAccess, ProvidersAccess {
             accessedDatabase.transient.vpnStatus = nextStatus
         }
 
+        // Arm the connect watchdog only after the status is committed to `.connecting`. Scheduling
+        // earlier (mid-switch, before this update) silently no-ops, because the timer guard requires
+        // `transient.vpnStatus == .connecting` — so a connect that hangs after a single `.connecting`
+        // event would never be retried and the app would sit in "Connecting…" forever. Once armed,
+        // each tick reschedules itself from the reconnect callbacks.
+        if nextStatus == .connecting {
+            scheduleFallbackTimerIfNeeded()
+        }
+
         if observedGiveUpDisconnect {
             return
         }
@@ -330,84 +391,25 @@ final class VPNDaemon: Daemon, DatabaseAccess, ProvidersAccess {
             return
         }
 
+        handleDisconnectError(
+            on: connection,
+            previousStatus: previousStatus,
+            wasDisconnectedManually: wasDisconnectedManually
+        )
+    }
+
+    /// Classifies a settled session's sticky `_lastDisconnectError` and drives the retry loop:
+    /// rotate/reconnect on a connectivity-check failure, or give up on a genuine failed connect.
+    /// A `.disconnected` observed mid-reconnect carries a stale error and is ignored so it is not
+    /// double-counted against the attempt cap.
+    private func handleDisconnectError(
+        on connection: NEVPNConnection,
+        previousStatus: VPNStatus,
+        wasDisconnectedManually: Bool
+    ) {
         log.debug("[VPNDaemon] Fetching last disconnect error...")
-        if let lastDisconnectError = connection.value(forKey: "_lastDisconnectError") as? NSError {
-            log.debug("[VPNDaemon] fetchLastDisconnectError — domain=\(lastDisconnectError.domain) code=\(lastDisconnectError.code) description='\(lastDisconnectError.localizedDescription)'")
 
-            let errorDomain = lastDisconnectError.domain
-            let errorCode = lastDisconnectError.code
-            var connectivityCheckFailed = false
-
-            // WireGuard connectivity check failure
-            #if canImport(PIAWireguard)
-                if errorDomain == PacketTunnelProviderError.errorDomain, errorCode == PacketTunnelProviderError.connectivityCheckFailed.errorCode {
-                    connectivityCheckFailed = true
-                }
-            #endif
-
-            // OpenVPN connectivity check failure
-            #if canImport(TunnelKitOpenVPN)
-                if errorDomain == OpenVPNError.errorDomain, errorCode == OpenVPNError.connectivityCheckFailed.errorCode {
-                    connectivityCheckFailed = true
-                }
-            #endif
-
-            // IKEv2 connectivity check failure.
-            // On tvOS, IKEv2 errors are reported under NEVPNConnectionErrorDomainPlugin
-            // rather than NEVPNConnectionErrorDomain, so check both when IKEv2 is active.
-            if #available(iOS 16, *) {
-                if errorDomain == NEVPNConnectionErrorDomain || errorDomain == "NEVPNConnectionErrorDomainPlugin" {
-                    connectivityCheckFailed = true
-                }
-            }
-
-            log.debug("connectivityCheckFailed=\(connectivityCheckFailed) previousStatus=\(previousStatus)")
-
-            if connectivityCheckFailed, isReconnecting {
-                // A forced reconnect is already in flight; this .disconnected carries a
-                // stale connectivity error from the session we just tore down. Ignore it
-                // so it is not double-counted against the attempt cap.
-                log.debug("connectivityCheckFailed ignored — reconnect already in progress")
-            } else if connectivityCheckFailed {
-                let wholeInternetIsReachable = accessedDatabase.transient.isNetworkReachable
-                if wholeInternetIsReachable, let lastConnectedCN = accessedDatabase.plain.lastServerCN {
-                    log.debug("connectivityCheckFailed — marking current server as unavailable and triggering reconnect")
-                    let targetRegion = try? Client.providers.serverProvider.targetServer
-                    let lastConnectedServer = targetRegion?.addresses().first(where: { $0.cn == lastConnectedCN })
-                    lastConnectedServer?.markServerAsUnavailable()
-                } else if !wholeInternetIsReachable {
-                    log.debug("There's no internet!")
-                }
-
-                numberOfAttempts += 1
-                if !wholeInternetIsReachable {
-                    giveUp(connectionIsDisconnected: true)
-                } else if fallbackPolicy.shouldRetry(afterFailedAttempts: numberOfAttempts) {
-                    isReconnecting = true
-                    Client.providers.vpnProvider.reconnect(forceDisconnect: true) { [weak self] error in
-                        DispatchQueue.main.async {
-                            guard let self else { return }
-                            if let error {
-                                log.error("Connectivity-failure reconnect could not start: \(error)")
-                                self.giveUp(connectionIsDisconnected: true)
-                            } else {
-                                self.scheduleFallbackTimerIfNeeded()
-                            }
-                        }
-                    }
-                } else {
-                    giveUp(connectionIsDisconnected: true)
-                }
-            } else {
-                if TerminalDisconnectPolicy.shouldGiveUpOnGenericError(
-                    previousStatus: previousStatus,
-                    isReconnecting: isReconnecting
-                ) {
-                    log.error("The VPN did fail \(lastDisconnectError)")
-                    giveUp(connectionIsDisconnected: true)
-                }
-            }
-        } else {
+        guard let lastDisconnectError = connection.value(forKey: "_lastDisconnectError") as? NSError else {
             log.debug("[VPNDaemon] fetchLastDisconnectError — no error reported (clean disconnect)")
             if TerminalDisconnectPolicy.shouldGiveUpOnCleanDisconnect(
                 previousStatus: previousStatus,
@@ -416,10 +418,90 @@ final class VPNDaemon: Daemon, DatabaseAccess, ProvidersAccess {
             ) {
                 giveUp(connectionIsDisconnected: true)
             }
+            return
+        }
+
+        log.debug("[VPNDaemon] fetchLastDisconnectError — domain=\(lastDisconnectError.domain) code=\(lastDisconnectError.code) description='\(lastDisconnectError.localizedDescription)'")
+
+        let connectivityCheckFailed = isConnectivityCheckFailure(
+            domain: lastDisconnectError.domain,
+            code: lastDisconnectError.code
+        )
+        log.debug("connectivityCheckFailed=\(connectivityCheckFailed) previousStatus=\(previousStatus)")
+
+        guard connectivityCheckFailed else {
+            if TerminalDisconnectPolicy.shouldGiveUpOnGenericError(
+                previousStatus: previousStatus,
+                isReconnecting: isReconnecting
+            ) {
+                log.error("The VPN did fail \(lastDisconnectError)")
+                giveUp(connectionIsDisconnected: true)
+            }
+            return
+        }
+
+        guard !isReconnecting else {
+            // A forced reconnect is already in flight; this .disconnected carries a stale
+            // connectivity error from the session we just tore down. Ignore it so it is not
+            // double-counted against the attempt cap.
+            log.debug("connectivityCheckFailed ignored — reconnect already in progress")
+            return
+        }
+
+        let wholeInternetIsReachable = accessedDatabase.transient.isNetworkReachable
+        if wholeInternetIsReachable, let lastConnectedCN = accessedDatabase.plain.lastServerCN {
+            log.debug("connectivityCheckFailed — marking current server as unavailable and triggering reconnect")
+            let targetRegion = try? Client.providers.serverProvider.targetServer
+            let lastConnectedServer = targetRegion?.addresses().first(where: { $0.cn == lastConnectedCN })
+            lastConnectedServer?.markServerAsUnavailable()
+        } else if !wholeInternetIsReachable {
+            log.debug("There's no internet!")
+        }
+
+        numberOfAttempts += 1
+        switch fallbackPolicy.decision(
+            afterFailedAttempts: numberOfAttempts,
+            internetIsReachable: wholeInternetIsReachable,
+            hasEstablishedConnection: didReachConnected
+        ) {
+        case .giveUp:
+            giveUp(connectionIsDisconnected: true)
+        case .reconnect:
+            startReconnect(context: "Connectivity-failure", giveUpConnectionIsDisconnected: true)
         }
     }
 
-    // MARK: Fallback timer
+    /// Whether a Network Extension disconnect error is a tunnel connectivity-check failure for any
+    /// of the three protocols (the signal that a server has gone unreachable), as opposed to a
+    /// generic connect failure.
+    private func isConnectivityCheckFailure(domain: String, code: Int) -> Bool {
+        // WireGuard connectivity check failure
+        #if canImport(PIAWireguard)
+            if domain == PacketTunnelProviderError.errorDomain, code == PacketTunnelProviderError.connectivityCheckFailed.errorCode {
+                return true
+            }
+        #endif
+
+        // OpenVPN connectivity check failure
+        #if canImport(TunnelKitOpenVPN)
+            if domain == OpenVPNError.errorDomain, code == OpenVPNError.connectivityCheckFailed.errorCode {
+                return true
+            }
+        #endif
+
+        // IKEv2 connectivity check failure.
+        // On tvOS, IKEv2 errors are reported under NEVPNConnectionErrorDomainPlugin
+        // rather than NEVPNConnectionErrorDomain, so check both when IKEv2 is active.
+        if #available(iOS 16, *) {
+            if domain == NEVPNConnectionErrorDomain || domain == "NEVPNConnectionErrorDomainPlugin" {
+                return true
+            }
+        }
+
+        return false
+    }
+
+    // MARK: - Fallback timer & retries
 
     /// Delay before the next fallback tick. It grows with the number of attempts so the
     /// app backs off during a sustained outage instead of hammering servers. The first
@@ -471,29 +553,45 @@ final class VPNDaemon: Daemon, DatabaseAccess, ProvidersAccess {
 
         numberOfAttempts += 1
 
-        guard accessedDatabase.transient.isNetworkReachable else {
-            log.debug("Connection attempt timed out without internet. Giving up.")
-            giveUp()
-            return
+        let internetIsReachable = accessedDatabase.transient.isNetworkReachable
+        if internetIsReachable {
+            let address = try? Client.providers.serverProvider.targetServer.bestAddress()
+            address?.markServerAsUnavailable()
         }
 
-        let address = try? Client.providers.serverProvider.targetServer.bestAddress()
-        address?.markServerAsUnavailable()
-
-        guard fallbackPolicy.shouldRetry(afterFailedAttempts: numberOfAttempts) else {
+        // Once the user has an established connection to preserve, keep rotating servers
+        // indefinitely (the delay is already capped) rather than giving up. Only a cold connect
+        // that never reached .connected is bounded by the attempt cap, and no internet always
+        // gives up.
+        guard
+            case .reconnect = fallbackPolicy.decision(
+                afterFailedAttempts: numberOfAttempts,
+                internetIsReachable: internetIsReachable,
+                hasEstablishedConnection: didReachConnected
+            )
+        else {
+            log.debug("Connection attempt exhausted (reachable=\(internetIsReachable)). Giving up.")
             giveUp()
             return
         }
 
         log.debug("NEVPNManager is still connecting. Reconnecting with a different server (attempt \(numberOfAttempts))...")
         updateUIWithAttemptNumber(numberOfAttempts)
+        startReconnect(context: "Fallback", giveUpConnectionIsDisconnected: false)
+    }
+
+    /// Issues a forced reconnect (`disconnect { connect }`). On success the fallback budget is
+    /// re-armed for the new attempt; if the reconnect cannot even be initiated, the loop gives up.
+    /// `giveUpConnectionIsDisconnected` matches the caller's context: `true` from the connectivity
+    /// path (the session is already down), `false` from the fallback tick (still connecting).
+    private func startReconnect(context: String, giveUpConnectionIsDisconnected: Bool) {
         isReconnecting = true
         Client.providers.vpnProvider.reconnect(forceDisconnect: true) { [weak self] error in
             DispatchQueue.main.async {
                 guard let self else { return }
                 if let error {
-                    log.error("Fallback reconnect could not start: \(error)")
-                    self.giveUp()
+                    log.error("\(context) reconnect could not start: \(error)")
+                    self.giveUp(connectionIsDisconnected: giveUpConnectionIsDisconnected)
                 } else {
                     // Start the next budget only after disconnect/save/start has completed.
                     self.scheduleFallbackTimerIfNeeded()
@@ -501,6 +599,8 @@ final class VPNDaemon: Daemon, DatabaseAccess, ProvidersAccess {
             }
         }
     }
+
+    // MARK: - Give up
 
     /// Stops the retry loop, disables on-demand, and tears down the real Network Extension
     /// session. Completion is tracked separately from the `.disconnected` status event so
@@ -516,6 +616,9 @@ final class VPNDaemon: Daemon, DatabaseAccess, ProvidersAccess {
         log.debug("Giving up active VPN reconnection cycle...")
         invalidateTimer()
         isReconnecting = false
+        // Terminal stop: there is no longer a connection to preserve, so a later manual connect
+        // starts a fresh, bounded cold-connect cycle rather than inheriting this latch.
+        didReachConnected = false
         giveUpState.begin(connectionIsDisconnected: connectionIsDisconnected || activeConnectionIsSettled)
         scheduleGiveUpWatchdog()
 
@@ -578,13 +681,14 @@ final class VPNDaemon: Daemon, DatabaseAccess, ProvidersAccess {
         giveUpWatchdog = nil
     }
 
-    // MARK: Invalidate
+    // MARK: - Invalidate timer
+
     private func invalidateTimer() {
         fallbackTimer?.invalidate()
         fallbackTimer = nil
     }
 
-    // MARK: Reset
+    // MARK: - Reset
 
     private func reset() {
         self.isReconnecting = false
@@ -592,13 +696,13 @@ final class VPNDaemon: Daemon, DatabaseAccess, ProvidersAccess {
         self.updateUIWithAttemptNumber(0)
     }
 
-    // MARK: Update UI
+    // MARK: - Update UI
 
     private func updateUIWithAttemptNumber(_ number: Int) {
         NotificationCenter.default.post(name: .PIADaemonsConnectingVPNStatus, object: number)
     }
 
-    // MARK: Notifications
+    // MARK: - Notifications
 
     @objc private func neStatusDidChange(notification: Notification) {
         guard let connection = notification.object as? NEVPNConnection else {

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Daemons/VPNDaemon.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Daemons/VPNDaemon.swift
@@ -45,6 +45,33 @@ struct VPNFallbackPolicy {
     }
 }
 
+/// Decides whether an observed `.disconnected` should terminate the retry cycle.
+///
+/// A forced reconnect is implemented as `disconnect { connect }` (see `DefaultVPNProvider.reconnect`),
+/// so it surfaces an intermediate `.disconnected` with `previousStatus == .connecting` while
+/// `isReconnecting` is still set — status updates are suppressed during a reconnect. That teardown
+/// must never be classified as a failed connect, otherwise the bounded 20/40/60 backoff gives up on
+/// its own first reconnect and never reaches attempts 2–3.
+enum TerminalDisconnectPolicy {
+    /// A `.disconnected` carrying no connectivity error. Give up only for a genuine connect attempt:
+    /// not an intermediate reconnect teardown, and not a manual disconnect (handled elsewhere).
+    static func shouldGiveUpOnCleanDisconnect(
+        previousStatus: VPNStatus,
+        isReconnecting: Bool,
+        wasDisconnectedManually: Bool
+    ) -> Bool {
+        previousStatus == .connecting && !isReconnecting && !wasDisconnectedManually
+    }
+
+    /// A `.disconnected` carrying a non-connectivity error. Same reconnect-teardown guard applies.
+    static func shouldGiveUpOnGenericError(
+        previousStatus: VPNStatus,
+        isReconnecting: Bool
+    ) -> Bool {
+        previousStatus == .connecting && !isReconnecting
+    }
+}
+
 struct VPNGiveUpState {
     private(set) var isActive = false
     private(set) var disconnectCompleted = false
@@ -81,6 +108,7 @@ final class VPNDaemon: Daemon, DatabaseAccess, ProvidersAccess {
 
     private(set) var hasEnabledUpdates: Bool
     private var fallbackTimer: Timer!
+    private var giveUpWatchdog: Timer?
     private var numberOfAttempts: Int
     private var isReconnecting: Bool
     private var lastKnownVpnStatus: VPNStatus = .disconnected
@@ -371,14 +399,21 @@ final class VPNDaemon: Daemon, DatabaseAccess, ProvidersAccess {
                     giveUp(connectionIsDisconnected: true)
                 }
             } else {
-                if previousStatus == .connecting {
+                if TerminalDisconnectPolicy.shouldGiveUpOnGenericError(
+                    previousStatus: previousStatus,
+                    isReconnecting: isReconnecting
+                ) {
                     log.error("The VPN did fail \(lastDisconnectError)")
                     giveUp(connectionIsDisconnected: true)
                 }
             }
         } else {
             log.debug("[VPNDaemon] fetchLastDisconnectError — no error reported (clean disconnect)")
-            if previousStatus == .connecting, !wasDisconnectedManually {
+            if TerminalDisconnectPolicy.shouldGiveUpOnCleanDisconnect(
+                previousStatus: previousStatus,
+                isReconnecting: isReconnecting,
+                wasDisconnectedManually: wasDisconnectedManually
+            ) {
                 giveUp(connectionIsDisconnected: true)
             }
         }
@@ -482,6 +517,7 @@ final class VPNDaemon: Daemon, DatabaseAccess, ProvidersAccess {
         invalidateTimer()
         isReconnecting = false
         giveUpState.begin(connectionIsDisconnected: connectionIsDisconnected || activeConnectionIsSettled)
+        scheduleGiveUpWatchdog()
 
         Client.providers.vpnProvider.disconnect { [weak self] error in
             DispatchQueue.main.async {
@@ -513,8 +549,33 @@ final class VPNDaemon: Daemon, DatabaseAccess, ProvidersAccess {
 
     private func finishGivingUpIfPossible() {
         guard giveUpState.isComplete else { return }
+        invalidateGiveUpWatchdog()
         giveUpState.reset()
         reset()
+    }
+
+    /// Failsafe so a give-up can never wedge the daemon permanently. `giveUp()` only completes
+    /// once both the `disconnect` completion callback and a settled `.disconnected` are observed;
+    /// if either signal never arrives, `isGivingUp` would stay true forever and silently kill
+    /// every future user connect (see the `.connected`/`.connecting` short-circuits). If the
+    /// terminal disconnect has not settled within `vpnDisconnectWaitTimeout`, force-reset so the
+    /// daemon recovers in-session.
+    private func scheduleGiveUpWatchdog() {
+        invalidateGiveUpWatchdog()
+        let timeout = Client.configuration.vpnDisconnectWaitTimeout
+        giveUpWatchdog = Timer.scheduledTimer(withTimeInterval: timeout, repeats: false) { [weak self] _ in
+            guard let self else { return }
+            self.giveUpWatchdog = nil
+            guard self.isGivingUp else { return }
+            log.error("Terminal VPN disconnect did not settle within \(timeout)s — force-resetting give-up state")
+            self.giveUpState.reset()
+            self.reset()
+        }
+    }
+
+    private func invalidateGiveUpWatchdog() {
+        giveUpWatchdog?.invalidate()
+        giveUpWatchdog = nil
     }
 
     // MARK: Invalidate

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/VPN/IKEv2Profile.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/VPN/IKEv2Profile.swift
@@ -28,7 +28,7 @@ private let log = PIALogger.logger(for: IKEv2Profile.self)
 /// Implementation of `VPNProfile` providing IKEv2 connectivity.
 public final class IKEv2Profile: NetworkExtensionProfile {
 
-    private var waitObserver: NSObjectProtocol?
+    private let restartCoordinator = TunnelRestartCoordinator()
 
     private var currentVPN: NEVPNManager {
         return NEVPNManager.shared()
@@ -83,59 +83,52 @@ public final class IKEv2Profile: NetworkExtensionProfile {
             let currentStatus = self.currentVPN.connection.status
             log.debug("[IKEv2] connect — current status: \(currentStatus.descriptionForLog)")
 
-            // If the tunnel is already active, stop it before starting the new one.
-            // Calling startVPNTunnel() on a connected IKEv2 tunnel may silently retain
-            // the existing connection rather than switching to the new server, resulting
-            // in the app believing it is connected when it is not.
-            if currentStatus == .connected || currentStatus == .connecting || currentStatus == .reasserting {
-                log.debug("[IKEv2] connect — stopping active tunnel before restart")
-                self.currentVPN.connection.stopVPNTunnel()
-            }
-
-            if currentStatus == .disconnecting {
+            // Only start immediately from a fully settled state. From any other state we
+            // stop the current tunnel and wait for a clean .disconnected before starting.
+            // Calling startVPNTunnel() on a tunnel that is still active or tearing down may
+            // silently retain the existing connection (wrong server) or fail the new
+            // attempt — the latter being the source of the reconnect storm when the
+            // fallback timer forces reconnects.
+            if TunnelRestartPolicy.canStartTunnel(from: currentStatus) {
+                self.startTunnel(context: "connect", callback: callback)
+            } else {
+                if currentStatus != .disconnecting {
+                    log.debug("[IKEv2] connect — stopping active tunnel before restart")
+                    self.currentVPN.connection.stopVPNTunnel()
+                }
                 log.debug("[IKEv2] connect — waiting for .disconnected before start")
                 self.waitForDisconnectedThenStart(callback: callback)
-            } else {
-                do {
-                    try self.currentVPN.connection.startVPNTunnel()
-                    log.debug("[IKEv2] connect — startVPNTunnel issued")
-                    callback?(nil)
-                } catch let e {
-                    log.error("[IKEv2] connect — startVPNTunnel threw: \(e)")
-                    callback?(e)
-                }
             }
         }
     }
 
+    private func startTunnel(context: String, callback: SuccessLibraryCallback?) {
+        do {
+            try currentVPN.connection.startVPNTunnel()
+            log.debug("[IKEv2] \(context) — startVPNTunnel issued")
+            callback?(nil)
+        } catch let e {
+            log.error("[IKEv2] \(context) — startVPNTunnel threw: \(e)")
+            callback?(e)
+        }
+    }
+
+    /// Waits for the previous session to settle before starting the replacement tunnel.
+    /// A timeout completes with an error instead of starting against a session that is
+    /// still tearing down.
     private func waitForDisconnectedThenStart(callback: SuccessLibraryCallback?) {
-        if let existing = waitObserver {
-            NotificationCenter.default.removeObserver(existing)
-            waitObserver = nil
-        }
-
-        var token: NSObjectProtocol?
-        token = NotificationCenter.default.addObserver(forName: .NEVPNStatusDidChange, object: currentVPN.connection, queue: .main) { [weak self, currentVPN] _ in
-            guard currentVPN.connection.status == .disconnected else {
-                return
+        restartCoordinator.wait(
+            for: currentVPN.connection,
+            timeout: Client.configuration.vpnDisconnectWaitTimeout,
+            onReady: { [weak self] in
+                log.debug("[IKEv2] waitForDisconnectedThenStart — disconnected, starting")
+                self?.startTunnel(context: "waitForDisconnectedThenStart", callback: callback)
+            },
+            onTimeout: {
+                log.error("[IKEv2] waitForDisconnectedThenStart — timed out while tunnel was still disconnecting")
+                callback?(ClientError.vpnDisconnectTimedOut)
             }
-
-            defer {
-                token.map { NotificationCenter.default.removeObserver($0) }
-                self?.waitObserver = nil
-            }
-
-            log.debug("[IKEv2] waitForDisconnectedThenStart — disconnected, starting")
-            do {
-                try currentVPN.connection.startVPNTunnel()
-                log.debug("[IKEv2] waitForDisconnectedThenStart — startVPNTunnel issued")
-                callback?(nil)
-            } catch let e {
-                log.error("[IKEv2] waitForDisconnectedThenStart — startVPNTunnel threw: \(e)")
-                callback?(e)
-            }
-        }
-        waitObserver = token
+        )
     }
 
     /// :nodoc:

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/VPN/NetworkExtensionProfile.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/VPN/NetworkExtensionProfile.swift
@@ -25,6 +25,95 @@ import NetworkExtension
 
 private let log = PIALogger.logger(for: NetworkExtensionProfile.self)
 
+enum TunnelRestartPolicy {
+    static func canStartTunnel(from status: NEVPNStatus) -> Bool {
+        status == .disconnected || status == .invalid
+    }
+}
+
+/// Serializes the stop/wait/start handoff for a tunnel profile. All observer and timeout
+/// state is confined to the main queue, and a generation prevents a superseded wait from
+/// starting an older configuration.
+final class TunnelRestartCoordinator {
+    private var generation: UInt = 0
+    private var observer: NSObjectProtocol?
+    private var timeoutItem: DispatchWorkItem?
+
+    func wait(
+        for connection: NEVPNConnection,
+        timeout: TimeInterval,
+        onReady: @escaping () -> Void,
+        onTimeout: @escaping () -> Void
+    ) {
+        DispatchQueue.main.async { [weak self] in
+            self?.beginWait(
+                for: connection,
+                timeout: timeout,
+                onReady: onReady,
+                onTimeout: onTimeout
+            )
+        }
+    }
+
+    private func beginWait(
+        for connection: NEVPNConnection,
+        timeout: TimeInterval,
+        onReady: @escaping () -> Void,
+        onTimeout: @escaping () -> Void
+    ) {
+        cancelPendingWait()
+        generation &+= 1
+        let waitGeneration = generation
+
+        guard TunnelRestartPolicy.canStartTunnel(from: connection.status) == false else {
+            onReady()
+            return
+        }
+
+        let finish: (Bool) -> Void = { [weak self, connection] didTimeOut in
+            guard let self, generation == waitGeneration else { return }
+            cancelPendingWait()
+
+            if TunnelRestartPolicy.canStartTunnel(from: connection.status) {
+                onReady()
+            } else if didTimeOut {
+                onTimeout()
+            }
+        }
+
+        observer = NotificationCenter.default.addObserver(
+            forName: .NEVPNStatusDidChange,
+            object: connection,
+            queue: .main
+        ) { [connection] _ in
+            guard TunnelRestartPolicy.canStartTunnel(from: connection.status) else {
+                return
+            }
+            finish(false)
+        }
+
+        let item = DispatchWorkItem { finish(true) }
+        timeoutItem = item
+        DispatchQueue.main.asyncAfter(deadline: .now() + timeout, execute: item)
+    }
+
+    private func cancelPendingWait() {
+        if let observer {
+            NotificationCenter.default.removeObserver(observer)
+            self.observer = nil
+        }
+        timeoutItem?.cancel()
+        timeoutItem = nil
+    }
+
+    deinit {
+        if let observer {
+            NotificationCenter.default.removeObserver(observer)
+        }
+        timeoutItem?.cancel()
+    }
+}
+
 /// Specific protocol bridging a `VPNProfile` to a native `NEVPNProtocol` from Apple's NetworkExtension framwork.
 public protocol NetworkExtensionProfile: VPNProfile {
 

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/VPN/PIATunnelProfile.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/VPN/PIATunnelProfile.swift
@@ -29,7 +29,7 @@
     /// Implementation of `VPNProfile` providing OpenVPN connectivity.
     public final class PIATunnelProfile: NetworkExtensionProfile {
         private let bundleIdentifier: String
-        private var waitObserver: NSObjectProtocol?
+        private let restartCoordinator = TunnelRestartCoordinator()
 
         /**
          Default initializer.
@@ -88,62 +88,57 @@
                     let currentStatus = vpn.connection.status
                     log.debug("[OpenVPN] connect — current status: \(currentStatus.descriptionForLog)")
 
-                    // If the tunnel is already active, stop it before starting the new one.
-                    // Calling startTunnel() on a live session may silently retain the existing
-                    // connection rather than switching to the new server, leaving the app in a
-                    // state where it believes it is connected when it is not.
-                    if currentStatus == .connected || currentStatus == .connecting || currentStatus == .reasserting {
-                        log.debug("[OpenVPN] connect — stopping active tunnel before restart")
-                        vpn.connection.stopVPNTunnel()
-                    }
-
-                    if currentStatus == .disconnecting {
+                    // Only start immediately from a fully settled state. From any other
+                    // state we stop the current session and wait for a clean .disconnected
+                    // before starting. Calling startTunnel() on a session that is still
+                    // active or tearing down may silently retain the existing connection
+                    // (wrong server) or fail the new attempt — the latter being the source
+                    // of the reconnect storm when the fallback timer forces reconnects.
+                    if TunnelRestartPolicy.canStartTunnel(from: currentStatus) {
+                        self.startTunnel(vpn: vpn, context: "connect", callback: callback)
+                    } else {
+                        if currentStatus != .disconnecting {
+                            log.debug("[OpenVPN] connect — stopping active tunnel before restart")
+                            vpn.connection.stopVPNTunnel()
+                        }
                         log.debug("[OpenVPN] connect — waiting for .disconnected before start")
                         self.waitForDisconnectedThenStart(vpn: vpn, callback: callback)
-                    } else {
-                        do {
-                            let session = vpn.connection as? NETunnelProviderSession
-                            try session?.startTunnel(options: nil)
-                            log.debug("[OpenVPN] connect — startTunnel issued")
-                            callback?(nil)
-                        } catch let e {
-                            log.error("[OpenVPN] connect — startTunnel threw: \(e)")
-                            callback?(e)
-                        }
                     }
                 }
             }
         }
 
+        private func startTunnel(vpn: NETunnelProviderManager, context: String, callback: SuccessLibraryCallback?) {
+            guard let session = vpn.connection as? NETunnelProviderSession else {
+                callback?(ClientError.vpnProfileUnavailable)
+                return
+            }
+            do {
+                try session.startTunnel(options: nil)
+                log.debug("[OpenVPN] \(context) — startTunnel issued")
+                callback?(nil)
+            } catch let e {
+                log.error("[OpenVPN] \(context) — startTunnel threw: \(e)")
+                callback?(e)
+            }
+        }
+
+        /// Waits for the previous session to settle before starting the replacement tunnel.
+        /// A timeout completes with an error instead of starting against a session that is
+        /// still tearing down.
         private func waitForDisconnectedThenStart(vpn: NETunnelProviderManager, callback: SuccessLibraryCallback?) {
-            if let existing = waitObserver {
-                NotificationCenter.default.removeObserver(existing)
-                waitObserver = nil
-            }
-
-            var token: NSObjectProtocol?
-            token = NotificationCenter.default.addObserver(forName: .NEVPNStatusDidChange, object: vpn.connection, queue: .main) { [weak self, vpn] _ in
-                guard vpn.connection.status == .disconnected else {
-                    return
+            restartCoordinator.wait(
+                for: vpn.connection,
+                timeout: Client.configuration.vpnDisconnectWaitTimeout,
+                onReady: { [weak self, vpn] in
+                    log.debug("[OpenVPN] waitForDisconnectedThenStart — disconnected, starting")
+                    self?.startTunnel(vpn: vpn, context: "waitForDisconnectedThenStart", callback: callback)
+                },
+                onTimeout: {
+                    log.error("[OpenVPN] waitForDisconnectedThenStart — timed out while tunnel was still disconnecting")
+                    callback?(ClientError.vpnDisconnectTimedOut)
                 }
-
-                defer {
-                    token.map { NotificationCenter.default.removeObserver($0) }
-                    self?.waitObserver = nil
-                }
-
-                log.debug("[OpenVPN] waitForDisconnectedThenStart — disconnected, starting")
-                do {
-                    let session = vpn.connection as? NETunnelProviderSession
-                    try session?.startTunnel(options: nil)
-                    log.debug("[OpenVPN] waitForDisconnectedThenStart — startTunnel issued")
-                    callback?(nil)
-                } catch let e {
-                    log.error("[OpenVPN] waitForDisconnectedThenStart — startTunnel threw: \(e)")
-                    callback?(e)
-                }
-            }
-            waitObserver = token
+            )
         }
 
         /// :nodoc:

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/VPN/PIAWGTunnelProfile.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/VPN/PIAWGTunnelProfile.swift
@@ -31,7 +31,7 @@ import Foundation
     /// Implementation of `VPNProfile` providing WireGuard connectivity.
     public final class PIAWGTunnelProfile: NetworkExtensionProfile {
 
-        private var waitObserver: NSObjectProtocol?
+        private let restartCoordinator = TunnelRestartCoordinator()
 
         public func parsedCustomConfiguration(from map: [String: Any]) -> VPNCustomConfiguration? {
 
@@ -158,62 +158,57 @@ import Foundation
                     let currentStatus = vpn.connection.status
                     log.debug("[WG] connect — current status: \(currentStatus.descriptionForLog)")
 
-                    // If the tunnel is already active, stop it before starting the new one.
-                    // Calling startTunnel() on a live session may silently retain the existing
-                    // connection rather than switching to the new server, leaving the app in a
-                    // state where it believes it is connected when it is not.
-                    if currentStatus == .connected || currentStatus == .connecting || currentStatus == .reasserting {
-                        log.debug("[WG] connect — stopping active tunnel before restart")
-                        vpn.connection.stopVPNTunnel()
-                    }
-
-                    if currentStatus == .disconnecting {
+                    // Only start immediately from a fully settled state. From any other
+                    // state we stop the current session and wait for a clean .disconnected
+                    // before starting. Calling startTunnel() on a session that is still
+                    // active or tearing down may silently retain the existing connection
+                    // (wrong server) or fail the new attempt — the latter being the source
+                    // of the reconnect storm when the fallback timer forces reconnects.
+                    if TunnelRestartPolicy.canStartTunnel(from: currentStatus) {
+                        self.startTunnel(vpn: vpn, context: "connect", callback: callback)
+                    } else {
+                        if currentStatus != .disconnecting {
+                            log.debug("[WG] connect — stopping active tunnel before restart")
+                            vpn.connection.stopVPNTunnel()
+                        }
                         log.debug("[WG] connect — waiting for .disconnected before start")
                         self.waitForDisconnectedThenStart(vpn: vpn, callback: callback)
-                    } else {
-                        do {
-                            let session = vpn.connection as? NETunnelProviderSession
-                            try session?.startTunnel(options: nil)
-                            log.debug("[WG] connect — startTunnel issued")
-                            callback?(nil)
-                        } catch let e {
-                            log.error("[WG] connect — startTunnel threw: \(e)")
-                            callback?(e)
-                        }
                     }
                 }
             }
         }
 
+        private func startTunnel(vpn: NETunnelProviderManager, context: String, callback: SuccessLibraryCallback?) {
+            guard let session = vpn.connection as? NETunnelProviderSession else {
+                callback?(ClientError.vpnProfileUnavailable)
+                return
+            }
+            do {
+                try session.startTunnel(options: nil)
+                log.debug("[WG] \(context) — startTunnel issued")
+                callback?(nil)
+            } catch let e {
+                log.error("[WG] \(context) — startTunnel threw: \(e)")
+                callback?(e)
+            }
+        }
+
+        /// Waits for the previous session to settle before starting the replacement tunnel.
+        /// A timeout completes with an error instead of starting against a session that is
+        /// still tearing down.
         private func waitForDisconnectedThenStart(vpn: NETunnelProviderManager, callback: SuccessLibraryCallback?) {
-            if let existing = waitObserver {
-                NotificationCenter.default.removeObserver(existing)
-                waitObserver = nil
-            }
-
-            var token: NSObjectProtocol?
-            token = NotificationCenter.default.addObserver(forName: .NEVPNStatusDidChange, object: vpn.connection, queue: .main) { [weak self, vpn] _ in
-                guard vpn.connection.status == .disconnected else {
-                    return
+            restartCoordinator.wait(
+                for: vpn.connection,
+                timeout: Client.configuration.vpnDisconnectWaitTimeout,
+                onReady: { [weak self, vpn] in
+                    log.debug("[WG] waitForDisconnectedThenStart — disconnected, starting")
+                    self?.startTunnel(vpn: vpn, context: "waitForDisconnectedThenStart", callback: callback)
+                },
+                onTimeout: {
+                    log.error("[WG] waitForDisconnectedThenStart — timed out while tunnel was still disconnecting")
+                    callback?(ClientError.vpnDisconnectTimedOut)
                 }
-
-                defer {
-                    token.map { NotificationCenter.default.removeObserver($0) }
-                    self?.waitObserver = nil
-                }
-
-                log.debug("[WG] waitForDisconnectedThenStart — disconnected, starting")
-                do {
-                    let session = vpn.connection as? NETunnelProviderSession
-                    try session?.startTunnel(options: nil)
-                    log.debug("[WG] waitForDisconnectedThenStart — startTunnel issued")
-                    callback?(nil)
-                } catch let e {
-                    log.error("[WG] waitForDisconnectedThenStart — startTunnel threw: \(e)")
-                    callback?(e)
-                }
-            }
-            waitObserver = token
+            )
         }
 
         /// :nodoc:

--- a/LocalPackages/PIALibrary/Tests/PIALibraryTests/VPNFallbackPolicyTests.swift
+++ b/LocalPackages/PIALibrary/Tests/PIALibraryTests/VPNFallbackPolicyTests.swift
@@ -30,6 +30,51 @@ struct VPNFallbackPolicyTests {
         #expect(policy.shouldRetry(afterFailedAttempts: 2))
         #expect(policy.shouldRetry(afterFailedAttempts: 3) == false)
     }
+
+    // MARK: Retry-vs-give-up decision
+
+    @Test("No internet always gives up, even mid cold-connect budget")
+    func noInternetGivesUp() {
+        #expect(
+            policy.decision(afterFailedAttempts: 0, internetIsReachable: false, hasEstablishedConnection: false)
+                == .giveUp
+        )
+        // Even with a connection to preserve, being fully offline gives up (kill-switch deadlock fix).
+        #expect(
+            policy.decision(afterFailedAttempts: 0, internetIsReachable: false, hasEstablishedConnection: true)
+                == .giveUp
+        )
+    }
+
+    @Test("An established connection keeps reconnecting indefinitely while online")
+    func establishedConnectionNeverGivesUpWhileOnline() {
+        // Past the cold-connect attempt cap, an established connection must still reconnect —
+        // giving up here would silently expose the user to leaks after they chose to be protected.
+        #expect(
+            policy.decision(afterFailedAttempts: 3, internetIsReachable: true, hasEstablishedConnection: true)
+                == .reconnect
+        )
+        #expect(
+            policy.decision(afterFailedAttempts: 99, internetIsReachable: true, hasEstablishedConnection: true)
+                == .reconnect
+        )
+    }
+
+    @Test("A cold connect is bounded by the attempt cap while online")
+    func coldConnectIsBoundedWhileOnline() {
+        #expect(
+            policy.decision(afterFailedAttempts: 1, internetIsReachable: true, hasEstablishedConnection: false)
+                == .reconnect
+        )
+        #expect(
+            policy.decision(afterFailedAttempts: 2, internetIsReachable: true, hasEstablishedConnection: false)
+                == .reconnect
+        )
+        #expect(
+            policy.decision(afterFailedAttempts: 3, internetIsReachable: true, hasEstablishedConnection: false)
+                == .giveUp
+        )
+    }
 }
 
 struct TunnelRestartPolicyTests {

--- a/LocalPackages/PIALibrary/Tests/PIALibraryTests/VPNFallbackPolicyTests.swift
+++ b/LocalPackages/PIALibrary/Tests/PIALibraryTests/VPNFallbackPolicyTests.swift
@@ -1,0 +1,94 @@
+import NetworkExtension
+import Testing
+
+@testable import PIALibrary
+
+struct VPNFallbackPolicyTests {
+    private let policy = VPNFallbackPolicy(
+        initialDelay: 20,
+        maximumDelay: 60,
+        maximumAttempts: 3
+    )
+
+    @Test("Fallback delay grows exponentially and respects its cap")
+    func delayBacksOffToCap() {
+        #expect(policy.delay(afterFailedAttempts: 0) == 20)
+        #expect(policy.delay(afterFailedAttempts: 1) == 40)
+        #expect(policy.delay(afterFailedAttempts: 2) == 60)
+        #expect(policy.delay(afterFailedAttempts: 3) == 60)
+    }
+
+    @Test("Negative attempt counts use the initial delay")
+    func negativeAttemptsUseInitialDelay() {
+        #expect(policy.delay(afterFailedAttempts: -1) == 20)
+    }
+
+    @Test("Retry permission ends at the configured attempt limit")
+    func retryLimitIsInclusiveOfTerminalAttempt() {
+        #expect(policy.shouldRetry(afterFailedAttempts: 0))
+        #expect(policy.shouldRetry(afterFailedAttempts: 1))
+        #expect(policy.shouldRetry(afterFailedAttempts: 2))
+        #expect(policy.shouldRetry(afterFailedAttempts: 3) == false)
+    }
+}
+
+struct TunnelRestartPolicyTests {
+    @Test("Only settled Network Extension states can start a replacement tunnel")
+    func onlySettledStatesCanStart() {
+        #expect(TunnelRestartPolicy.canStartTunnel(from: .invalid))
+        #expect(TunnelRestartPolicy.canStartTunnel(from: .disconnected))
+        #expect(TunnelRestartPolicy.canStartTunnel(from: .connecting) == false)
+        #expect(TunnelRestartPolicy.canStartTunnel(from: .connected) == false)
+        #expect(TunnelRestartPolicy.canStartTunnel(from: .reasserting) == false)
+        #expect(TunnelRestartPolicy.canStartTunnel(from: .disconnecting) == false)
+    }
+}
+
+struct VPNGiveUpStateTests {
+    @Test("Give-up completes when callback arrives before disconnected status")
+    func callbackBeforeStatus() {
+        var state = VPNGiveUpState()
+        state.begin(connectionIsDisconnected: false)
+
+        state.recordDisconnectCompletion(connectionIsSettled: false)
+        #expect(state.isComplete == false)
+
+        state.recordDisconnected()
+        #expect(state.isComplete)
+    }
+
+    @Test("Give-up completes when disconnected status arrives before callback")
+    func statusBeforeCallback() {
+        var state = VPNGiveUpState()
+        state.begin(connectionIsDisconnected: false)
+
+        state.recordDisconnected()
+        #expect(state.isComplete == false)
+
+        state.recordDisconnectCompletion(connectionIsSettled: false)
+        #expect(state.isComplete)
+    }
+
+    @Test("An already disconnected session completes with the disconnect callback")
+    func alreadyDisconnected() {
+        var state = VPNGiveUpState()
+        state.begin(connectionIsDisconnected: true)
+
+        state.recordDisconnectCompletion(connectionIsSettled: true)
+        #expect(state.isComplete)
+    }
+
+    @Test("Reset prepares a completed state for a fresh connection cycle")
+    func reset() {
+        var state = VPNGiveUpState()
+        state.begin(connectionIsDisconnected: true)
+        state.recordDisconnectCompletion(connectionIsSettled: true)
+
+        state.reset()
+
+        #expect(state.isActive == false)
+        #expect(state.disconnectCompleted == false)
+        #expect(state.reachedDisconnected == false)
+        #expect(state.isComplete == false)
+    }
+}

--- a/LocalPackages/PIALibrary/Tests/PIALibraryTests/VPNFallbackPolicyTests.swift
+++ b/LocalPackages/PIALibrary/Tests/PIALibraryTests/VPNFallbackPolicyTests.swift
@@ -44,6 +44,90 @@ struct TunnelRestartPolicyTests {
     }
 }
 
+struct TerminalDisconnectPolicyTests {
+    // MARK: Clean disconnect (no error reported)
+
+    @Test("A clean failed connect attempt terminates the cycle")
+    func cleanFailedConnectGivesUp() {
+        #expect(
+            TerminalDisconnectPolicy.shouldGiveUpOnCleanDisconnect(
+                previousStatus: .connecting,
+                isReconnecting: false,
+                wasDisconnectedManually: false
+            )
+        )
+    }
+
+    @Test("The intermediate teardown of a forced reconnect does NOT terminate the cycle")
+    func reconnectTeardownDoesNotGiveUpOnCleanDisconnect() {
+        // Regression guard: `reconnect(forceDisconnect:)` is `disconnect { connect }`, so it drives
+        // the tunnel through `.disconnected` while `isReconnecting == true` and `previousStatus`
+        // still reads `.connecting`. Without the `isReconnecting` guard this returned true and the
+        // 20/40/60 backoff gave up on its own first reconnect.
+        #expect(
+            TerminalDisconnectPolicy.shouldGiveUpOnCleanDisconnect(
+                previousStatus: .connecting,
+                isReconnecting: true,
+                wasDisconnectedManually: false
+            ) == false
+        )
+    }
+
+    @Test("A manual disconnect does NOT terminate the cycle here")
+    func manualDisconnectDoesNotGiveUpOnCleanDisconnect() {
+        #expect(
+            TerminalDisconnectPolicy.shouldGiveUpOnCleanDisconnect(
+                previousStatus: .connecting,
+                isReconnecting: false,
+                wasDisconnectedManually: true
+            ) == false
+        )
+    }
+
+    @Test("A disconnect that was not preceded by connecting does NOT terminate the cycle")
+    func nonConnectingCleanDisconnectDoesNotGiveUp() {
+        #expect(
+            TerminalDisconnectPolicy.shouldGiveUpOnCleanDisconnect(
+                previousStatus: .connected,
+                isReconnecting: false,
+                wasDisconnectedManually: false
+            ) == false
+        )
+    }
+
+    // MARK: Generic (non-connectivity) error
+
+    @Test("A generic error on a genuine connect attempt terminates the cycle")
+    func genericErrorFailedConnectGivesUp() {
+        #expect(
+            TerminalDisconnectPolicy.shouldGiveUpOnGenericError(
+                previousStatus: .connecting,
+                isReconnecting: false
+            )
+        )
+    }
+
+    @Test("A generic error during a forced reconnect teardown does NOT terminate the cycle")
+    func reconnectTeardownDoesNotGiveUpOnGenericError() {
+        #expect(
+            TerminalDisconnectPolicy.shouldGiveUpOnGenericError(
+                previousStatus: .connecting,
+                isReconnecting: true
+            ) == false
+        )
+    }
+
+    @Test("A generic error while not connecting does NOT terminate the cycle")
+    func nonConnectingGenericErrorDoesNotGiveUp() {
+        #expect(
+            TerminalDisconnectPolicy.shouldGiveUpOnGenericError(
+                previousStatus: .disconnecting,
+                isReconnecting: false
+            ) == false
+        )
+    }
+}
+
 struct VPNGiveUpStateTests {
     @Test("Give-up completes when callback arrives before disconnected status")
     func callbackBeforeStatus() {


### PR DESCRIPTION
Here's the full picture of everything this branch does, in plain language.

## The problem it fixes

The original bug was a **"reconnect storm"**: when connecting the VPN (especially WireGuard on slower/older devices), the app could get stuck rapidly retrying — killing connections that were just slow, hammering servers, and sometimes freezing in "Connecting…" or a stuck state. Along the way, a few related failure modes were fixed too.

## What changed, area by area

**1. More patient timing** (`Client+Configuration.swift`)
- First connection attempt now gets **20 seconds** instead of 5, so a slow-but-healthy connect isn't killed.
- Retries slow down instead of repeating fast: **20s → 40s → 60s** (capped), max **3 attempts** for a fresh connect.
- Added a **10-second** limit for waiting on a clean shutdown.

**2. Bounded retries instead of an endless loop** (`VPNDaemon.swift`)
- The old "fire every 5 seconds forever" timer is gone. Each attempt now schedules a single timer with the next, longer delay.
- For a **cold connect** that never succeeds (dead region, unreachable endpoint), it stops cleanly after 3 attempts.

**3. Never abandon a connection you actually had** — the key safety behavior
- This is the important distinction. If you were **Connected** and the server dies **while you still have internet**, the app now **keeps trying forever** (rotating servers, with the capped backoff) rather than giving up. Giving up would disconnect you and turn off the kill switch, silently exposing you to leaks after you chose to be protected.
- It tracks this with a "you had an established connection" flag (`didReachConnected`) that's set once you reach Connected and cleared only when you manually disconnect or it truly gives up.
- The retry-vs-give-up decision is now in one place (`VPNFallbackPolicy.decision`): **no internet → give up** (nothing to leak, avoids the kill-switch deadlock); **internet + you were connected → keep trying**; **internet + cold connect → bounded by the cap**.

**4. Clean "stop, wait, then start" handoff** (`NetworkExtensionProfile.swift` + the WireGuard/OpenVPN/IKEv2 profiles)
- New shared helper `TunnelRestartCoordinator` with one rule: **only start a new tunnel once the old one is fully shut down.** Otherwise stop it, wait for it to settle, then start.
- If the old tunnel doesn't finish within 10 seconds, it reports an error (`vpnDisconnectTimedOut`, in `ClientError.swift`) instead of stacking a new tunnel on a dying one. Same safe logic now for all three protocols.

**5. A real disconnect when giving up, with a safety net** (`VPNDaemon.swift`)
- When it does give up, it does a genuine disconnect and disables auto-reconnect, ending in a real Disconnected state — instead of hanging forever waiting on a signal the kill switch can suppress.
- Added a **watchdog** so a give-up can never get permanently stuck: if the disconnect confirmation never arrives within 10s, it force-resets so the app always recovers.

**6. The "stuck in Connecting forever" fix** (found in device testing)
- The reconnect watchdog was being armed *before* the app's status was actually set to "Connecting", so it silently failed to start on the first try. When a reconnect hung, nothing rotated servers → stuck forever. Now the watchdog is armed *after* the status is committed, so it reliably fires and rotates.

## Code-quality cleanup (no behavior change)

- The giant ~285-line status-handling method was slimmed by pulling out three focused pieces: `handleDisconnectError` (classifies the disconnect reason), `isConnectivityCheckFailure` (the WireGuard/OpenVPN/IKEv2 error-matching), and `startReconnect` (dedupes the two identical reconnect blocks).
- The core decisions are now small, testable units (`VPNFallbackPolicy`, `VPNRetryDecision`, `TerminalDisconnectPolicy`, `VPNGiveUpState`, `TunnelRestartPolicy`).
- Added `// MARK: -` section separators throughout for navigation.
- **Unit tests** (`VPNFallbackPolicyTests.swift`) cover the backoff math, the retry/give-up decision (including "keep trying forever while connected" and "cold connect is bounded"), the restart-safety rule, the give-up state machine, and the reconnect-teardown guard.

## Bottom line

A connection attempt gets a realistic amount of time; a cold connect that can't succeed stops after 3 tries; **a connection that drops while you still have internet keeps recovering indefinitely and never leaves you unprotected**; server switches never stack tunnels; give-up can't hang the app; and the watchdog now reliably rotates servers so it can't sit in "Connecting…" forever.

One caveat worth remembering: during a sustained outage the retry cadence settles at ~60s between attempts (kill switch protects you throughout) — snappier than the old storm, but a genuinely-desired reconnect could take up to a minute once a good server is reachable. That's a tuning knob if you want it faster.
