### PR TITLE
KM-17456: fix reconnect leaving the VPN disconnected with Kill Switch off

### DIFF
--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Daemons/VPNDaemon.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Daemons/VPNDaemon.swift
@@ -96,11 +96,13 @@ final class VPNDaemon: Daemon, DatabaseAccess, ProvidersAccess {
 
         var nextStatus: VPNStatus = .disconnected
 
-        // Captured before the switch below, which resets the flag when the
-        // .disconnected transition of a manual disconnect is processed. The
-        // last-disconnect-error handling further down must still know that the
-        // disconnect was user-initiated.
+        // Captured before the switch, which clears the flag; the last-disconnect-error
+        // handling below still needs it. Abort here too: for an update already queued
+        // when the user gave up, `disconnect()`'s abort has not landed yet.
         let disconnectedManually = Client.configuration.disconnectedManually
+        if disconnectedManually {
+            abortReconnectCycleIfNeeded()
+        }
 
         switch connection.status {
         case .connected:
@@ -295,6 +297,37 @@ final class VPNDaemon: Daemon, DatabaseAccess, ProvidersAccess {
         } else {
             log.debug("[VPNDaemon] fetchLastDisconnectError — no error reported (clean disconnect)")
         }
+    }
+
+    // MARK: Abort
+
+    /**
+     Abandons any reconnect cycle in flight.
+
+     Called when the user gives up on a connection attempt. A cycle left running
+     would fight that intent on two fronts: the retry timer keeps bringing the
+     tunnel back up, and `isReconnecting` suppresses the status writes below, so
+     the UI never leaves "connecting" and the toggle stays disarmed
+     (`canConnectVPN()` refuses to act while the status reads `.connecting`).
+
+     Safe to call from any thread; the work is serialized onto the main queue,
+     where every other mutation of this daemon's state happens.
+     */
+    func abortReconnectCycleIfNeeded() {
+        guard Thread.isMainThread else {
+            DispatchQueue.main.async {
+                self.abortReconnectCycleIfNeeded()
+            }
+            return
+        }
+        guard isReconnecting || fallbackTimer != nil else {
+            return
+        }
+
+        log.debug("Abandoning the reconnect cycle in flight — the user gave up on the attempt")
+        isReconnectingAfterConnectivityFailure = false
+        invalidateTimer()
+        reset()
     }
 
     // MARK: Invalidate

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/VPN/DefaultVPNProvider.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/VPN/DefaultVPNProvider.swift
@@ -278,6 +278,13 @@ public final class DefaultVPNProvider: VPNProvider, ConfigurationAccess, Databas
             return
         }
 
+        // The user is giving up on the attempt, so abandon any reconnect cycle in
+        // flight: its retries would undo this disconnect, and while it runs the
+        // daemon suppresses status updates and the app never reaches .disconnected.
+        if accessedConfiguration.disconnectedManually {
+            VPNDaemon.shared.abortReconnectCycleIfNeeded()
+        }
+
         // Capture the tunnel log best-effort, in parallel: the provider message
         // never gets a reply when the tunnel process is wedged (e.g. after a
         // network change), so the disconnect below must not wait on it.

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/VPN/IKEv2Profile.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/VPN/IKEv2Profile.swift
@@ -80,42 +80,18 @@ public final class IKEv2Profile: NetworkExtensionProfile {
                 return
             }
 
-            let currentStatus = self.currentVPN.connection.status
+            let connection = self.currentVPN.connection
 
             // If the tunnel is already active, stop it before starting the new one.
             // Calling startVPNTunnel() on a connected IKEv2 tunnel may silently retain
             // the existing connection rather than switching to the new server, resulting
             // in the app believing it is connected when it is not.
-            if currentStatus == .connected || currentStatus == .connecting || currentStatus == .reasserting {
-                self.currentVPN.connection.stopVPNTunnel()
-            }
-
-            if currentStatus == .disconnecting {
-                self.waitForDisconnectedThenStart(callback: callback)
-            } else {
-                do {
-                    try self.currentVPN.connection.startVPNTunnel()
-                    callback?(nil)
-                } catch let e {
-                    callback?(e)
-                }
-            }
-        }
-    }
-
-    private func waitForDisconnectedThenStart(callback: SuccessLibraryCallback?) {
-        var observer: NSObjectProtocol?
-        observer = NotificationCenter.default.addObserver(forName: .NEVPNStatusDidChange, object: currentVPN.connection, queue: .main) { [currentVPN] _ in
-            guard currentVPN.connection.status == .disconnected else {
-                return
-            }
-
-            if let observer {
-                NotificationCenter.default.removeObserver(observer)
+            if connection.status == .connected || connection.status == .connecting || connection.status == .reasserting {
+                connection.stopVPNTunnel()
             }
 
             do {
-                try currentVPN.connection.startVPNTunnel()
+                try self.afterTeardown(of: connection) { try connection.startVPNTunnel() }
                 callback?(nil)
             } catch let e {
                 callback?(e)

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/VPN/NetworkExtensionProfile.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/VPN/NetworkExtensionProfile.swift
@@ -126,6 +126,61 @@ extension NetworkExtensionProfile {
         }
     }
 
+    /**
+     Runs a block once the connection is no longer tearing down, immediately if it
+     is not.
+
+     NetworkExtension silently drops a start request issued while the connection is
+     `.disconnecting`, and no further status change follows to trigger a retry. A
+     reconnect hits that window routinely: `disconnect()` calls back as soon as its
+     preferences round-trip lands, well before the tunnel is actually down. The
+     on-demand rules used to hide this by bringing the tunnel back up, but with the
+     kill switch off — in particular on the reconnect that follows disabling it —
+     nothing does, and the VPN stays down for good.
+
+     Rethrows whatever `perform` throws when it runs right away. A deferred run
+     happens after this returns, so its failure is logged rather than reported.
+
+     - Parameter connection: The connection whose teardown must complete first.
+     - Parameter perform: Issues the actual start request.
+     */
+    func afterTeardown(of connection: NEVPNConnection, perform: @escaping () throws -> Void) throws {
+        guard connection.status == .disconnecting else {
+            try perform()
+            return
+        }
+
+        log.debug("The tunnel is still disconnecting, deferring the start until it is down")
+
+        var observer: NSObjectProtocol?
+        var hasRun = false
+
+        let performOnce = {
+            guard !hasRun else { return }
+            hasRun = true
+            if let observer {
+                NotificationCenter.default.removeObserver(observer)
+            }
+            do {
+                try perform()
+            } catch let e {
+                log.error("The deferred tunnel start failed: \(e)")
+            }
+        }
+
+        observer = NotificationCenter.default.addObserver(forName: .NEVPNStatusDidChange, object: connection, queue: .main) { _ in
+            guard connection.status != .disconnecting else { return }
+            performOnce()
+        }
+        // The teardown may have completed while the observer was being installed,
+        // in which case no further status change is coming.
+        if connection.status != .disconnecting {
+            performOnce()
+        }
+        // A wedged teardown must not swallow the start for good.
+        DispatchQueue.main.asyncAfter(deadline: .now() + 5.0) { performOnce() }
+    }
+
     private func configureOnDemandOnWiFiNetworksFor(
         _ trustedNetworks: [String: Int],
         _ vpn: NEVPNManager

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/VPN/NetworkExtensionProfile.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/VPN/NetworkExtensionProfile.swift
@@ -158,8 +158,18 @@ extension NetworkExtensionProfile {
         let performOnce = {
             guard !hasRun else { return }
             hasRun = true
-            if let observer {
-                NotificationCenter.default.removeObserver(observer)
+            if let token = observer {
+                NotificationCenter.default.removeObserver(token)
+                // Also breaks the retain cycle: the block below captures this very
+                // token, so removing the observation alone would not release it.
+                observer = nil
+            }
+            // The user may have given up on the attempt while the teardown was in
+            // flight. Never bring the tunnel back up against that intent — the
+            // disconnect that expressed it is what put us in this window.
+            guard !Client.configuration.disconnectedManually else {
+                log.debug("Abandoning the deferred tunnel start — the user gave up on the attempt")
+                return
             }
             do {
                 try perform()

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/VPN/PIATunnelProfile.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/VPN/PIATunnelProfile.swift
@@ -88,7 +88,7 @@
                     }
                     do {
                         let session = vpn.connection as? NETunnelProviderSession
-                        try session?.startTunnel(options: nil)
+                        try self.afterTeardown(of: vpn.connection) { try session?.startTunnel(options: nil) }
                         callback?(nil)
                     } catch let e {
                         callback?(e)

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/VPN/PIAWGTunnelProfile.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/VPN/PIAWGTunnelProfile.swift
@@ -157,7 +157,7 @@ import Foundation
                     }
                     do {
                         let session = vpn.connection as? NETunnelProviderSession
-                        try session?.startTunnel(options: nil)
+                        try self.afterTeardown(of: vpn.connection) { try session?.startTunnel(options: nil) }
                         callback?(nil)
                     } catch let e {
                         callback?(e)


### PR DESCRIPTION
[KM-17456](https://polymoon.atlassian.net/browse/KM-17456)

Follow-up to #370, which fixed a keychain race under the same ticket but not this scenario: while connected, disable Kill Switch and tap **RECONNECT** — the app disconnects and never comes back.

### Root cause

`DefaultVPNProvider.reconnect` chains `connect` off `disconnect`'s callback, but that callback fires when the preferences round-trip lands, not when the tunnel is down (traced firing at `connection.status == .connected`). So `startTunnel` is issued while the session is still `.disconnecting`, where NetworkExtension discards it silently — no throw, no further status change, so nothing retries.

Every other reconnect survives the same race for one of two reasons that disabling Kill Switch removes:
- **On-demand rules resurrect the tunnel.** Working reconnects save `onDemandRules = 1` and the OS starts the tunnel itself. Kill Switch off leaves `onDemandRules = 0`.
- **`VPNDaemon` retries.** Tunnel-initiated drops carry a disconnect error, so the `connectivityCheckFailed` branch re-fires `reconnect` on each transition until one lands after `.disconnected`. This disconnect is clean, so it never fires.

### Changes

**`afterTeardown(of:perform:)`** in `NetworkExtensionProfile` — defers the start until the connection leaves `.disconnecting`. Replaces the IKEv2-only `waitForDisconnectedThenStart` and now covers OpenVPN and WireGuard too.

**Giving up on a connection attempt** — tapping the button during `.connecting` issued a real disconnect, but the fallback timer tick that shows "please wait" also sets `isReconnecting = true`, which suppressed the status write (so the UI never left `.connecting`, keeping `canConnectVPN()` false and every later tap dead-ended) while the retry timer undid the disconnect. Now `VPNDaemon.abortReconnectCycleIfNeeded()` tears the cycle down, called from `disconnect()` when user-initiated, and `afterTeardown` refuses to start against that intent.

### Testing

Reproduced and verified on **Mac Catalyst** (`PIA VPN Development`, OpenVPN) with instrumented tracing; builds clean.

No unit tests: the retry cycle is private to the `VPNDaemon` singleton and only reachable through an `NEVPNConnection`, so covering it needs an injectable status source — worth doing separately.

### Known gaps, not addressed here

- The 5s fallback in `afterTeardown` calls `performOnce()` without re-checking status, so a teardown slower than 5s burns the attempt on a call NE drops and unhooks the observer — reintroducing the bug in exactly the case the fallback exists for.
- IKEv2's `connect` reads `connection.status` immediately after its own async `stopVPNTunnel()`, so it still reads `.connected` and the guard never engages on that path.
- The wait predicate is `!= .disconnecting` rather than `== .disconnected`, so it can fire on `.connecting`/`.invalid`.
- A deferred start that fails is only logged; callers already got `callback?(nil)`.

The ticket's own repro keeps Kill Switch **on** and reports "settings not applied" rather than a disconnect — same root cause, on-demand masking the symptom. Both paths need QA (`needs_labTesting`).
