### PR TITLE
KM-17456: Fix Mac Catalyst reconnect keychain race

### DIFF
--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Util/Keychain.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Util/Keychain.swift
@@ -105,7 +105,18 @@ public class Keychain {
             query[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlock
             query[kSecValueData as String] = data
             let addStatus = SecItemAdd(query as CFDictionary, nil)
-            guard addStatus == errSecSuccess else {
+            switch addStatus {
+            case errSecSuccess:
+                return
+            case errSecDuplicateItem:
+                // Lost a first-write race — the item now exists, so update it in place.
+                query.removeValue(forKey: kSecAttrAccessible as String)
+                query.removeValue(forKey: kSecValueData as String)
+                guard SecItemUpdate(query as CFDictionary, attributesToUpdate as CFDictionary) == errSecSuccess
+                else {
+                    throw KeychainError.add
+                }
+            default:
                 throw KeychainError.add
             }
         default:

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Util/Keychain.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Util/Keychain.swift
@@ -82,17 +82,33 @@ public class Keychain {
 
     /// :nodoc:
     public func set(password: String, for username: String) throws {
-        removePassword(for: username)
+        guard let data = password.data(using: .utf8) else {
+            throw KeychainError.add
+        }
 
         var query = [String: Any]()
         setScope(query: &query)
         query[kSecClass as String] = kSecClassGenericPassword
         query[kSecAttrAccount as String] = username
-        query[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlock
-        query[kSecValueData as String] = password.data(using: .utf8)
 
-        let status = SecItemAdd(query as CFDictionary, nil)
-        guard (status == errSecSuccess) else {
+        let attributesToUpdate: [String: Any] = [
+            kSecValueData as String: data,
+            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlock
+        ]
+        let updateStatus = SecItemUpdate(query as CFDictionary, attributesToUpdate as CFDictionary)
+
+        switch updateStatus {
+        case errSecSuccess:
+            return
+        case errSecItemNotFound:
+            // No existing item — add a fresh one.
+            query[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlock
+            query[kSecValueData as String] = data
+            let addStatus = SecItemAdd(query as CFDictionary, nil)
+            guard addStatus == errSecSuccess else {
+                throw KeychainError.add
+            }
+        default:
             throw KeychainError.add
         }
     }


### PR DESCRIPTION
## What
Changes `Keychain.set(password:for:)` to update the keychain item **in place** via `SecItemUpdate` (falling back to `SecItemAdd` only when the item doesn't exist yet), instead of deleting the item and re-adding it.

## Why
The previous delete-then-add approach had two problems on the VPN reconnect path:

- **Stale persistent reference.** Delete + add creates a *new* keychain item with a *new* persistent reference, invalidating the `passwordReference` already baked into the saved `NEVPNProtocolConfiguration`. On reconnect the tunnel could no longer resolve the credential → auth failure. `SecItemUpdate` preserves item identity, so the reference stays valid.
- **Read gap.** With a keychain access group shared between the app and the Network Extension, a concurrent read landing between the delete and the add saw `errSecItemNotFound`. Updating in place is atomic and removes that window.

This is the standard update-in-place pattern used by Apple's own keychain sample code.