### PR TITLE
KM-17445: don't signup already purchased

### DIFF
--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Account/AccountProvider.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Account/AccountProvider.swift
@@ -197,6 +197,7 @@ public protocol AccountProvider: AnyObject {
         func isAPIEndpointAvailable(_ callback: LibraryCallback<Bool>?)
 
         /// Restores the purchase history, possibly recovering from corruption.
+        /// It syncs with the App Store to get latest data.
         func restorePurchases() async -> Result<JWS, ClientError>
 
         /**

--- a/LocalPackages/PIALocalizations/Sources/PIALocalizations/Generated/L10n.swift
+++ b/LocalPackages/PIALocalizations/Sources/PIALocalizations/Generated/L10n.swift
@@ -1191,6 +1191,22 @@ public enum L10n {
       public static let title = L10n.tr("Localizable", "signup.in_progress.title", fallback: "Confirm sign-up")
     }
     public enum Purchase {
+      public enum Existing {
+        public enum Subscription {
+          /// Your App Store account already has an active Private Internet Access subscription. Restore it to get your account details instead of purchasing again.
+          public static let message = L10n.tr("Localizable", "signup.purchase.existing.subscription.message", fallback: "Your App Store account already has an active Private Internet Access subscription. Restore it to get your account details instead of purchasing again.")
+          /// Subscription found
+          public static let title = L10n.tr("Localizable", "signup.purchase.existing.subscription.title", fallback: "Subscription found")
+        }
+      }
+      public enum Restore {
+        public enum Empty {
+          /// There is no active Private Internet Access subscription on your App Store account. Subscribe to create an account.
+          public static let message = L10n.tr("Localizable", "signup.purchase.restore.empty.message", fallback: "There is no active Private Internet Access subscription on your App Store account. Subscribe to create an account.")
+          /// No subscription found
+          public static let title = L10n.tr("Localizable", "signup.purchase.restore.empty.title", fallback: "No subscription found")
+        }
+      }
       public enum Subscribe {
         /// Subscribe now
         public static let now = L10n.tr("Localizable", "signup.purchase.subscribe.now", fallback: "Subscribe now")

--- a/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/ar.lproj/Localizable.strings
+++ b/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/ar.lproj/Localizable.strings
@@ -557,6 +557,11 @@
 
 "signup.purchase.subscribe.now"= "اشتراك الآن";
 
+"signup.purchase.existing.subscription.title"= "تم العثور على اشتراك";
+"signup.purchase.existing.subscription.message"= "يحتوي حساب App Store الخاص بك بالفعل على اشتراك نشط في Private Internet Access. استعده للحصول على تفاصيل حسابك بدلاً من الشراء مرة أخرى.";
+"signup.purchase.restore.empty.title"= "لم يتم العثور على اشتراك";
+"signup.purchase.restore.empty.message"= "لا يوجد اشتراك نشط في Private Internet Access على حساب App Store الخاص بك. اشترك لإنشاء حساب.";
+
 // WALKTHROUGH
 
 "signup.walkthrough.page.2.title"= "خوادم آمنة في أكثر من 90 دولة";

--- a/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/da.lproj/Localizable.strings
+++ b/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/da.lproj/Localizable.strings
@@ -557,6 +557,11 @@
 
 "signup.purchase.subscribe.now"= "Tilmeld nu";
 
+"signup.purchase.existing.subscription.title"= "Abonnement fundet";
+"signup.purchase.existing.subscription.message"= "Din App Store-konto har allerede et aktivt Private Internet Access-abonnement. Gendan det for at få dine kontooplysninger i stedet for at købe igen.";
+"signup.purchase.restore.empty.title"= "Intet abonnement fundet";
+"signup.purchase.restore.empty.message"= "Der er intet aktivt Private Internet Access-abonnement på din App Store-konto. Tilmeld dig for at oprette en konto.";
+
 // WALKTHROUGH
 
 "signup.walkthrough.page.2.title"= "Sikre servere i over 90 lande";

--- a/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/de.lproj/Localizable.strings
+++ b/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/de.lproj/Localizable.strings
@@ -557,6 +557,11 @@
 
 "signup.purchase.subscribe.now"= "Jetzt abonnieren";
 
+"signup.purchase.existing.subscription.title"= "Abonnement gefunden";
+"signup.purchase.existing.subscription.message"= "Ihr App Store-Konto verfügt bereits über ein aktives Private Internet Access-Abonnement. Stellen Sie es wieder her, um Ihre Kontodaten zu erhalten, anstatt erneut zu kaufen.";
+"signup.purchase.restore.empty.title"= "Kein Abonnement gefunden";
+"signup.purchase.restore.empty.message"= "Es gibt kein aktives Private Internet Access-Abonnement in Ihrem App Store-Konto. Abonnieren Sie, um ein Konto zu erstellen.";
+
 // WALKTHROUGH
 
 "signup.walkthrough.page.2.title"= "Sichere Server in über 90 Ländern";

--- a/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/en.lproj/Localizable.strings
+++ b/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/en.lproj/Localizable.strings
@@ -557,6 +557,11 @@
 
 "signup.purchase.subscribe.now"= "Subscribe now";
 
+"signup.purchase.existing.subscription.title"= "Subscription found";
+"signup.purchase.existing.subscription.message"= "Your App Store account already has an active Private Internet Access subscription. Restore it to get your account details instead of purchasing again.";
+"signup.purchase.restore.empty.title"= "No subscription found";
+"signup.purchase.restore.empty.message"= "There is no active Private Internet Access subscription on your App Store account. Subscribe to create an account.";
+
 // WALKTHROUGH
 
 "signup.walkthrough.page.2.title"= "Secure servers in 90+ countries";

--- a/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/es-MX.lproj/Localizable.strings
+++ b/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/es-MX.lproj/Localizable.strings
@@ -557,6 +557,11 @@
 
 "signup.purchase.subscribe.now"= "Suscríbete ahora";
 
+"signup.purchase.existing.subscription.title"= "Suscripción encontrada";
+"signup.purchase.existing.subscription.message"= "Tu cuenta de App Store ya tiene una suscripción activa de Private Internet Access. Restáurala para obtener los datos de tu cuenta en lugar de comprar de nuevo.";
+"signup.purchase.restore.empty.title"= "No se encontró ninguna suscripción";
+"signup.purchase.restore.empty.message"= "No hay ninguna suscripción activa de Private Internet Access en tu cuenta de App Store. Suscríbete para crear una cuenta.";
+
 // WALKTHROUGH
 
 "signup.walkthrough.page.2.title"= "Servidores seguros en más de 90 países";

--- a/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/fr.lproj/Localizable.strings
+++ b/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/fr.lproj/Localizable.strings
@@ -557,6 +557,11 @@
 
 "signup.purchase.subscribe.now"= "S'abonner maintenant";
 
+"signup.purchase.existing.subscription.title"= "Abonnement trouvé";
+"signup.purchase.existing.subscription.message"= "Votre compte App Store possède déjà un abonnement Private Internet Access actif. Restaurez-le pour obtenir les détails de votre compte au lieu d'acheter à nouveau.";
+"signup.purchase.restore.empty.title"= "Aucun abonnement trouvé";
+"signup.purchase.restore.empty.message"= "Il n'y a aucun abonnement Private Internet Access actif sur votre compte App Store. Abonnez-vous pour créer un compte.";
+
 // WALKTHROUGH
 
 "signup.walkthrough.page.2.title"= "Serveurs sécurisés dans plus de 90 pays";

--- a/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/it.lproj/Localizable.strings
+++ b/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/it.lproj/Localizable.strings
@@ -557,6 +557,11 @@
 
 "signup.purchase.subscribe.now"= "Iscriviti ora";
 
+"signup.purchase.existing.subscription.title"= "Abbonamento trovato";
+"signup.purchase.existing.subscription.message"= "Il tuo account App Store dispone già di un abbonamento attivo a Private Internet Access. Ripristinalo per ottenere i dettagli del tuo account invece di acquistare di nuovo.";
+"signup.purchase.restore.empty.title"= "Nessun abbonamento trovato";
+"signup.purchase.restore.empty.message"= "Non è presente alcun abbonamento attivo a Private Internet Access sul tuo account App Store. Abbonati per creare un account.";
+
 // WALKTHROUGH
 
 "signup.walkthrough.page.2.title"= "Server sicuri in oltre 90 paesi";

--- a/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/ja.lproj/Localizable.strings
+++ b/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/ja.lproj/Localizable.strings
@@ -558,6 +558,11 @@
 
 "signup.purchase.subscribe.now"= "今すぐ定期購読を購入";
 
+"signup.purchase.existing.subscription.title"= "サブスクリプションが見つかりました";
+"signup.purchase.existing.subscription.message"= "お使いのApp Storeアカウントには、有効なPrivate Internet Accessのサブスクリプションが既に存在します。再度購入する代わりに復元してアカウント情報を取得してください。";
+"signup.purchase.restore.empty.title"= "サブスクリプションが見つかりません";
+"signup.purchase.restore.empty.message"= "お使いのApp Storeアカウントに有効なPrivate Internet Accessのサブスクリプションがありません。アカウントを作成するには定期購入してください。";
+
 // WALKTHROUGH
 
 "signup.walkthrough.page.2.title"= "90ヶ国以上に安全なサーバー";

--- a/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/ko.lproj/Localizable.strings
+++ b/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/ko.lproj/Localizable.strings
@@ -557,6 +557,11 @@
 
 "signup.purchase.subscribe.now"= "지금 구독";
 
+"signup.purchase.existing.subscription.title"= "구독을 찾았습니다";
+"signup.purchase.existing.subscription.message"= "App Store 계정에 이미 활성 Private Internet Access 구독이 있습니다. 다시 구매하는 대신 복원하여 계정 정보를 받으세요.";
+"signup.purchase.restore.empty.title"= "구독을 찾을 수 없습니다";
+"signup.purchase.restore.empty.message"= "App Store 계정에 활성 Private Internet Access 구독이 없습니다. 계정을 생성하려면 구독하세요.";
+
 // WALKTHROUGH
 
 "signup.walkthrough.page.2.title"= "90개 이상의 국가에 보안 서버";

--- a/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/nb.lproj/Localizable.strings
+++ b/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/nb.lproj/Localizable.strings
@@ -557,6 +557,11 @@
 
 "signup.purchase.subscribe.now"= "Abonner nå";
 
+"signup.purchase.existing.subscription.title"= "Abonnement funnet";
+"signup.purchase.existing.subscription.message"= "App Store-kontoen din har allerede et aktivt Private Internet Access-abonnement. Gjenopprett det for å få kontoopplysningene dine i stedet for å kjøpe på nytt.";
+"signup.purchase.restore.empty.title"= "Ingen abonnement funnet";
+"signup.purchase.restore.empty.message"= "Det finnes ikke noe aktivt Private Internet Access-abonnement på App Store-kontoen din. Abonner for å opprette en konto.";
+
 // WALKTHROUGH
 
 "signup.walkthrough.page.2.title"= "Sikre servere i over 90 land";

--- a/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/nl.lproj/Localizable.strings
+++ b/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/nl.lproj/Localizable.strings
@@ -557,6 +557,11 @@
 
 "signup.purchase.subscribe.now"= "Nu abonneren";
 
+"signup.purchase.existing.subscription.title"= "Abonnement gevonden";
+"signup.purchase.existing.subscription.message"= "Uw App Store-account heeft al een actief Private Internet Access-abonnement. Herstel het om uw accountgegevens te ontvangen in plaats van opnieuw te kopen.";
+"signup.purchase.restore.empty.title"= "Geen abonnement gevonden";
+"signup.purchase.restore.empty.message"= "Er is geen actief Private Internet Access-abonnement op uw App Store-account. Abonneer u om een account aan te maken.";
+
 // WALKTHROUGH
 
 "signup.walkthrough.page.2.title"= "Beveiligde servers in meer dan 90 landen";

--- a/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/pl.lproj/Localizable.strings
+++ b/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/pl.lproj/Localizable.strings
@@ -557,6 +557,11 @@
 
 "signup.purchase.subscribe.now"= "Subskrybuj teraz";
 
+"signup.purchase.existing.subscription.title"= "Znaleziono subskrypcję";
+"signup.purchase.existing.subscription.message"= "Twoje konto App Store ma już aktywną subskrypcję Private Internet Access. Przywróć ją, aby uzyskać dane swojego konta, zamiast dokonywać ponownego zakupu.";
+"signup.purchase.restore.empty.title"= "Nie znaleziono subskrypcji";
+"signup.purchase.restore.empty.message"= "Na Twoim koncie App Store nie ma aktywnej subskrypcji Private Internet Access. Zasubskrybuj, aby utworzyć konto.";
+
 // WALKTHROUGH
 
 "signup.walkthrough.page.2.title"= "Bezpieczne serwery w ponad 90 krajach";

--- a/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/pt-BR.lproj/Localizable.strings
+++ b/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/pt-BR.lproj/Localizable.strings
@@ -559,6 +559,11 @@
 
 "signup.purchase.subscribe.now"= "Assine agora";
 
+"signup.purchase.existing.subscription.title"= "Assinatura encontrada";
+"signup.purchase.existing.subscription.message"= "Sua conta da App Store já possui uma assinatura ativa da Private Internet Access. Restaure-a para obter os detalhes da sua conta em vez de comprar novamente.";
+"signup.purchase.restore.empty.title"= "Nenhuma assinatura encontrada";
+"signup.purchase.restore.empty.message"= "Não há nenhuma assinatura ativa da Private Internet Access na sua conta da App Store. Assine para criar uma conta.";
+
 // WALKTHROUGH
 
 "signup.walkthrough.page.2.title"= "Servidores seguros em mais de 90 países";

--- a/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/ru.lproj/Localizable.strings
+++ b/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/ru.lproj/Localizable.strings
@@ -557,6 +557,11 @@
 
 "signup.purchase.subscribe.now"= "Подписаться";
 
+"signup.purchase.existing.subscription.title"= "Подписка найдена";
+"signup.purchase.existing.subscription.message"= "На вашем аккаунте App Store уже есть активная подписка Private Internet Access. Восстановите её, чтобы получить данные своей учетной записи, вместо повторной покупки.";
+"signup.purchase.restore.empty.title"= "Подписка не найдена";
+"signup.purchase.restore.empty.message"= "На вашем аккаунте App Store нет активной подписки Private Internet Access. Оформите подписку, чтобы создать учетную запись.";
+
 // WALKTHROUGH
 
 "signup.walkthrough.page.2.title"= "Защищенные серверы в более чем 90 странах";

--- a/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/th.lproj/Localizable.strings
+++ b/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/th.lproj/Localizable.strings
@@ -557,6 +557,11 @@
 
 "signup.purchase.subscribe.now"= "สมัครสมาชิกตอนนี้";
 
+"signup.purchase.existing.subscription.title"= "พบการสมัครสมาชิก";
+"signup.purchase.existing.subscription.message"= "บัญชี App Store ของคุณมีการสมัครสมาชิก Private Internet Access ที่ใช้งานอยู่แล้ว กู้คืนเพื่อรับรายละเอียดบัญชีของคุณแทนการซื้อใหม่";
+"signup.purchase.restore.empty.title"= "ไม่พบการสมัครสมาชิก";
+"signup.purchase.restore.empty.message"= "ไม่มีการสมัครสมาชิก Private Internet Access ที่ใช้งานอยู่ในบัญชี App Store ของคุณ สมัครสมาชิกเพื่อสร้างบัญชี";
+
 // WALKTHROUGH
 
 "signup.walkthrough.page.2.title"= "เซิร์ฟเวอร์ที่ปลอดภัยในกว่า 90 ประเทศ";

--- a/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/tr.lproj/Localizable.strings
+++ b/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/tr.lproj/Localizable.strings
@@ -548,6 +548,11 @@
 
 "signup.purchase.subscribe.now"= "Hemen abone ol";
 
+"signup.purchase.existing.subscription.title"= "Abonelik bulundu";
+"signup.purchase.existing.subscription.message"= "App Store hesabınızda zaten etkin bir Private Internet Access aboneliği var. Yeniden satın almak yerine hesap bilgilerinizi almak için geri yükleyin.";
+"signup.purchase.restore.empty.title"= "Abonelik bulunamadı";
+"signup.purchase.restore.empty.message"= "App Store hesabınızda etkin bir Private Internet Access aboneliği bulunmuyor. Hesap oluşturmak için abone olun.";
+
 
 "signup.purchase.trials.intro"= "7 günlük ücretsiz deneme sürenizi başlatın";
 

--- a/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/zh-Hans.lproj/Localizable.strings
+++ b/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/zh-Hans.lproj/Localizable.strings
@@ -557,6 +557,11 @@
 
 "signup.purchase.subscribe.now"= "立即订阅";
 
+"signup.purchase.existing.subscription.title"= "找到订阅";
+"signup.purchase.existing.subscription.message"= "您的App Store账户已有有效的Private Internet Access订阅。恢复它以获取您的账户详细信息，而不是再次购买。";
+"signup.purchase.restore.empty.title"= "未找到订阅";
+"signup.purchase.restore.empty.message"= "您的App Store账户上没有有效的Private Internet Access订阅。订阅以创建账户。";
+
 // WALKTHROUGH
 
 "signup.walkthrough.page.2.title"= "90多个国家的安全服务器";

--- a/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/zh-Hant.lproj/Localizable.strings
+++ b/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/zh-Hant.lproj/Localizable.strings
@@ -557,6 +557,11 @@
 
 "signup.purchase.subscribe.now"= "馬上訂閱";
 
+"signup.purchase.existing.subscription.title"= "找到訂閱";
+"signup.purchase.existing.subscription.message"= "您的App Store帳戶已有有效的Private Internet Access訂閱。還原它以取得您的帳戶詳細資訊，而不是再次購買。";
+"signup.purchase.restore.empty.title"= "找不到訂閱";
+"signup.purchase.restore.empty.message"= "您的App Store帳戶上沒有有效的Private Internet Access訂閱。訂閱以建立帳戶。";
+
 // WALKTHROUGH
 
 "signup.walkthrough.page.2.title"= "90多個國家的安全伺服器";

--- a/PIA VPN/UI/GetStartedViewController.swift
+++ b/PIA VPN/UI/GetStartedViewController.swift
@@ -146,7 +146,9 @@ final class GetStartedViewController: PIAWelcomeViewController {
                 await MainActor.run {
                     self.isRestoring = false
                     self.handleLoadingState()
-                    self.handleBadReceipt()
+                    // The entitlements were just synchronized, so there is
+                    // nothing to restore and the user needs to subscribe.
+                    self.alertNothingToRestore()
                 }
                 return
 
@@ -158,12 +160,13 @@ final class GetStartedViewController: PIAWelcomeViewController {
 
                     if let error {
                         log.error("Failed to login with receipt: \(error)")
-                        self.handleBadReceipt()
+                        self.alertBadReceipt()
                         return
                     }
 
                     guard let userAccount else {
-                        self.handleBadReceipt()
+                        log.error("Failed to retrieve user account")
+                        self.alertBadReceipt()
                         return
                     }
 
@@ -176,15 +179,6 @@ final class GetStartedViewController: PIAWelcomeViewController {
         }
     }
 
-    private func handleBadReceipt() {
-        let alert = Macros.alert(
-            L10n.Account.Restore.Failure.title,
-            L10n.Account.Restore.Failure.message
-        )
-        alert.addDefaultAction(L10n.Global.close)
-        present(alert, animated: true, completion: nil)
-    }
-
     private func startPurchaseProcessWithEmail(
         _ email: String,
         andPlan plan: PurchasePlan
@@ -195,13 +189,15 @@ final class GetStartedViewController: PIAWelcomeViewController {
         Task { [weak self] in
             guard let self else { return }
 
-            if self.signupAttemptCount > 0 {
-                // if it tried to signup (and failed, that's why we're here again)
-                // synchronize entitlements to find missing purchases or purge stale ones.
-                log.debug("Already failed to signup, synchronizing entitlements")
-                if let error = await Client.store.synchronizeEntitlements() {
-                    log.error("Failed to synchronize entitlements: \(error)")
-                }
+            if await Client.store.currentEntitlementJWS() != nil {
+                // The App Store account may already own a subscription. Could be real
+                // or stale data from Apple. Offer to restore it instead which actually
+                // syncs with Apple servers so we know for sure.
+                log.debug("Found an existing entitlement, offering to restore instead of purchasing")
+                self.isPurchasing = false
+                self.handleLoadingState()
+                self.alertExistingEntitlement()
+                return
             }
 
             let result = await config.accountProvider.purchase(plan: plan.plan)
@@ -234,6 +230,41 @@ final class GetStartedViewController: PIAWelcomeViewController {
             }
         }
     }
+
+    // MARK: - Alerts
+
+    private func alertExistingEntitlement() {
+        let alert = Macros.alert(
+            L10n.Signup.Purchase.Existing.Subscription.title,
+            L10n.Signup.Purchase.Existing.Subscription.message
+        )
+        alert.addCancelAction(L10n.Global.close)
+        alert.addActionWithTitle(L10n.Account.Restore.button) { [weak self] in
+            guard let self else { return }
+            self.logInWithReceipt(nil)
+        }
+        present(alert, animated: true, completion: nil)
+    }
+
+    private func alertBadReceipt() {
+        let alert = Macros.alert(
+            L10n.Account.Restore.Failure.title,
+            L10n.Account.Restore.Failure.message
+        )
+        alert.addDefaultAction(L10n.Global.close)
+        present(alert, animated: true, completion: nil)
+    }
+
+    private func alertNothingToRestore() {
+        let alert = Macros.alert(
+            L10n.Signup.Purchase.Restore.Empty.title,
+            L10n.Signup.Purchase.Restore.Empty.message
+        )
+        alert.addDefaultAction(L10n.Global.close)
+        present(alert, animated: true, completion: nil)
+    }
+
+    // MARK: - Config and Segues
 
     static func with(config: Config, delegate: PIAWelcomeViewControllerDelegate) -> UIViewController? {
         let nav = StoryboardScene.Welcome.initialScene.instantiate()


### PR DESCRIPTION
If we found an existing purchase when subscribing, let the user restore the purchase instead. Restoring actually syncs with the App Store so we make sure it doesn't have stale data. Restore syncs and logs in or presents an error modal if there wasn't actually a valid purchase.