### PR TITLE
KM-17595: Recover email from Sign In With Apple

### DIFF
--- a/LocalPackages/PIABase/Package.swift
+++ b/LocalPackages/PIABase/Package.swift
@@ -17,6 +17,11 @@ let package = Package(
         // Targets can depend on other targets in this package and products from dependencies.
         .target(
             name: "PIABase"
+        ),
+        // Test target using Swift Testing
+        .testTarget(
+            name: "PIABaseTests",
+            dependencies: ["PIABase"]
         )
 
     ],

--- a/LocalPackages/PIABase/Sources/PIABase/Data+Base64URL.swift
+++ b/LocalPackages/PIABase/Sources/PIABase/Data+Base64URL.swift
@@ -1,0 +1,70 @@
+//
+//  Data+Base64URL.swift
+//  PIABase
+//
+//  Copyright © 2026 Private Internet Access, Inc.
+//
+//  This file is part of the Private Internet Access iOS Client.
+//
+//  The Private Internet Access iOS Client is free software: you can redistribute it and/or
+//  modify it under the terms of the GNU General Public License as published by the Free
+//  Software Foundation, either version 3 of the License, or (at your option) any later version.
+//
+//  The Private Internet Access iOS Client is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+//  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+//  details.
+//
+//  You should have received a copy of the GNU General Public License along with the Private
+//  Internet Access iOS Client.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Foundation
+
+extension Data {
+
+    /// Initializes a data object with the given base64url encoded string, the
+    /// URL- and filename-safe alphabet defined in RFC 4648 §5.
+    ///
+    /// It is the counterpart of `Data(base64Encoded:)` for the encoding used by
+    /// JWT/JWS and friends: `-` and `_` replace `+` and `/`, and the trailing
+    /// `=` padding is usually dropped. Both padded and unpadded input is
+    /// accepted; input using the standard base64 alphabet is rejected.
+    ///
+    /// - Parameter base64UrlEncoded: The base64url encoded string.
+    /// - Returns: `nil` when the string is not valid base64url.
+    public init?(base64UrlEncoded string: String) {
+        // + and / belong to the standard alphabet only, and would otherwise
+        // survive the translation below and decode as if they were base64url.
+        guard !string.contains("+"), !string.contains("/") else { return nil }
+
+        var base64 =
+            string
+            .replacingOccurrences(of: "-", with: "+")
+            .replacingOccurrences(of: "_", with: "/")
+
+        let remainder = base64.count % 4
+        switch remainder {
+        case 0:
+            break
+        case 2, 3:
+            base64.append(String(repeating: "=", count: 4 - remainder))
+        default:
+            // A single leftover character can never encode a whole byte.
+            return nil
+        }
+
+        guard let data = Data(base64Encoded: base64) else { return nil }
+        self = data
+    }
+
+    /// Returns a base64url encoded string, using the URL- and filename-safe
+    /// alphabet defined in RFC 4648 §5 and omitting the trailing `=` padding as
+    /// JWT/JWS require.
+    public func base64UrlEncodedString() -> String {
+        base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+}

--- a/LocalPackages/PIABase/Tests/PIABaseTests/DataBase64URLTests.swift
+++ b/LocalPackages/PIABase/Tests/PIABaseTests/DataBase64URLTests.swift
@@ -1,0 +1,106 @@
+//
+//  DataBase64URLTests.swift
+//  PIABase
+//
+//  Copyright © 2026 Private Internet Access, Inc.
+//
+//  This file is part of the Private Internet Access iOS Client.
+//
+//  The Private Internet Access iOS Client is free software: you can redistribute it and/or
+//  modify it under the terms of the GNU General Public License as published by the Free
+//  Software Foundation, either version 3 of the License, or (at your option) any later version.
+//
+//  The Private Internet Access iOS Client is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+//  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+//  details.
+//
+//  You should have received a copy of the GNU General Public License along with the Private
+//  Internet Access iOS Client.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Foundation
+import Testing
+
+@testable import PIABase
+
+struct DataBase64URLTests {
+
+    // MARK: - Encoding
+
+    @Test("Encoding uses the URL-safe alphabet")
+    func encodingUsesURLSafeAlphabet() {
+        // These encode to sextets 62 and 63, i.e. "+" and "/" in the standard alphabet.
+        #expect(Data([0xFB, 0xEF, 0xBE]).base64UrlEncodedString() == "----")
+        #expect(Data([0xFF, 0xFF, 0xFF]).base64UrlEncodedString() == "____")
+    }
+
+    @Test("Encoding omits the padding")
+    func encodingOmitsPadding() {
+        #expect(Data("a".utf8).base64UrlEncodedString() == "YQ")
+        #expect(Data("ab".utf8).base64UrlEncodedString() == "YWI")
+        #expect(Data("abc".utf8).base64UrlEncodedString() == "YWJj")
+    }
+
+    @Test("Encoding empty data yields an empty string")
+    func encodingEmptyData() {
+        #expect(Data().base64UrlEncodedString() == "")
+    }
+
+    // MARK: - Decoding
+
+    @Test("Decoding accepts unpadded input of every remainder length")
+    func decodingAcceptsUnpaddedInput() {
+        #expect(Data(base64UrlEncoded: "YQ") == Data("a".utf8))
+        #expect(Data(base64UrlEncoded: "YWI") == Data("ab".utf8))
+        #expect(Data(base64UrlEncoded: "YWJj") == Data("abc".utf8))
+    }
+
+    @Test("Decoding accepts padded input")
+    func decodingAcceptsPaddedInput() {
+        #expect(Data(base64UrlEncoded: "YQ==") == Data("a".utf8))
+        #expect(Data(base64UrlEncoded: "YWI=") == Data("ab".utf8))
+    }
+
+    @Test("Decoding translates the URL-safe alphabet")
+    func decodingTranslatesURLSafeAlphabet() {
+        #expect(Data(base64UrlEncoded: "----") == Data([0xFB, 0xEF, 0xBE]))
+        #expect(Data(base64UrlEncoded: "____") == Data([0xFF, 0xFF, 0xFF]))
+    }
+
+    @Test("Decoding an empty string yields empty data")
+    func decodingEmptyString() {
+        #expect(Data(base64UrlEncoded: "") == Data())
+    }
+
+    @Test("Decoding rejects the standard alphabet")
+    func decodingRejectsStandardAlphabet() {
+        #expect(Data(base64UrlEncoded: "++--") == nil)
+        #expect(Data(base64UrlEncoded: "//__") == nil)
+    }
+
+    @Test("Decoding rejects a length that cannot encode whole bytes")
+    func decodingRejectsImpossibleLength() {
+        #expect(Data(base64UrlEncoded: "Y") == nil)
+        #expect(Data(base64UrlEncoded: "YWJjY") == nil)
+    }
+
+    @Test("Decoding rejects characters outside the alphabet")
+    func decodingRejectsInvalidCharacters() {
+        #expect(Data(base64UrlEncoded: "!!!!") == nil)
+        #expect(Data(base64UrlEncoded: "YQ ==") == nil)
+        #expect(Data(base64UrlEncoded: "Y=WI") == nil)
+    }
+
+    // MARK: - Round trip
+
+    @Test("Encoding then decoding round-trips arbitrary bytes")
+    func roundTrip() {
+        for length in 0...64 {
+            let data = Data((0..<length).map { UInt8(($0 * 37 + 11) % 256) })
+            #expect(
+                Data(base64UrlEncoded: data.base64UrlEncodedString()) == data,
+                "failed for length \(length)")
+        }
+    }
+}

--- a/PIA VPN.xcodeproj/project.pbxproj
+++ b/PIA VPN.xcodeproj/project.pbxproj
@@ -259,6 +259,7 @@
 				Core/Messages/PIACommandTests.swift,
 				Core/NMTTests.swift,
 				Core/PIACardTests.swift,
+				Core/Utils/AppleIDIdentityTokenTests.swift,
 				Core/Utils/PIAHotspotHelperTests.swift,
 				"Helpers/Stubs+PIALibrary.swift",
 				Mocks/AccountProviderMock.swift,

--- a/PIA VPN/Core/Extensions/ASAuthorizationAppleIDCredential+Email.swift
+++ b/PIA VPN/Core/Extensions/ASAuthorizationAppleIDCredential+Email.swift
@@ -1,0 +1,77 @@
+//
+//  ASAuthorizationAppleIDCredential+Email.swift
+//  PIA VPN
+//
+//  Copyright © 2026 Private Internet Access, Inc.
+//
+//  This file is part of the Private Internet Access iOS Client.
+//
+//  The Private Internet Access iOS Client is free software: you can redistribute it and/or
+//  modify it under the terms of the GNU General Public License as published by the Free
+//  Software Foundation, either version 3 of the License, or (at your option) any later version.
+//
+//  The Private Internet Access iOS Client is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+//  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+//  details.
+//
+//  You should have received a copy of the GNU General Public License along with the Private
+//  Internet Access iOS Client.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import AuthenticationServices
+import Foundation
+import PIABase
+import PIALibrary
+
+/// Decodes the claims Apple only exposes inside the identity token JWT.
+enum AppleIDIdentityToken {
+
+    private struct Claims: Decodable {
+        let email: String?
+    }
+
+    /// Returns the `email` claim of an Apple identity token, or `nil` when the
+    /// token is malformed or carries no email.
+    ///
+    /// The signature is not verified: the token comes straight from
+    /// `AuthenticationServices` in-process, and the value is only used to
+    /// prefill the email field for an account update the backend validates.
+    static func email(fromIdentityToken identityToken: Data) -> String? {
+        guard let token = String(data: identityToken, encoding: .utf8) else { return nil }
+
+        let segments = token.split(separator: ".", omittingEmptySubsequences: false)
+        guard segments.count == 3, let payload = Data(base64UrlEncoded: String(segments[1])) else {
+            return nil
+        }
+
+        let email = try? JSONDecoder().decode(Claims.self, from: payload).email
+        guard let email, !email.isEmpty else { return nil }
+        return email
+    }
+}
+
+private let log = PIALogger.logger(for: ASAuthorizationAppleIDCredential.self)
+
+// `ASAuthorizationAppleIDCredential.email` is a convenience property that Apple
+// populates on the *first* authorization for a given app only. On every
+// subsequent authorization it is `nil`, even when the email scope is still
+// granted. The `identityToken` JWT, on the other hand, carries the `email`
+// claim on every successful authorization, so decoding it locally is the
+// supported way to recover the address.
+extension ASAuthorizationAppleIDCredential {
+    /// The user's email, preferring the convenience property and falling back to
+    /// the `email` claim of the identity token when Apple omits it.
+    var resolvedEmail: String? {
+        if let email, !email.isEmpty {
+            log.debug("Returning email from credential")
+            return email
+        }
+        if let identityToken, let email = AppleIDIdentityToken.email(fromIdentityToken: identityToken), !email.isEmpty {
+            log.debug("Returning email from identity token")
+            return email
+        }
+        log.debug("Unable to find email to return")
+        return nil
+    }
+}

--- a/PIA VPN/UI/ConfirmVPNPlanViewController.swift
+++ b/PIA VPN/UI/ConfirmVPNPlanViewController.swift
@@ -196,7 +196,10 @@ final class ConfirmVPNPlanViewController: AutolayoutViewController, BrandableNav
         labelOr.text = L10n.Welcome.Purchase.or.uppercased()
         labelOr.textAlignment = .center
 
-        let signInWithAppleButton = ASAuthorizationAppleIDButton(type: .signIn, style: Theme.current.palette.appearance == .dark ? .whiteOutline : .black)
+        let signInWithAppleButton = ASAuthorizationAppleIDButton(
+            type: .continue,
+            style: Theme.current.palette.appearance == .dark ? .whiteOutline : .black
+        )
         signInWithAppleButton.addTarget(self, action: #selector(handleAuthorizationAppleID), for: .touchUpInside)
 
         self.addEmailContainer.addSubview(signInWithAppleButton)
@@ -228,6 +231,7 @@ final class ConfirmVPNPlanViewController: AutolayoutViewController, BrandableNav
         controller.delegate = self
         controller.presentationContextProvider = self
 
+        log.debug("Requesting email via Sign In With Apple")
         controller.performRequests()
     }
 
@@ -269,12 +273,13 @@ extension ConfirmVPNPlanViewController: GDPRDelegate {
 extension ConfirmVPNPlanViewController: ASAuthorizationControllerPresentationContextProviding {
     public func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
         guard let appleIDCredentials = authorization.credential as? ASAuthorizationAppleIDCredential else { return }
-        if let email = appleIDCredentials.email {
+        if let email = appleIDCredentials.resolvedEmail, !email.isEmpty {
             textEmail.text = email
             let preferences = Client.preferences.editable()
             preferences.signInWithAppleFakeEmail = email
             preferences.commit()
         } else {
+            log.error("Sign In With Apple returned no email, falling back to the stored one")
             textEmail.text = Client.preferences.signInWithAppleFakeEmail
         }
 

--- a/PIA VPN/UI/Menu/AddEmailToAccountViewController.swift
+++ b/PIA VPN/UI/Menu/AddEmailToAccountViewController.swift
@@ -187,7 +187,7 @@ class AddEmailToAccountViewController: AutolayoutViewController, BrandableNaviga
         labelOr.text = L10n.Global.or.uppercased()
         labelOr.textAlignment = .center
 
-        let signInWithAppleButton = ASAuthorizationAppleIDButton(type: .signIn, style: Theme.current.palette.appearance == .dark ? .whiteOutline : .black)
+        let signInWithAppleButton = ASAuthorizationAppleIDButton(type: .continue, style: Theme.current.palette.appearance == .dark ? .whiteOutline : .black)
         signInWithAppleButton.addTarget(self, action: #selector(handleAuthorizationAppleID), for: .touchUpInside)
 
         self.addEmailContainer.addSubview(signInWithAppleButton)
@@ -219,6 +219,7 @@ class AddEmailToAccountViewController: AutolayoutViewController, BrandableNaviga
         controller.delegate = self
         controller.presentationContextProvider = self
 
+        log.debug("Requesting email via Sign In With Apple")
         controller.performRequests()
     }
 
@@ -293,12 +294,13 @@ class AddEmailToAccountViewController: AutolayoutViewController, BrandableNaviga
 extension AddEmailToAccountViewController: ASAuthorizationControllerPresentationContextProviding {
     public func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
         guard let appleIDCredentials = authorization.credential as? ASAuthorizationAppleIDCredential else { return }
-        if let email = appleIDCredentials.email {
+        if let email = appleIDCredentials.resolvedEmail, !email.isEmpty {
             textEmail.text = email
             let preferences = Client.preferences.editable()
             preferences.signInWithAppleFakeEmail = email
             preferences.commit()
         } else {
+            log.error("Sign In With Apple returned no email, falling back to the stored one")
             textEmail.text = Client.preferences.signInWithAppleFakeEmail
         }
         self.signUp(nil)

--- a/PIA VPNTests/Core/Utils/AppleIDIdentityTokenTests.swift
+++ b/PIA VPNTests/Core/Utils/AppleIDIdentityTokenTests.swift
@@ -1,0 +1,90 @@
+//
+//  AppleIDIdentityTokenTests.swift
+//  PIA VPN
+//
+//  Copyright © 2026 Private Internet Access, Inc.
+//
+//  This file is part of the Private Internet Access iOS Client.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software
+//  without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+//  permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+//  PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+//  CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+//
+
+import PIABase
+import XCTest
+
+@testable import PIA_VPN
+
+class AppleIDIdentityTokenTests: XCTestCase {
+
+    func testDecodesEmailClaim() {
+        let token = makeToken(payload: #"{"sub":"001234.abc","email":"user@privaterelay.appleid.com","email_verified":"true","is_private_email":"true"}"#)
+
+        XCTAssertEqual(AppleIDIdentityToken.email(fromIdentityToken: token), "user@privaterelay.appleid.com")
+    }
+
+    func testDecodesEmailClaimFromPayloadNeedingBase64URLPadding() {
+        // Payloads whose base64url length is not a multiple of 4 must still decode.
+        for filler in ["a", "ab", "abc", "abcd"] {
+            let token = makeToken(payload: #"{"pad":"\#(filler)","email":"user@example.com"}"#)
+            XCTAssertEqual(
+                AppleIDIdentityToken.email(fromIdentityToken: token),
+                "user@example.com",
+                "failed for filler \(filler)")
+        }
+    }
+
+    func testDecodesEmailClaimFromPayloadUsingBase64URLAlphabet() {
+        // "~~~?" base64-encodes to "fn5+Pw==", which contains both + and /
+        // once the payload is long enough, so it exercises the URL alphabet.
+        let token = makeToken(payload: #"{"nonce":"~~~?????>>>","email":"user@example.com"}"#)
+
+        XCTAssertEqual(AppleIDIdentityToken.email(fromIdentityToken: token), "user@example.com")
+    }
+
+    func testReturnsNilWhenEmailClaimIsMissing() {
+        let token = makeToken(payload: #"{"sub":"001234.abc","email_verified":"true"}"#)
+
+        XCTAssertNil(AppleIDIdentityToken.email(fromIdentityToken: token))
+    }
+
+    func testReturnsNilWhenEmailClaimIsEmpty() {
+        let token = makeToken(payload: #"{"email":""}"#)
+
+        XCTAssertNil(AppleIDIdentityToken.email(fromIdentityToken: token))
+    }
+
+    func testReturnsNilWhenPayloadIsNotJSON() {
+        let token = makeToken(payload: "not json")
+
+        XCTAssertNil(AppleIDIdentityToken.email(fromIdentityToken: token))
+    }
+
+    func testReturnsNilWhenTokenIsNotAThreeSegmentJWT() {
+        XCTAssertNil(AppleIDIdentityToken.email(fromIdentityToken: Data("header.payload".utf8)))
+        XCTAssertNil(AppleIDIdentityToken.email(fromIdentityToken: Data("a.b.c.d".utf8)))
+        XCTAssertNil(AppleIDIdentityToken.email(fromIdentityToken: Data()))
+    }
+
+    func testReturnsNilWhenPayloadIsNotBase64() {
+        XCTAssertNil(AppleIDIdentityToken.email(fromIdentityToken: Data("header.!!!!.signature".utf8)))
+    }
+
+    // MARK: Helpers
+
+    /// Builds an unsigned JWT carrying the given payload, encoded the way Apple
+    /// encodes identity tokens (base64url, no padding).
+    private func makeToken(payload: String) -> Data {
+        let header = Data(#"{"alg":"RS256","kid":"test"}"#.utf8).base64UrlEncodedString()
+        let claims = Data(payload.utf8).base64UrlEncodedString()
+        return Data("\(header).\(claims).signature".utf8)
+    }
+}


### PR DESCRIPTION
Retrieve `email` from Sign In With Apple either via credentials or decoding the identity token (JWT)