### PR TITLE
KM-17276: Only stop active tunnel before restart when connected

### DIFF
--- a/LocalPackages/PIALibrary/Sources/PIALibrary/VPN/IKEv2Profile.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/VPN/IKEv2Profile.swift
@@ -87,7 +87,7 @@ public final class IKEv2Profile: NetworkExtensionProfile {
             // Calling startVPNTunnel() on a connected IKEv2 tunnel may silently retain
             // the existing connection rather than switching to the new server, resulting
             // in the app believing it is connected when it is not.
-            if currentStatus == .connected || currentStatus == .connecting || currentStatus == .reasserting {
+            if currentStatus == .connected {
                 log.debug("[IKEv2] connect — stopping active tunnel before restart")
                 self.currentVPN.connection.stopVPNTunnel()
             }

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/VPN/PIATunnelProfile.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/VPN/PIATunnelProfile.swift
@@ -92,7 +92,7 @@
                     // Calling startTunnel() on a live session may silently retain the existing
                     // connection rather than switching to the new server, leaving the app in a
                     // state where it believes it is connected when it is not.
-                    if currentStatus == .connected || currentStatus == .connecting || currentStatus == .reasserting {
+                    if currentStatus == .connected {
                         log.debug("[OpenVPN] connect — stopping active tunnel before restart")
                         vpn.connection.stopVPNTunnel()
                     }

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/VPN/PIAWGTunnelProfile.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/VPN/PIAWGTunnelProfile.swift
@@ -162,7 +162,7 @@ import Foundation
                     // Calling startTunnel() on a live session may silently retain the existing
                     // connection rather than switching to the new server, leaving the app in a
                     // state where it believes it is connected when it is not.
-                    if currentStatus == .connected || currentStatus == .connecting || currentStatus == .reasserting {
+                    if currentStatus == .connected {
                         log.debug("[WG] connect — stopping active tunnel before restart")
                         vpn.connection.stopVPNTunnel()
                     }


### PR DESCRIPTION
## Summary
Narrows the pre-restart stop guard in all three VPN profiles (IKEv2, OpenVPN, WireGuard) from `.connected || .connecting || .reasserting` down to just `.connected`.

This matches the documented rationale above the guard: only a fully **connected** tunnel silently retains its existing connection when `startVPNTunnel()`/`startTunnel()` is called, leaving the app believing it is connected to the wrong server. Transient states (`.connecting`, `.reasserting`) no longer trigger a forced stop/start, avoiding unnecessary tunnel churn — notably on `.reasserting`, which the OS enters on its own during network changes.

## Changes
- `IKEv2Profile.swift`
- `PIATunnelProfile.swift`
- `PIAWGTunnelProfile.swift`

## Testing notes
- Please verify the **change-server-while-still-connecting** flow on a physical device, since this reverts part of the KM-15765 multi-status guard.