### PR TITLE
Declare swift-log dependency in PIAAccount

### DIFF
--- a/LocalPackages/PIAAccount/Package.swift
+++ b/LocalPackages/PIAAccount/Package.swift
@@ -17,14 +17,16 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(path: "../PIABase")
+        .package(path: "../PIABase"),
+        .package(url: "https://github.com/apple/swift-log", exact: "1.13.1")
     ],
     targets: [
         // Main library target (merged for simplicity)
         .target(
             name: "PIAAccount",
             dependencies: [
-                .product(name: "PIABase", package: "PIABase")
+                .product(name: "PIABase", package: "PIABase"),
+                .product(name: "Logging", package: "swift-log")
             ],
             path: "Sources"
         ),


### PR DESCRIPTION
`PIAAccount` imports `Logging` but never declared swift-log in its manifest. The module only resolved when the build scheduler happened to compile swift-log before `PIAAccount`, so the tvOS CI build started failing with `unable to resolve module dependency: 'Logging'`.

Pinned to `1.13.1` to match `PIALibrary`.