### PR TITLE
KM-17335: Fix VPN reconnect deadlock when on-demand blocks the reachability probe

### DIFF
--- a/LocalPackages/PIALibrary/Sources/PIALibrary/VPN/DefaultVPNProvider.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/VPN/DefaultVPNProvider.swift
@@ -302,10 +302,25 @@ public final class DefaultVPNProvider: VPNProvider, ConfigurationAccess, Databas
     }
 
     public func reconnect(forceDisconnect: Bool, _ callback: SuccessLibraryCallback?) {
-        guard accessedDatabase.transient.isNetworkReachable else {
-            log.warning("Skip reconnect, internet is unreachable")
-            callback?(ClientError.internetUnreachable)
-            return
+        // When always-on (on-demand) is enabled and the tunnel is down, the OS
+        // gates all traffic behind the inactive VPN, so the reachability probe
+        // fails even on a perfectly healthy network — a false negative. Skipping
+        // the reconnect in that state deadlocks: the probe can only succeed once
+        // the tunnel is back up, but the guard refuses to bring it up, so the app
+        // spins forever until the user manually disconnects (which drops
+        // on-demand). Only honor the reachability guard when on-demand is off
+        // (manual mode), where reconnecting into a genuinely dead link would just
+        // cycle servers pointlessly.
+        if accessedPreferences.isPersistentConnection {
+            if !accessedDatabase.transient.isNetworkReachable {
+                log.warning("Reconnect proceeding despite unreachable probe — on-demand is enabled, likely a false negative from VPN routing")
+            }
+        } else {
+            guard accessedDatabase.transient.isNetworkReachable else {
+                log.warning("Skip reconnect, internet is unreachable")
+                callback?(ClientError.internetUnreachable)
+                return
+            }
         }
 
         guard accessedProviders.accountProvider.isLoggedIn else {


### PR DESCRIPTION
## Problem

With always-on (on-demand) enabled, if the tunnel drops the OS gates all traffic behind the now-inactive VPN. The app's HTTP reachability probe can never complete, so `isNetworkReachable` flips to `false` — a **false negative** even on a perfectly healthy Wi-Fi (logs show `en0 wifi LQM: good` with `VPN is inactive`).

`DefaultVPNProvider.reconnect()` then skips every reconnect (`Skip reconnect, internet is unreachable`), which **deadlocks**: the probe can only succeed once the tunnel is back up, but the guard refuses to bring it up. The app spins in a reconnect loop indefinitely (observed for 75+ minutes) until the user manually disconnects — which drops on-demand and frees routing.

## Fix

The reachability guard in `reconnect()` now only short-circuits when always-on is **off**:
- **On-demand on:** proceed with the reconnect despite the unreachable probe. The disconnect-first step drops on-demand, frees OS routing, then reconnects — automating the manual stop→connect that was the only workaround.
- **On-demand off (manual mode):** guard unchanged — a genuinely dead link still short-circuits, so we don't pointlessly cycle servers.