### PR TITLE
KM-17521 Hide manage subscription link on Mac Catalyst

### DIFF
--- a/PIA VPN/Core/Utils/SubscriptionManagementUtil.swift
+++ b/PIA VPN/Core/Utils/SubscriptionManagementUtil.swift
@@ -28,6 +28,16 @@ private let log = PIALogger.logger(for: SubscriptionManagementUtil.self)
 /// Utility for managing subscription-related functionality across UIKit and SwiftUI
 enum SubscriptionManagementUtil {
 
+    /// Whether the App Store subscription management sheet can be presented for the given account.
+    /// `AppStore.showManageSubscriptions(in:)` is unsupported when running on Mac, and only App Store
+    /// subscriptions can be managed in the first place.
+    ///
+    /// - Parameter info: The account info to check the plan of.
+    static func canManageSubscription(for info: AccountInfo) -> Bool {
+        guard !Platform.isRunningOnMac else { return false }
+        return info.plan == .monthly || info.plan == .yearly || info.plan == .trial
+    }
+
     /// Opens the App Store subscription management sheet using StoreKit 2.
     /// This method presents the native iOS subscription management interface within the app.
     ///
@@ -36,6 +46,11 @@ enum SubscriptionManagementUtil {
     ///                          For SwiftUI, use the `@Environment(\.windowScene)` property wrapper.
     @MainActor
     static func openManageSubscription(in windowScene: UIWindowScene) async {
+        guard !Platform.isRunningOnMac else {
+            log.error("Subscription management is not supported when running on Mac")
+            return
+        }
+
         do {
             try await AppStore.showManageSubscriptions(in: windowScene)
         } catch {

--- a/PIA VPN/UI/Menu/AccountViewController.swift
+++ b/PIA VPN/UI/Menu/AccountViewController.swift
@@ -214,10 +214,7 @@ final class AccountViewController: AutolayoutViewController {
             }
             styleExpirationDate()
 
-            let hasManageablePlan = userInfo.plan == .monthly || userInfo.plan == .yearly || userInfo.plan == .trial
-            let canManageSubscription = hasManageablePlan && !Platform.isRunningOnMac
-
-            if canManageSubscription {
+            if SubscriptionManagementUtil.canManageSubscription(for: userInfo) {
                 labelSubscriptions.isHidden = false
                 labelSubscriptionTopConstraint.constant = 20
             } else {

--- a/PIA VPN/UI/Menu/AccountViewController.swift
+++ b/PIA VPN/UI/Menu/AccountViewController.swift
@@ -214,7 +214,10 @@ final class AccountViewController: AutolayoutViewController {
             }
             styleExpirationDate()
 
-            if userInfo.plan == .monthly || userInfo.plan == .yearly || userInfo.plan == .trial {
+            let hasManageablePlan = userInfo.plan == .monthly || userInfo.plan == .yearly || userInfo.plan == .trial
+            let canManageSubscription = hasManageablePlan && !Platform.isRunningOnMac
+
+            if canManageSubscription {
                 labelSubscriptions.isHidden = false
                 labelSubscriptionTopConstraint.constant = 20
             } else {

--- a/PIA VPN/UI/Menu/MenuViewController.swift
+++ b/PIA VPN/UI/Menu/MenuViewController.swift
@@ -148,7 +148,10 @@ final class MenuViewController: AutolayoutViewController {
             let info = currentUser.info
         {
 
-            if info.plan == .monthly || info.plan == .yearly || info.plan == .trial {
+            let hasManageablePlan = info.plan == .monthly || info.plan == .yearly || info.plan == .trial
+            let canManageSubscription = hasManageablePlan && !Platform.isRunningOnMac
+
+            if canManageSubscription {
 
                 switch info.plan {
                 case .yearly:

--- a/PIA VPN/UI/Menu/MenuViewController.swift
+++ b/PIA VPN/UI/Menu/MenuViewController.swift
@@ -148,10 +148,7 @@ final class MenuViewController: AutolayoutViewController {
             let info = currentUser.info
         {
 
-            let hasManageablePlan = info.plan == .monthly || info.plan == .yearly || info.plan == .trial
-            let canManageSubscription = hasManageablePlan && !Platform.isRunningOnMac
-
-            if canManageSubscription {
+            if SubscriptionManagementUtil.canManageSubscription(for: info) {
 
                 switch info.plan {
                 case .yearly:


### PR DESCRIPTION
The "manage your subscription from here" link can't open the App Store subscription sheet on Mac Catalyst, so hide it there — both in the Account screen and in the sidebar plan header.