### PR TITLE
KM-17276: increase VPN connectivity retry delay to 20s

### DIFF
--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Client+Configuration.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Client+Configuration.swift
@@ -208,7 +208,7 @@ extension Client {
             connectivityRetryDelay = 10000
             connectivityMaxAttempts = 3
 
-            vpnConnectivityRetryDelay = 5.0
+            vpnConnectivityRetryDelay = 20.0
             vpnConnectivityMaxAttempts = 3
 
             rsa4096Certificate = nil


### PR DESCRIPTION
## Summary
The VPNDaemon fallback timer (`VPNDaemon.swift:287`) fires every `vpnConnectivityRetryDelay` seconds while status is `.connecting`, marking the current server unavailable and rotating to a different server. At 5s, a valid-but-slow handshake could be cut short before it completed, causing failures on slow connections.

This bumps `vpnConnectivityRetryDelay` from `5.0` to `20.0` (`Client+Configuration.swift:211`), giving slow handshakes time to complete before the daemon rotates away.

## Trade-off
The same delay gates how quickly a genuinely-unreachable server is detected and rotated away from — dead servers now take ~4× longer to skip. Accepted trade-off for reliability on slow connections.

## Test plan
- [ ] Verify connection succeeds on a slow/throttled network where handshake takes >5s
- [ ] Verify reconnect/rotation still works when a server is unreachable