### PR TITLE
KM-17445: use token auth on signup

### DIFF
--- a/LocalPackages/PIAAccount/Sources/PIAAccount/Models/ResponseModels.swift
+++ b/LocalPackages/PIAAccount/Sources/PIAAccount/Models/ResponseModels.swift
@@ -296,8 +296,21 @@ public struct DedicatedIPTokenDetails: Codable, Sendable {
     }
 }
 
-/// New account credentials after VPN sign up
+/// New account credentials after VPN sign up. Can be either:
+/// - username + password
+/// - username + apiToken + expiresAt
 public struct VpnSignUpInformation: Codable, Sendable {
     public let username: String
-    public let password: String
+    public let password: String?
+    /// The API token string
+    public let apiToken: String?
+    /// ISO 8601 expiration date string
+    public let expiresAt: String?
+
+    enum CodingKeys: String, CodingKey {
+        case username = "username"
+        case password = "password"
+        case apiToken = "api_token"
+        case expiresAt = "expires_at"
+    }
 }

--- a/LocalPackages/PIAAccount/Sources/PIAAccount/Models/ResponseModels.swift
+++ b/LocalPackages/PIAAccount/Sources/PIAAccount/Models/ResponseModels.swift
@@ -300,12 +300,14 @@ public struct DedicatedIPTokenDetails: Codable, Sendable {
 /// - username + password
 /// - username + apiToken + expiresAt
 public struct VpnSignUpInformation: Codable, Sendable {
+    /// The newly created user's username
     public let username: String
+    /// The newly created user's password. Might be missing due to some error on account creation.
     public let password: String?
     /// The API token string
-    public let apiToken: String?
+    public let apiToken: String
     /// ISO 8601 expiration date string
-    public let expiresAt: String?
+    public let expiresAt: String
 
     enum CodingKeys: String, CodingKey {
         case username = "username"

--- a/LocalPackages/PIAAccount/Sources/PIAAccount/Networking/AccountHTTPClient.swift
+++ b/LocalPackages/PIAAccount/Sources/PIAAccount/Networking/AccountHTTPClient.swift
@@ -1,4 +1,7 @@
 import Foundation
+import Logging
+
+private let log = Logger(label: String(describing: AccountHTTPClient.self))
 
 /// Actor-based HTTP client for making API requests with optional certificate pinning
 actor AccountHTTPClient {
@@ -59,6 +62,9 @@ actor AccountHTTPClient {
         decoder: JSONDecoder = .piaCodable
     ) async throws -> T {
         do {
+            if let method = request.httpMethod, let url = request.url {
+                log.debug("\(method) \(url.absoluteString)")
+            }
             let (data, response) = try await session.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {

--- a/LocalPackages/PIAAccount/Sources/PIAAccount/PIAAccountAPI.swift
+++ b/LocalPackages/PIAAccount/Sources/PIAAccount/PIAAccountAPI.swift
@@ -161,17 +161,6 @@ public protocol PIAAccountAPI {
     @discardableResult
     func setEmail(email: String, resetPassword: Bool) async throws -> String?
 
-    /// Sets or updates the account email (iOS-specific with credentials)
-    /// - Parameters:
-    ///   - username: Account username
-    ///   - password: Account password
-    ///   - email: New email address
-    ///   - resetPassword: Whether to trigger password reset
-    /// - Returns: New password if resetPassword is true, nil otherwise
-    /// - Throws: PIAAccountError if the request fails
-    @discardableResult
-    func setEmail(username: String, password: String, email: String, resetPassword: Bool) async throws -> String?
-
     // MARK: - Dedicated IP
 
     /// Retrieves the list of countries and regions where Dedicated IPs are available.

--- a/LocalPackages/PIAAccount/Sources/PIAAccount/PIAAccountClient.swift
+++ b/LocalPackages/PIAAccount/Sources/PIAAccount/PIAAccountClient.swift
@@ -408,11 +408,22 @@ public actor PIAAccountClient: PIAAccountAPI {
     public func signUp(information: IOSSignupInformation) async throws -> VpnSignUpInformation {
         let bodyData = try JSONEncoder.piaCodable.encode(information)
 
-        return try await endpointManager.executeWithFailover(
+        let response: VpnSignUpInformation = try await endpointManager.executeWithFailover(
             path: .signup,
             method: .post,
             bodyType: .json(bodyData)
         )
+
+        // store a token if we received one
+        if let token = response.apiToken, let expiresAt = response.expiresAt {
+            let tokenResponse = APITokenResponse(apiToken: token, expiresAt: expiresAt)
+            // Store API token
+            try await tokenManager.storeAPIToken(tokenResponse)
+            // Request VPN token
+            try await refreshVPNToken()
+        }
+
+        return response
     }
 
     // MARK: - Social

--- a/LocalPackages/PIAAccount/Sources/PIAAccount/PIAAccountClient.swift
+++ b/LocalPackages/PIAAccount/Sources/PIAAccount/PIAAccountClient.swift
@@ -241,34 +241,6 @@ public actor PIAAccountClient: PIAAccountAPI {
         return response.password
     }
 
-    public func setEmail(username: String, password: String, email: String, resetPassword: Bool) async throws -> String? {
-        // Create Basic Auth header with username:password (matching Kotlin IOSAccount.kt line 244-247)
-        let credentials = "\(username):\(password)"
-        guard let credentialsData = credentials.data(using: .utf8) else {
-            throw PIAAccountError.encodingFailed(
-                NSError(domain: "PIAAccount", code: 0, userInfo: [NSLocalizedDescriptionKey: "Failed to encode credentials"])
-            )
-        }
-        let base64Credentials = credentialsData.base64EncodedString()
-        let headers = ["Authorization": "Basic \(base64Credentials)"]
-
-        let formParams = [
-            "username": username,
-            "password": password,
-            "email": email,
-            "reset_password": resetPassword ? "true" : "false"
-        ]
-
-        let response: SetEmailInformation = try await endpointManager.executeWithFailover(
-            path: .setEmail,
-            method: .post,
-            bodyType: .formEncoded(formParams),
-            headers: headers
-        )
-
-        return response.password
-    }
-
     // MARK: - Dedicated IP
 
     public func supportedDedicatedIPCountries() async throws -> DipCountriesResponse {
@@ -414,14 +386,11 @@ public actor PIAAccountClient: PIAAccountAPI {
             bodyType: .json(bodyData)
         )
 
-        // store a token if we received one
-        if let token = response.apiToken, let expiresAt = response.expiresAt {
-            let tokenResponse = APITokenResponse(apiToken: token, expiresAt: expiresAt)
-            // Store API token
-            try await tokenManager.storeAPIToken(tokenResponse)
-            // Request VPN token
-            try await refreshVPNToken()
-        }
+        let tokenResponse = APITokenResponse(apiToken: response.apiToken, expiresAt: response.expiresAt)
+        // Store API token
+        try await tokenManager.storeAPIToken(tokenResponse)
+        // Request VPN token
+        try await refreshVPNToken()
 
         return response
     }

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Account/DefaultAccountProvider.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Account/DefaultAccountProvider.swift
@@ -119,7 +119,6 @@ public final class DefaultAccountProvider: AccountProvider, ConfigurationAccess,
             guard let username = accessedDatabase.secure.username() else {
                 return nil
             }
-            // TODO: do we need this???
             let password = accessedDatabase.secure.password(for: username) ?? ""
             return UserAccount(
                 credentials: Credentials(username: username, password: password),

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Account/DefaultAccountProvider.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Account/DefaultAccountProvider.swift
@@ -119,9 +119,8 @@ public final class DefaultAccountProvider: AccountProvider, ConfigurationAccess,
             guard let username = accessedDatabase.secure.username() else {
                 return nil
             }
-            guard let password = accessedDatabase.secure.password(for: username) else {
-                return nil
-            }
+            // TODO: do we need this???
+            let password = accessedDatabase.secure.password(for: username) ?? ""
             return UserAccount(
                 credentials: Credentials(username: username, password: password),
                 info: accessedDatabase.plain.accountInfo
@@ -495,7 +494,8 @@ public final class DefaultAccountProvider: AccountProvider, ConfigurationAccess,
             accessedDatabase.plain.lastSignupEmail = request.email
 
             do {
-                let (credentials, needsToken) = try await webServices.signup(with: signup)
+                let signupResponse = try await webServices.signup(with: signup)
+                let credentials = signupResponse.buildCredentials()
 
                 if let transaction = request.transaction {
                     accessedStore.finishTransaction(transaction, success: true)
@@ -506,9 +506,6 @@ public final class DefaultAccountProvider: AccountProvider, ConfigurationAccess,
                 accessedDatabase.secure.setUsername(credentials.username)
                 accessedDatabase.secure.setPassword(credentials.password, for: credentials.username)
 
-                if needsToken {
-                    try await webServices.token(credentials: credentials)
-                }
                 let accountInfo = try await webServices.info()
                 accessedDatabase.plain.accountInfo = accountInfo
                 accessedDatabase.secure.setPublicUsername(accountInfo.username)

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Account/DefaultAccountProvider.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Account/DefaultAccountProvider.swift
@@ -495,7 +495,7 @@ public final class DefaultAccountProvider: AccountProvider, ConfigurationAccess,
             accessedDatabase.plain.lastSignupEmail = request.email
 
             do {
-                let credentials = try await webServices.signup(with: signup)
+                let (credentials, needsToken) = try await webServices.signup(with: signup)
 
                 if let transaction = request.transaction {
                     accessedStore.finishTransaction(transaction, success: true)
@@ -506,7 +506,9 @@ public final class DefaultAccountProvider: AccountProvider, ConfigurationAccess,
                 accessedDatabase.secure.setUsername(credentials.username)
                 accessedDatabase.secure.setPassword(credentials.password, for: credentials.username)
 
-                try await webServices.token(credentials: credentials)
+                if needsToken {
+                    try await webServices.token(credentials: credentials)
+                }
                 let accountInfo = try await webServices.info()
                 accessedDatabase.plain.accountInfo = accountInfo
                 accessedDatabase.secure.setPublicUsername(accountInfo.username)

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Account/EphemeralAccountProvider.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Account/EphemeralAccountProvider.swift
@@ -120,7 +120,7 @@ final class EphemeralAccountProvider: AccountProvider, ProvidersAccess, InAppAcc
             }
 
             do {
-                guard let (credentials, _) = try await webServices?.signup(with: signup) else {
+                guard let signupResponse = try await webServices?.signup(with: signup) else {
                     DispatchQueue.main.async { callback?(nil, nil) }
                     return
                 }
@@ -129,7 +129,7 @@ final class EphemeralAccountProvider: AccountProvider, ProvidersAccess, InAppAcc
                     accessedStore.finishTransaction(transaction, success: true)
                 }
 
-                let user = UserAccount(credentials: credentials, info: nil)
+                let user = UserAccount(credentials: signupResponse.buildCredentials(), info: nil)
                 self.currentUser = user
                 self.isLoggedIn = true
                 DispatchQueue.main.async { callback?(user, nil) }

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Account/EphemeralAccountProvider.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Account/EphemeralAccountProvider.swift
@@ -120,7 +120,7 @@ final class EphemeralAccountProvider: AccountProvider, ProvidersAccess, InAppAcc
             }
 
             do {
-                guard let credentials = try await webServices?.signup(with: signup) else {
+                guard let (credentials, _) = try await webServices?.signup(with: signup) else {
                     DispatchQueue.main.async { callback?(nil, nil) }
                     return
                 }

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Account/UserAccount.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Account/UserAccount.swift
@@ -23,7 +23,7 @@
 import Foundation
 
 /// The compound user account.
-public struct UserAccount: CustomStringConvertible, Equatable {
+public struct UserAccount: CustomStringConvertible, Equatable, Sendable {
 
     /// The account credentials.
     public let credentials: Credentials

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Mock/MockWebServices.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Mock/MockWebServices.swift
@@ -70,11 +70,11 @@ final class MockWebServices: WebServices {
 
     func deleteAccount() async throws {}
 
-    func signup(with request: Signup) async throws -> Credentials {
+    func signup(with request: Signup) async throws -> (credentials: Credentials, needsToken: Bool) {
         guard let result = credentials?() else {
             throw ClientError.unsupported
         }
-        return result
+        return (credentials: result, needsToken: true)
     }
 
     func redeem(with request: Redeem, _ callback: ((Credentials?, Error?) -> Void)?) {

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Mock/MockWebServices.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Mock/MockWebServices.swift
@@ -70,11 +70,11 @@ final class MockWebServices: WebServices {
 
     func deleteAccount() async throws {}
 
-    func signup(with request: Signup) async throws -> (credentials: Credentials, needsToken: Bool) {
+    func signup(with request: Signup) async throws -> SignupResponse {
         guard let result = credentials?() else {
             throw ClientError.unsupported
         }
-        return (credentials: result, needsToken: true)
+        return .credentials(result)
     }
 
     func redeem(with request: Redeem, _ callback: ((Credentials?, Error?) -> Void)?) {

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/WebServices/AccountInfo.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/WebServices/AccountInfo.swift
@@ -23,7 +23,7 @@
 import Foundation
 
 /// The information associated with a `Credentials`.
-public struct AccountInfo: Codable, Equatable {
+public struct AccountInfo: Codable, Equatable, Sendable {
 
     /// The linked email address if any.
     public internal(set) var email: String?

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/WebServices/Credentials.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/WebServices/Credentials.swift
@@ -23,7 +23,7 @@
 import Foundation
 
 /// The account credentials.
-public struct Credentials: Codable, Equatable {
+public struct Credentials: Codable, Equatable, Sendable {
 
     /// The username, typically a number prefixed with "p".
     public let username: String

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/WebServices/PIAWebServices.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/WebServices/PIAWebServices.swift
@@ -176,6 +176,7 @@ final class PIAWebServices: WebServices, ConfigurationAccess {
 
     private func mapNativeLoginError(_ error: Error) -> ClientError {
         let code = (error as? PIAAccountError)?.code ?? (error as? PIAMultipleErrors)?.code
+        log.debug("\(#function) code: \(code ?? 0) error: \(error)")
         switch code ?? 0 {
         case 402:
             return .expired
@@ -223,13 +224,9 @@ final class PIAWebServices: WebServices, ConfigurationAccess {
 
     func update(credentials: Credentials, resetPassword reset: Bool, email: String) async throws {
         do {
-            if reset {
-                let newPassword = try await nativeAccountAPI.setEmail(email: email, resetPassword: reset)
-                if let newPassword = newPassword {
-                    Client.configuration.tempAccountPassword = newPassword
-                }
-            } else {
-                try await nativeAccountAPI.setEmail(username: credentials.username, password: credentials.password, email: email, resetPassword: reset)
+            let newPassword = try await nativeAccountAPI.setEmail(email: email, resetPassword: reset)
+            if reset, let newPassword {
+                Client.configuration.tempAccountPassword = newPassword
             }
         } catch {
             throw mapNativeLoginError(error)
@@ -258,7 +255,7 @@ final class PIAWebServices: WebServices, ConfigurationAccess {
     }
 
     #if os(iOS) || os(tvOS)
-        func signup(with request: Signup) async throws -> (credentials: Credentials, needsToken: Bool) {
+        func signup(with request: Signup) async throws -> SignupResponse {
             var marketingJSON = ""
             if let marketing = request.marketing {
                 marketingJSON = stringify(json: marketing)
@@ -278,10 +275,13 @@ final class PIAWebServices: WebServices, ConfigurationAccess {
 
             do {
                 let response = try await nativeAccountAPI.signUp(information: info)
-                let needsToken = (response.apiToken?.isEmpty ?? true) || (response.expiresAt?.isEmpty ?? true)
-                let credentials = Credentials(username: response.username, password: response.password ?? "")
-                return (credentials: credentials, needsToken: needsToken)
+                if let password = response.password {
+                    return .credentials(Credentials(username: response.username, password: password))
+                } else {
+                    return .username(response.username)
+                }
             } catch {
+                log.error("Failed to signup: \(error)")
                 let code = (error as? PIAAccountError)?.code ?? (error as? PIAMultipleErrors)?.code
                 throw code == 400 ? ClientError.badReceipt : ClientError.invalidParameter
             }

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/WebServices/PIAWebServices.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/WebServices/PIAWebServices.swift
@@ -258,7 +258,7 @@ final class PIAWebServices: WebServices, ConfigurationAccess {
     }
 
     #if os(iOS) || os(tvOS)
-        func signup(with request: Signup) async throws -> Credentials {
+        func signup(with request: Signup) async throws -> (credentials: Credentials, needsToken: Bool) {
             var marketingJSON = ""
             if let marketing = request.marketing {
                 marketingJSON = stringify(json: marketing)
@@ -278,7 +278,9 @@ final class PIAWebServices: WebServices, ConfigurationAccess {
 
             do {
                 let response = try await nativeAccountAPI.signUp(information: info)
-                return Credentials(username: response.username, password: response.password)
+                let needsToken = (response.apiToken?.isEmpty ?? true) || (response.expiresAt?.isEmpty ?? true)
+                let credentials = Credentials(username: response.username, password: response.password ?? "")
+                return (credentials: credentials, needsToken: needsToken)
             } catch {
                 let code = (error as? PIAAccountError)?.code ?? (error as? PIAMultipleErrors)?.code
                 throw code == 400 ? ClientError.badReceipt : ClientError.invalidParameter

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/WebServices/Signup.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/WebServices/Signup.swift
@@ -63,3 +63,20 @@ private let log = PIALogger.logger(for: SignupRequest.self)
         }
     }
 #endif
+
+public enum SignupResponse: Sendable {
+    case username(String)
+    case credentials(Credentials)
+
+    /// Creates ``Credentials`` from the reponse.
+    ///
+    /// When on the ``username(_:)`` case, password will be empty string.
+    public func buildCredentials() -> Credentials {
+        switch self {
+        case .username(let username):
+            return Credentials(username: username, password: "")
+        case .credentials(let credentials):
+            return credentials
+        }
+    }
+}

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/WebServices/WebServices.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/WebServices/WebServices.swift
@@ -62,11 +62,9 @@ protocol WebServices: AnyObject {
      */
     func deleteAccount() async throws
 
-    #if os(iOS) || os(tvOS)
-        func signup(with request: Signup) async throws -> Credentials
+    func signup(with request: Signup) async throws -> (credentials: Credentials, needsToken: Bool)
 
-        func processPayment(credentials: Credentials, request: Payment) async throws
-    #endif
+    func processPayment(credentials: Credentials, request: Payment) async throws
 
     // MARK: Store
 

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/WebServices/WebServices.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/WebServices/WebServices.swift
@@ -62,7 +62,7 @@ protocol WebServices: AnyObject {
      */
     func deleteAccount() async throws
 
-    func signup(with request: Signup) async throws -> (credentials: Credentials, needsToken: Bool)
+    func signup(with request: Signup) async throws -> SignupResponse
 
     func processPayment(credentials: Credentials, request: Payment) async throws
 

--- a/PIA VPN/UI/ConfirmVPNPlanViewController.swift
+++ b/PIA VPN/UI/ConfirmVPNPlanViewController.swift
@@ -135,7 +135,7 @@ final class ConfirmVPNPlanViewController: AutolayoutViewController, BrandableNav
 
                 let alert = Macros.alert(L10n.Signup.Unreachable.vcTitle, L10n.Welcome.Update.Account.Email.error)
                 alert.addActionWithTitle(L10n.Global.close) {
-                    self?.perform(segue: StoryboardSegue.Signup.successShowCredentialsSegueIdentifier)
+                    self?.onSuccess(password: password)
                 }
                 self?.present(alert, animated: true, completion: nil)
 
@@ -144,7 +144,20 @@ final class ConfirmVPNPlanViewController: AutolayoutViewController, BrandableNav
 
             log.debug("Account: Email successfully modified")
             self?.textEmail.endEditing(true)
-            self?.perform(segue: StoryboardSegue.Signup.successShowCredentialsSegueIdentifier)
+            self?.onSuccess(password: password)
+        }
+    }
+
+    private func onSuccess(password: String) {
+        if password.isEmpty {
+            // we skip the screen showing username+password
+            guard let user = config.metadata.user else {
+                log.error("User account not set in metadata")
+                return
+            }
+            config.completionDelegate?.welcomeDidSignup(withUser: user, topViewController: self)
+        } else {
+            perform(segue: StoryboardSegue.Signup.successShowCredentialsSegueIdentifier)
         }
     }
 

--- a/PIA VPN/UI/ConfirmVPNPlanViewController.swift
+++ b/PIA VPN/UI/ConfirmVPNPlanViewController.swift
@@ -134,7 +134,9 @@ final class ConfirmVPNPlanViewController: AutolayoutViewController, BrandableNav
                 self?.textEmail.text = ""
 
                 let alert = Macros.alert(L10n.Signup.Unreachable.vcTitle, L10n.Welcome.Update.Account.Email.error)
-                alert.addDefaultAction(L10n.Global.close)
+                alert.addActionWithTitle(L10n.Global.close) {
+                    self?.perform(segue: StoryboardSegue.Signup.successShowCredentialsSegueIdentifier)
+                }
                 self?.present(alert, animated: true, completion: nil)
 
                 return


### PR DESCRIPTION
- Now `/v5/signup` can either return username + password, or username + apiToken.
- With a password we work as we did before: another request to get the token
- With apiToken: we simply continue, as we have the token already