### PR TITLE
KM-17333: Display connected state when relaunching the app

### DIFF
--- a/LocalPackages/PIALibrary/Sources/PIALibrary/VPN/IKEv2Profile.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/VPN/IKEv2Profile.swift
@@ -164,8 +164,13 @@ public final class IKEv2Profile: NetworkExtensionProfile {
 
             // If the tunnel was already dead, no NEVPNStatusDidChange follows
             // the stop above; sync the app status so the UI does not stay
-            // stuck on a stale "connecting" state.
-            if self.currentVPN.connection.status == .disconnected || self.currentVPN.connection.status == .invalid {
+            // stuck on a stale "connecting" state. Only do this when this
+            // profile is the active one — disconnecting an inactive profile
+            // (e.g. cleanup of a stale manager on launch) must never clobber
+            // the status of a different, still-connected active tunnel.
+            if (self.currentVPN.connection.status == .disconnected || self.currentVPN.connection.status == .invalid),
+                Client.database.transient.activeVPNProfile?.vpnType == self.vpnType
+            {
                 DispatchQueue.main.async {
                     Client.database.plain.lastKnownVpnStatus = .disconnected
                     Client.database.transient.vpnStatus = .disconnected

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/VPN/PIATunnelProfile.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/VPN/PIATunnelProfile.swift
@@ -172,8 +172,13 @@
 
                 // If the tunnel was already dead, no NEVPNStatusDidChange follows
                 // the stop above; sync the app status so the UI does not stay
-                // stuck on a stale "connecting" state.
-                if vpn.connection.status == .disconnected || vpn.connection.status == .invalid {
+                // stuck on a stale "connecting" state. Only do this when this
+                // profile is the active one — disconnecting an inactive profile
+                // (e.g. cleanup of a stale manager on launch) must never clobber
+                // the status of a different, still-connected active tunnel.
+                if (vpn.connection.status == .disconnected || vpn.connection.status == .invalid),
+                    Client.database.transient.activeVPNProfile?.vpnType == self.vpnType
+                {
                     DispatchQueue.main.async {
                         Client.database.plain.lastKnownVpnStatus = .disconnected
                         Client.database.transient.vpnStatus = .disconnected

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/VPN/PIAWGTunnelProfile.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/VPN/PIAWGTunnelProfile.swift
@@ -242,8 +242,13 @@ import Foundation
 
                 // If the tunnel was already dead, no NEVPNStatusDidChange follows
                 // the stop above; sync the app status so the UI does not stay
-                // stuck on a stale "connecting" state.
-                if vpn.connection.status == .disconnected || vpn.connection.status == .invalid {
+                // stuck on a stale "connecting" state. Only do this when this
+                // profile is the active one — disconnecting an inactive profile
+                // (e.g. cleanup of a stale manager on launch) must never clobber
+                // the status of a different, still-connected active tunnel.
+                if (vpn.connection.status == .disconnected || vpn.connection.status == .invalid),
+                    Client.database.transient.activeVPNProfile?.vpnType == self.vpnType
+                {
                     DispatchQueue.main.async {
                         Client.database.plain.lastKnownVpnStatus = .disconnected
                         Client.database.transient.vpnStatus = .disconnected


### PR DESCRIPTION
Fix: Added a guard so the status-sync in disconnect() only applies when the profile being disconnected is the currently active profile (Client.database.transient.activeVPNProfile?.vpnType == self.vpnType). This:
- Prevents inactive-profile cleanup from ever touching the global status (fixes the bug).
- Preserves KM-16992's original intent — a real user-initiated disconnect of the active tunnel still syncs the UI immediately when the tunnel was already dead.