### PR TITLE
KM-17457: Introduce IAP processing KPI metrics

### DIFF
--- a/LocalPackages/PIALibrary/Package.swift
+++ b/LocalPackages/PIALibrary/Package.swift
@@ -71,6 +71,7 @@ let package = Package(
             name: "PIALibraryTests",
             dependencies: [
                 "PIALibrary",
+                .product(name: "PIAKPI", package: "PIAKPI"),
                 .product(
                     name: "TunnelKitOpenVPN",
                     package: "mobile-ios-openvpn",

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Account/DefaultAccountProvider.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Account/DefaultAccountProvider.swift
@@ -526,8 +526,10 @@ public final class DefaultAccountProvider: AccountProvider, ConfigurationAccess,
             } catch let error as ClientError where error == .badReceipt {
                 // If signup failed with badReceipt (HTTP 400), try login-with-receipt.
                 // This handles returning users (e.g. "Duplicate purchase" from API).
-                // The fallback reports the final verification outcome, so no event here.
-                await attemptLoginWithReceiptFallback(transaction: request.transaction, callback: callback)
+                // That second attempt on the same transaction is the retry; the fallback
+                // reports its outcome, so no failure event here.
+                ServiceQualityManager.shared.iapProcessingRetryEvent(origin: .signup, error: error, retryCount: 1)
+                await attemptLoginWithReceiptFallback(transaction: request.transaction, retryCount: 1, callback: callback)
             } catch {
                 let isOffline = (error as? URLError)?.code == .notConnectedToInternet
                 let reportedError: Error = isOffline ? ClientError.internetUnreachable : error
@@ -542,7 +544,7 @@ public final class DefaultAccountProvider: AccountProvider, ConfigurationAccess,
             }
         }
 
-        private func attemptLoginWithReceiptFallback(transaction: (any InAppTransaction)?, callback: ((UserAccount?, Error?) -> Void)?) async {
+        private func attemptLoginWithReceiptFallback(transaction: (any InAppTransaction)?, retryCount: Int, callback: ((UserAccount?, Error?) -> Void)?) async {
             let jws: JWS?
             if let transaction {
                 jws = transaction.jwsRepresentation
@@ -551,7 +553,7 @@ public final class DefaultAccountProvider: AccountProvider, ConfigurationAccess,
             }
 
             guard let jws else {
-                ServiceQualityManager.shared.iapProcessingFailureEvent(origin: .signup, error: ClientError.badReceipt)
+                ServiceQualityManager.shared.iapProcessingFailureEvent(origin: .signup, error: ClientError.badReceipt, retryCount: retryCount)
                 DispatchQueue.main.async { callback?(nil, ClientError.badReceipt) }
                 return
             }
@@ -559,12 +561,12 @@ public final class DefaultAccountProvider: AccountProvider, ConfigurationAccess,
             do {
                 try await webServices.token(receipt: jws)
             } catch {
-                ServiceQualityManager.shared.iapProcessingFailureEvent(origin: .signup, error: error)
+                ServiceQualityManager.shared.iapProcessingFailureEvent(origin: .signup, error: error, retryCount: retryCount)
                 DispatchQueue.main.async { callback?(nil, ClientError.badReceipt) }
                 return
             }
             // Receipt verified via the login-with-receipt fallback.
-            ServiceQualityManager.shared.iapProcessingSuccessEvent(origin: .signup)
+            ServiceQualityManager.shared.iapProcessingSuccessEvent(origin: .signup, retryCount: retryCount)
 
             if let transaction = transaction {
                 accessedStore.finishTransaction(transaction, success: true)

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Account/DefaultAccountProvider.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Account/DefaultAccountProvider.swift
@@ -177,14 +177,14 @@ public final class DefaultAccountProvider: AccountProvider, ConfigurationAccess,
 
         Task { @MainActor in
             let credentials = Credentials(username: "", password: "")
-            ServiceQualityManager.shared.iapProcessingPurchaseEvent(origin: .signup)
+            ServiceQualityManager.shared.iapProcessingPurchaseEvent(origin: .restore)
 
             do {
                 try await webServices.token(receipt: receiptRequest.receipt)
-                ServiceQualityManager.shared.iapProcessingSuccessEvent(origin: .signup)
+                ServiceQualityManager.shared.iapProcessingSuccessEvent(origin: .restore)
                 self.handleLoginResult(error: nil, credentials: credentials, callback: callback)
             } catch {
-                ServiceQualityManager.shared.iapProcessingFailureEvent(origin: .signup, error: error)
+                ServiceQualityManager.shared.iapProcessingFailureEvent(origin: .restore, error: error)
                 self.handleLoginResult(error: error, credentials: credentials, callback: callback)
             }
         }
@@ -659,13 +659,13 @@ public final class DefaultAccountProvider: AccountProvider, ConfigurationAccess,
             }
 
             // A renewal IAP transaction starts processing (Kape verification path).
-            ServiceQualityManager.shared.iapProcessingPurchaseEvent(origin: .renewal)
+            ServiceQualityManager.shared.iapProcessingPurchaseEvent(origin: .renew)
 
             var verificationSucceeded = false
             do {
                 try await webServices.processPayment(credentials: user.credentials, request: payment)
                 verificationSucceeded = true
-                ServiceQualityManager.shared.iapProcessingSuccessEvent(origin: .renewal)
+                ServiceQualityManager.shared.iapProcessingSuccessEvent(origin: .renew)
 
                 if let transaction = request.transaction {
                     accessedStore.finishTransaction(transaction, success: true)
@@ -680,7 +680,7 @@ public final class DefaultAccountProvider: AccountProvider, ConfigurationAccess,
                 DispatchQueue.main.async { callback?(user, nil) }
             } catch {
                 if !verificationSucceeded {
-                    ServiceQualityManager.shared.iapProcessingFailureEvent(origin: .renewal, error: error)
+                    ServiceQualityManager.shared.iapProcessingFailureEvent(origin: .renew, error: error)
                 }
                 DispatchQueue.main.async { callback?(nil, error) }
             }

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Account/DefaultAccountProvider.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Account/DefaultAccountProvider.swift
@@ -177,11 +177,14 @@ public final class DefaultAccountProvider: AccountProvider, ConfigurationAccess,
 
         Task { @MainActor in
             let credentials = Credentials(username: "", password: "")
+            ServiceQualityManager.shared.iapProcessingPurchaseEvent(origin: .signup)
 
             do {
                 try await webServices.token(receipt: receiptRequest.receipt)
+                ServiceQualityManager.shared.iapProcessingSuccessEvent(origin: .signup)
                 self.handleLoginResult(error: nil, credentials: credentials, callback: callback)
             } catch {
+                ServiceQualityManager.shared.iapProcessingFailureEvent(origin: .signup, error: error)
                 self.handleLoginResult(error: error, credentials: credentials, callback: callback)
             }
         }

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Account/DefaultAccountProvider.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Account/DefaultAccountProvider.swift
@@ -496,9 +496,15 @@ public final class DefaultAccountProvider: AccountProvider, ConfigurationAccess,
 
             accessedDatabase.plain.lastSignupEmail = request.email
 
+            // A new IAP transaction starts processing (Kape verification path).
+            ServiceQualityManager.shared.iapProcessingPurchaseEvent(origin: .signup)
+
+            var verificationSucceeded = false
             do {
                 let signupResponse = try await webServices.signup(with: signup)
                 let credentials = signupResponse.buildCredentials()
+                verificationSucceeded = true
+                ServiceQualityManager.shared.iapProcessingSuccessEvent(origin: .signup)
 
                 if let transaction = request.transaction {
                     accessedStore.finishTransaction(transaction, success: true)
@@ -520,14 +526,19 @@ public final class DefaultAccountProvider: AccountProvider, ConfigurationAccess,
             } catch let error as ClientError where error == .badReceipt {
                 // If signup failed with badReceipt (HTTP 400), try login-with-receipt.
                 // This handles returning users (e.g. "Duplicate purchase" from API).
+                // The fallback reports the final verification outcome, so no event here.
                 await attemptLoginWithReceiptFallback(transaction: request.transaction, callback: callback)
             } catch {
-                if let urlError = error as? URLError, (urlError.code == .notConnectedToInternet) {
-                    DispatchQueue.main.async { callback?(nil, ClientError.internetUnreachable) }
-                    return
+                let isOffline = (error as? URLError)?.code == .notConnectedToInternet
+                let reportedError: Error = isOffline ? ClientError.internetUnreachable : error
+
+                // Report a verification failure only if success was not already reported
+                // (later account-setup calls failing is not a verification failure).
+                if !verificationSucceeded {
+                    ServiceQualityManager.shared.iapProcessingFailureEvent(origin: .signup, error: reportedError)
                 }
 
-                DispatchQueue.main.async { callback?(nil, error) }
+                DispatchQueue.main.async { callback?(nil, reportedError) }
             }
         }
 
@@ -540,6 +551,7 @@ public final class DefaultAccountProvider: AccountProvider, ConfigurationAccess,
             }
 
             guard let jws else {
+                ServiceQualityManager.shared.iapProcessingFailureEvent(origin: .signup, error: ClientError.badReceipt)
                 DispatchQueue.main.async { callback?(nil, ClientError.badReceipt) }
                 return
             }
@@ -547,9 +559,12 @@ public final class DefaultAccountProvider: AccountProvider, ConfigurationAccess,
             do {
                 try await webServices.token(receipt: jws)
             } catch {
+                ServiceQualityManager.shared.iapProcessingFailureEvent(origin: .signup, error: error)
                 DispatchQueue.main.async { callback?(nil, ClientError.badReceipt) }
                 return
             }
+            // Receipt verified via the login-with-receipt fallback.
+            ServiceQualityManager.shared.iapProcessingSuccessEvent(origin: .signup)
 
             if let transaction = transaction {
                 accessedStore.finishTransaction(transaction, success: true)
@@ -638,8 +653,14 @@ public final class DefaultAccountProvider: AccountProvider, ConfigurationAccess,
                 return
             }
 
+            // A renewal IAP transaction starts processing (Kape verification path).
+            ServiceQualityManager.shared.iapProcessingPurchaseEvent(origin: .renewal)
+
+            var verificationSucceeded = false
             do {
                 try await webServices.processPayment(credentials: user.credentials, request: payment)
+                verificationSucceeded = true
+                ServiceQualityManager.shared.iapProcessingSuccessEvent(origin: .renewal)
 
                 if let transaction = request.transaction {
                     accessedStore.finishTransaction(transaction, success: true)
@@ -653,6 +674,9 @@ public final class DefaultAccountProvider: AccountProvider, ConfigurationAccess,
                 Macros.postNotification(.PIAAccountDidRefresh, [.user: user])
                 DispatchQueue.main.async { callback?(user, nil) }
             } catch {
+                if !verificationSucceeded {
+                    ServiceQualityManager.shared.iapProcessingFailureEvent(origin: .renewal, error: error)
+                }
                 DispatchQueue.main.async { callback?(nil, error) }
             }
         }

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/ServiceQuality/ServiceQualityManager.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/ServiceQuality/ServiceQualityManager.swift
@@ -89,7 +89,6 @@ public final class ServiceQualityManager: NSObject {
         case environment
         case retryCount
         case error
-        case csi
         case internalError
         case rawError
     }
@@ -284,8 +283,8 @@ public final class ServiceQualityManager: NSObject {
     }
 
     /// A verification attempt failed and is being retried on the KapeClientSDK path.
-    /// NOTE: not wired yet — client-side retry logic is delivered by the separate
-    /// retry/XV ticket, which will call this with the incremented `retryCount`.
+    /// Reported when signup verification returns HTTP 400 and the login-with-receipt
+    /// fallback re-verifies the same transaction; `retryCount` is that attempt's number.
     public func iapProcessingRetryEvent(origin: KPIIapOrigin, error: Error, retryCount: Int) {
         var properties = baseIapProperties(origin: origin)
         properties[KPIIapPropertyKey.retryCount.rawValue] = String(retryCount)
@@ -328,7 +327,8 @@ public final class ServiceQualityManager: NSObject {
     }
 
     /// Optional diagnostic detail for failure events (`internalError`, `rawError`).
-    /// `csi` has no client-side source and is intentionally omitted.
+    /// The XV spec also lists a `csi` property, which has no client-side source on
+    /// Apple platforms and is therefore never reported.
     private func iapErrorDetails(for error: Error) -> [String: String] {
         var details: [String: String] = [
             KPIIapPropertyKey.rawError.rawValue: String(describing: error)

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/ServiceQuality/ServiceQualityManager.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/ServiceQuality/ServiceQualityManager.swift
@@ -27,7 +27,7 @@ private let log = PIALogger.logger(for: ServiceQualityManager.self)
 public final class ServiceQualityManager: NSObject {
 
     public static let shared = ServiceQualityManager()
-    private let kpiPreferenceName = "PIA_KPI_PREFERENCE_NAME"
+    private static let kpiPreferenceName = "PIA_KPI_PREFERENCE_NAME"
     private var kpiManager: KPIAPI?
     private var isAppActive = true
 
@@ -68,12 +68,60 @@ public final class ServiceQualityManager: NSObject {
         case timeToConnect = "time_to_connect"
     }
 
+    /**
+     * Enum defining the in-app-purchase processing events.
+     * These track the KapeClientSDK receipt-verification funnel.
+     */
+    private enum KPIIapEvent: String {
+        case iapProcessingPurchase = "iap_processing_purchase"
+        case iapProcessingSuccess = "iap_processing_success"
+        case iapProcessingRetry = "iap_processing_retry"
+        case iapProcessingFailure = "iap_processing_failure"
+    }
+
+    /**
+     * Property keys for the IAP processing events. Their raw values are camelCase
+     * on purpose: they are the cross-platform (XV) wire contract, unlike the
+     * lower_snake_case keys used by the connection events above.
+     */
+    private enum KPIIapPropertyKey: String {
+        case origin
+        case environment
+        case retryCount
+        case error
+        case csi
+        case internalError
+        case rawError
+    }
+
+    /**
+     * The user-facing flow a purchase originated from, reported as the `origin`
+     * property. NOTE: the XV spec lists `origin` but does not enumerate its values;
+     * these map to the two purchase-crediting flows and can be adjusted if XV
+     * expects a fixed literal (e.g. a store name).
+     */
+    public enum KPIIapOrigin: String {
+        case signup
+        case renewal
+    }
+
     public override init() {
         super.init()
+        kpiManager = ServiceQualityManager.makeKPIManager()
+        registerAppStateObservers()
+    }
 
+    /// Injectable initializer used by unit tests to supply a mock `KPIAPI`.
+    init(kpiManager: KPIAPI?) {
+        super.init()
+        self.kpiManager = kpiManager
+        registerAppStateObservers()
+    }
+
+    private static func makeKPIManager() -> KPIAPI? {
         do {
             let provider: KPIClientStateProvider = Client.environment == .staging ? PIAKPIStagingClientStateProvider() : PIAKPIClientStateProvider()
-            kpiManager = try KPIBuilder()
+            return try KPIBuilder()
                 .setFlushEventMode(.perBatch)
                 .setKPIClientStateProvider(provider)
                 .setEventTimeRoundGranularity(.hours)
@@ -84,8 +132,11 @@ public final class ServiceQualityManager: NSObject {
                 .build()
         } catch {
             log.error("KPI manager build failed: \(error)")
+            return nil
         }
+    }
 
+    private func registerAppStateObservers() {
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(appChangedState(with:)),
@@ -96,7 +147,6 @@ public final class ServiceQualityManager: NSObject {
             selector: #selector(appChangedState(with:)),
             name: UIApplication.didBecomeActiveNotification,
             object: nil)
-
     }
 
     deinit {
@@ -213,6 +263,103 @@ public final class ServiceQualityManager: NSObject {
             do {
                 try await kpiManager.submit(event: event)
                 log.debug("KPI event submitted \(event)")
+            } catch {
+                log.error("\(error)")
+            }
+        }
+    }
+
+    // MARK: IAP processing events
+
+    /// A new IAP transaction starts processing on the KapeClientSDK path.
+    public func iapProcessingPurchaseEvent(origin: KPIIapOrigin) {
+        submitIapEvent(.iapProcessingPurchase, properties: baseIapProperties(origin: origin))
+    }
+
+    /// The purchase succeeded verification using KapeClientSDK.
+    public func iapProcessingSuccessEvent(origin: KPIIapOrigin, retryCount: Int = 0) {
+        var properties = baseIapProperties(origin: origin)
+        properties[KPIIapPropertyKey.retryCount.rawValue] = String(retryCount)
+        submitIapEvent(.iapProcessingSuccess, properties: properties)
+    }
+
+    /// A verification attempt failed and is being retried on the KapeClientSDK path.
+    /// NOTE: not wired yet — client-side retry logic is delivered by the separate
+    /// retry/XV ticket, which will call this with the incremented `retryCount`.
+    public func iapProcessingRetryEvent(origin: KPIIapOrigin, error: Error, retryCount: Int) {
+        var properties = baseIapProperties(origin: origin)
+        properties[KPIIapPropertyKey.retryCount.rawValue] = String(retryCount)
+        properties[KPIIapPropertyKey.error.rawValue] = iapErrorCode(for: error)
+        submitIapEvent(.iapProcessingRetry, properties: properties)
+    }
+
+    /// The purchase failed verification using KapeClientSDK.
+    public func iapProcessingFailureEvent(origin: KPIIapOrigin, error: Error, retryCount: Int? = nil) {
+        var properties = baseIapProperties(origin: origin)
+        properties[KPIIapPropertyKey.error.rawValue] = iapErrorCode(for: error)
+        if let retryCount {
+            properties[KPIIapPropertyKey.retryCount.rawValue] = String(retryCount)
+        }
+        properties.merge(iapErrorDetails(for: error)) { _, new in new }
+        submitIapEvent(.iapProcessingFailure, properties: properties)
+    }
+
+    private func baseIapProperties(origin: KPIIapOrigin) -> [String: String] {
+        [
+            KPIIapPropertyKey.origin.rawValue: origin.rawValue,
+            KPIIapPropertyKey.environment.rawValue: Client.environment.rawValue
+        ]
+    }
+
+    /// Short, stable identifier for the primary `error` property.
+    private func iapErrorCode(for error: Error) -> String {
+        switch error {
+        case let clientError as ClientError:
+            switch clientError {
+            case .unknown(let code, _): return "unknown_\(code)"
+            case .throttled(let retryAfter): return "throttled_\(retryAfter)"
+            case .libraryError: return "library_error"
+            default: return String(describing: clientError)
+            }
+        default:
+            let nsError = error as NSError
+            return "\(nsError.domain)_\(nsError.code)"
+        }
+    }
+
+    /// Optional diagnostic detail for failure events (`internalError`, `rawError`).
+    /// `csi` has no client-side source and is intentionally omitted.
+    private func iapErrorDetails(for error: Error) -> [String: String] {
+        var details: [String: String] = [
+            KPIIapPropertyKey.rawError.rawValue: String(describing: error)
+        ]
+        if let clientError = error as? ClientError {
+            switch clientError {
+            case .unknown(_, let message), .libraryError(let message):
+                if let message {
+                    details[KPIIapPropertyKey.internalError.rawValue] = message
+                }
+            default:
+                break
+            }
+        }
+        return details
+    }
+
+    private func submitIapEvent(_ event: KPIIapEvent, properties: [String: String]) {
+        guard Client.preferences.shareServiceQualityData, let kpiManager else { return }
+
+        let clientEvent = KPIClientEvent(
+            eventCountry: nil,
+            eventName: event.rawValue,
+            eventProperties: properties,
+            eventInstant: Date()
+        )
+
+        Task {
+            do {
+                try await kpiManager.submit(event: clientEvent)
+                log.debug("KPI event submitted \(clientEvent)")
             } catch {
                 log.error("\(error)")
             }

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/ServiceQuality/ServiceQualityManager.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/ServiceQuality/ServiceQualityManager.swift
@@ -95,13 +95,15 @@ public final class ServiceQualityManager: NSObject {
 
     /**
      * The user-facing flow a purchase originated from, reported as the `origin`
-     * property. NOTE: the XV spec lists `origin` but does not enumerate its values;
-     * these map to the two purchase-crediting flows and can be adjusted if XV
-     * expects a fixed literal (e.g. a store name).
+     * property. These are the values enumerated by the XV spec; the raw values are
+     * the wire contract, so they must not be renamed. `update` is not emitted yet:
+     * no plan-change flow is instrumented.
      */
     public enum KPIIapOrigin: String {
         case signup
-        case renewal
+        case renew
+        case restore
+        case update
     }
 
     public override init() {

--- a/LocalPackages/PIALibrary/Tests/PIALibraryTests/Mocks/MockKPIAPI.swift
+++ b/LocalPackages/PIALibrary/Tests/PIALibraryTests/Mocks/MockKPIAPI.swift
@@ -24,8 +24,8 @@ import PIAKPI
 import XCTest
 
 /// Test double for `KPIAPI` that captures submitted events. Events are submitted from a
-/// detached `Task` inside `ServiceQualityManager`, so tests fulfill `submitExpectation`
-/// to await the submission before asserting.
+/// detached `Task` inside `ServiceQualityManager`, so tests await one of the expectations
+/// below before asserting.
 final class MockKPIAPI: KPIAPI, @unchecked Sendable {
 
     private let lock = NSLock()
@@ -38,11 +38,27 @@ final class MockKPIAPI: KPIAPI, @unchecked Sendable {
         return storedEvents
     }
 
-    /// Fulfilled once for every `submit(event:)` call.
-    func expectSubmission(_ expectation: XCTestExpectation) {
+    /// Returns an expectation fulfilled once per `submit(event:)` call and satisfied by
+    /// exactly `count` of them. A further submission over-fulfills it and fails the test,
+    /// so an unexpected extra event cannot pass unnoticed.
+    func expectSubmissions(_ count: Int = 1) -> XCTestExpectation {
+        let expectation = XCTestExpectation(description: "\(count) event(s) submitted")
+        expectation.expectedFulfillmentCount = count
+        return storing(expectation)
+    }
+
+    /// Returns an inverted expectation that fails if any event is submitted.
+    func expectNoSubmission() -> XCTestExpectation {
+        let expectation = XCTestExpectation(description: "no event submitted")
+        expectation.isInverted = true
+        return storing(expectation)
+    }
+
+    private func storing(_ expectation: XCTestExpectation) -> XCTestExpectation {
         lock.lock()
         defer { lock.unlock() }
         submitExpectation = expectation
+        return expectation
     }
 
     func start() async {}

--- a/LocalPackages/PIALibrary/Tests/PIALibraryTests/Mocks/MockKPIAPI.swift
+++ b/LocalPackages/PIALibrary/Tests/PIALibraryTests/Mocks/MockKPIAPI.swift
@@ -1,0 +1,60 @@
+//
+//  MockKPIAPI.swift
+//  PIALibraryTests
+//
+//  Copyright © 2026 Private Internet Access, Inc.
+//
+//  This file is part of the Private Internet Access iOS Client.
+//
+//  The Private Internet Access iOS Client is free software: you can redistribute it and/or
+//  modify it under the terms of the GNU General Public License as published by the Free
+//  Software Foundation, either version 3 of the License, or (at your option) any later version.
+//
+//  The Private Internet Access iOS Client is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+//  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+//  details.
+//
+//  You should have received a copy of the GNU General Public License along with the Private
+//  Internet Access iOS Client.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Foundation
+import PIAKPI
+import XCTest
+
+/// Test double for `KPIAPI` that captures submitted events. Events are submitted from a
+/// detached `Task` inside `ServiceQualityManager`, so tests fulfill `submitExpectation`
+/// to await the submission before asserting.
+final class MockKPIAPI: KPIAPI, @unchecked Sendable {
+
+    private let lock = NSLock()
+    private var storedEvents: [KPIClientEvent] = []
+    private var submitExpectation: XCTestExpectation?
+
+    var submittedEvents: [KPIClientEvent] {
+        lock.lock()
+        defer { lock.unlock() }
+        return storedEvents
+    }
+
+    /// Fulfilled once for every `submit(event:)` call.
+    func expectSubmission(_ expectation: XCTestExpectation) {
+        lock.lock()
+        defer { lock.unlock() }
+        submitExpectation = expectation
+    }
+
+    func start() async {}
+    func stop() async throws {}
+    func flush() async throws {}
+    func recentEvents() async -> [String] { [] }
+
+    func submit(event: KPIClientEvent) async throws {
+        lock.lock()
+        storedEvents.append(event)
+        let expectation = submitExpectation
+        lock.unlock()
+        expectation?.fulfill()
+    }
+}

--- a/LocalPackages/PIALibrary/Tests/PIALibraryTests/ServiceQualityManagerTests.swift
+++ b/LocalPackages/PIALibrary/Tests/PIALibraryTests/ServiceQualityManagerTests.swift
@@ -1,0 +1,139 @@
+//
+//  ServiceQualityManagerTests.swift
+//  PIALibraryTests
+//
+//  Copyright © 2026 Private Internet Access, Inc.
+//
+//  This file is part of the Private Internet Access iOS Client.
+//
+//  The Private Internet Access iOS Client is free software: you can redistribute it and/or
+//  modify it under the terms of the GNU General Public License as published by the Free
+//  Software Foundation, either version 3 of the License, or (at your option) any later version.
+//
+//  The Private Internet Access iOS Client is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+//  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+//  details.
+//
+//  You should have received a copy of the GNU General Public License along with the Private
+//  Internet Access iOS Client.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import PIAKPI
+import XCTest
+
+@testable import PIALibrary
+
+final class ServiceQualityManagerTests: XCTestCase {
+
+    private var mockKPI: MockKPIAPI!
+    private var sut: ServiceQualityManager!
+
+    override func setUp() {
+        super.setUp()
+        Client.database = Client.Database(group: "group.com.privateinternetaccess")
+        mockKPI = MockKPIAPI()
+        sut = ServiceQualityManager(kpiManager: mockKPI)
+        setConsent(true)
+    }
+
+    override func tearDown() {
+        setConsent(false)
+        sut = nil
+        mockKPI = nil
+        super.tearDown()
+    }
+
+    private func setConsent(_ enabled: Bool) {
+        let prefs = Client.preferences.editable()
+        prefs.shareServiceQualityData = enabled
+        prefs.commit()
+    }
+
+    private func firstSubmittedEvent(
+        after action: () -> Void,
+        timeout: TimeInterval = 2.0
+    ) -> KPIClientEvent? {
+        let submitted = expectation(description: "event submitted")
+        mockKPI.expectSubmission(submitted)
+        action()
+        wait(for: [submitted], timeout: timeout)
+        return mockKPI.submittedEvents.first
+    }
+
+    func testPurchaseEventNameAndProperties() {
+        let event = firstSubmittedEvent {
+            sut.iapProcessingPurchaseEvent(origin: .signup)
+        }
+
+        XCTAssertEqual(event?.eventName, "iap_processing_purchase")
+        XCTAssertEqual(event?.eventProperties["origin"], "signup")
+        XCTAssertEqual(event?.eventProperties["environment"], Client.environment.rawValue)
+        // Purchase carries only origin + environment.
+        XCTAssertNil(event?.eventProperties["retryCount"])
+        XCTAssertNil(event?.eventProperties["error"])
+    }
+
+    func testSuccessEventIncludesRetryCount() {
+        let event = firstSubmittedEvent {
+            sut.iapProcessingSuccessEvent(origin: .renewal, retryCount: 0)
+        }
+
+        XCTAssertEqual(event?.eventName, "iap_processing_success")
+        XCTAssertEqual(event?.eventProperties["origin"], "renewal")
+        XCTAssertEqual(event?.eventProperties["retryCount"], "0")
+    }
+
+    func testRetryEventIncludesErrorAndRetryCount() {
+        let event = firstSubmittedEvent {
+            sut.iapProcessingRetryEvent(
+                origin: .renewal,
+                error: ClientError.throttled(retryAfter: 5),
+                retryCount: 2
+            )
+        }
+
+        XCTAssertEqual(event?.eventName, "iap_processing_retry")
+        XCTAssertEqual(event?.eventProperties["origin"], "renewal")
+        XCTAssertEqual(event?.eventProperties["error"], "throttled_5")
+        XCTAssertEqual(event?.eventProperties["retryCount"], "2")
+    }
+
+    func testFailureEventIncludesErrorCodeAndRawError() {
+        let event = firstSubmittedEvent {
+            sut.iapProcessingFailureEvent(origin: .signup, error: ClientError.badReceipt)
+        }
+
+        XCTAssertEqual(event?.eventName, "iap_processing_failure")
+        XCTAssertEqual(event?.eventProperties["origin"], "signup")
+        XCTAssertEqual(event?.eventProperties["error"], "badReceipt")
+        XCTAssertNotNil(event?.eventProperties["rawError"])
+        // retryCount is optional on failure and omitted until retry logic exists.
+        XCTAssertNil(event?.eventProperties["retryCount"])
+    }
+
+    func testFailureEventSurfacesInternalErrorMessage() {
+        let event = firstSubmittedEvent {
+            sut.iapProcessingFailureEvent(
+                origin: .signup,
+                error: ClientError.unknown(code: 606, message: "boom")
+            )
+        }
+
+        XCTAssertEqual(event?.eventProperties["error"], "unknown_606")
+        XCTAssertEqual(event?.eventProperties["internalError"], "boom")
+    }
+
+    func testEventSuppressedWhenConsentDisabled() {
+        setConsent(false)
+
+        let notSubmitted = expectation(description: "no event submitted")
+        notSubmitted.isInverted = true
+        mockKPI.expectSubmission(notSubmitted)
+
+        sut.iapProcessingPurchaseEvent(origin: .signup)
+
+        wait(for: [notSubmitted], timeout: 1.0)
+        XCTAssertTrue(mockKPI.submittedEvents.isEmpty)
+    }
+}

--- a/LocalPackages/PIALibrary/Tests/PIALibraryTests/ServiceQualityManagerTests.swift
+++ b/LocalPackages/PIALibrary/Tests/PIALibraryTests/ServiceQualityManagerTests.swift
@@ -28,17 +28,20 @@ final class ServiceQualityManagerTests: XCTestCase {
 
     private var mockKPI: MockKPIAPI!
     private var sut: ServiceQualityManager!
+    private var originalConsent: Bool!
 
     override func setUp() {
         super.setUp()
         Client.database = Client.Database(group: "group.com.privateinternetaccess")
+        originalConsent = Client.preferences.shareServiceQualityData
         mockKPI = MockKPIAPI()
         sut = ServiceQualityManager(kpiManager: mockKPI)
         setConsent(true)
     }
 
     override func tearDown() {
-        setConsent(false)
+        setConsent(originalConsent)
+        originalConsent = nil
         sut = nil
         mockKPI = nil
         super.tearDown()
@@ -54,8 +57,7 @@ final class ServiceQualityManagerTests: XCTestCase {
         after action: () -> Void,
         timeout: TimeInterval = 2.0
     ) -> KPIClientEvent? {
-        let submitted = expectation(description: "event submitted")
-        mockKPI.expectSubmission(submitted)
+        let submitted = mockKPI.expectSubmissions()
         action()
         wait(for: [submitted], timeout: timeout)
         return mockKPI.submittedEvents.first
@@ -127,9 +129,7 @@ final class ServiceQualityManagerTests: XCTestCase {
     func testEventSuppressedWhenConsentDisabled() {
         setConsent(false)
 
-        let notSubmitted = expectation(description: "no event submitted")
-        notSubmitted.isInverted = true
-        mockKPI.expectSubmission(notSubmitted)
+        let notSubmitted = mockKPI.expectNoSubmission()
 
         sut.iapProcessingPurchaseEvent(origin: .signup)
 

--- a/LocalPackages/PIALibrary/Tests/PIALibraryTests/ServiceQualityManagerTests.swift
+++ b/LocalPackages/PIALibrary/Tests/PIALibraryTests/ServiceQualityManagerTests.swift
@@ -76,27 +76,44 @@ final class ServiceQualityManagerTests: XCTestCase {
         XCTAssertNil(event?.eventProperties["error"])
     }
 
+    /// The `origin` raw values are the XV wire contract, so they are asserted as literals.
+    func testOriginWireValues() {
+        XCTAssertEqual(ServiceQualityManager.KPIIapOrigin.signup.rawValue, "signup")
+        XCTAssertEqual(ServiceQualityManager.KPIIapOrigin.renew.rawValue, "renew")
+        XCTAssertEqual(ServiceQualityManager.KPIIapOrigin.restore.rawValue, "restore")
+        XCTAssertEqual(ServiceQualityManager.KPIIapOrigin.update.rawValue, "update")
+    }
+
+    func testRestoreOriginIsReported() {
+        let event = firstSubmittedEvent {
+            sut.iapProcessingPurchaseEvent(origin: .restore)
+        }
+
+        XCTAssertEqual(event?.eventName, "iap_processing_purchase")
+        XCTAssertEqual(event?.eventProperties["origin"], "restore")
+    }
+
     func testSuccessEventIncludesRetryCount() {
         let event = firstSubmittedEvent {
-            sut.iapProcessingSuccessEvent(origin: .renewal, retryCount: 0)
+            sut.iapProcessingSuccessEvent(origin: .renew, retryCount: 0)
         }
 
         XCTAssertEqual(event?.eventName, "iap_processing_success")
-        XCTAssertEqual(event?.eventProperties["origin"], "renewal")
+        XCTAssertEqual(event?.eventProperties["origin"], "renew")
         XCTAssertEqual(event?.eventProperties["retryCount"], "0")
     }
 
     func testRetryEventIncludesErrorAndRetryCount() {
         let event = firstSubmittedEvent {
             sut.iapProcessingRetryEvent(
-                origin: .renewal,
+                origin: .renew,
                 error: ClientError.throttled(retryAfter: 5),
                 retryCount: 2
             )
         }
 
         XCTAssertEqual(event?.eventName, "iap_processing_retry")
-        XCTAssertEqual(event?.eventProperties["origin"], "renewal")
+        XCTAssertEqual(event?.eventProperties["origin"], "renew")
         XCTAssertEqual(event?.eventProperties["error"], "throttled_5")
         XCTAssertEqual(event?.eventProperties["retryCount"], "2")
     }


### PR DESCRIPTION
Adds four KPI events for the IAP receipt-verification flow: `iap_processing_purchase`, `iap_processing_success`, `iap_processing_retry`, `iap_processing_failure`.

https://polymoon.atlassian.net/browse/KM-17457