### PR TITLE
KM-17598: add secret to widget connect URL

### DIFF
--- a/LocalPackages/PIALibrary/Sources/PIALibrary/AppConstants.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/AppConstants.swift
@@ -108,7 +108,8 @@ public struct AppConstants {
         public static let url = "piavpn:login?token="
     }
 
-    public struct Widget {
+    public enum Widget {
+        public static let kind = "PIAWidget"
         public static let connect = "piavpn:connect"
     }
 

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Util/WidgetConnectAuthorization.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Util/WidgetConnectAuthorization.swift
@@ -28,7 +28,6 @@ private let log = PIALogger.logger(for: WidgetConnectAuthorization.self)
 public protocol WidgetConnectSecretStore {
     func readSecret() -> String?
     func write(_ secret: String)
-    func clear()
 }
 
 /// Authorizes the widget initiated VPN toggle deep link.
@@ -60,13 +59,6 @@ public final class WidgetConnectAuthorization {
 
         guard let secret = Self.makeSecret() else { return }
         store.write(secret)
-    }
-
-    /// Removes the secret from storage
-    public func clearSecret() {
-        lock.lock()
-        defer { lock.unlock() }
-        store.clear()
     }
 
     /// The URL the widget opens to toggle the VPN connection, carrying the shared secret.
@@ -141,28 +133,24 @@ public struct UserDefaultsWidgetConnectSecretStore: WidgetConnectSecretStore {
 
     private static let key = "vpn.widget.connect.secret"
 
-    private let defaults: UserDefaults?
+    private let defaults: UserDefaults
 
     public init(group: String = AppConstants.appGroup) {
-        self.defaults = UserDefaults(suiteName: group)
+        guard let defaults = UserDefaults(suiteName: group) else {
+            log.error("Unable to create UserDefaults for app group")
+            fatalError("No app group container")
+        }
+        self.defaults = defaults
     }
 
     public func readSecret() -> String? {
-        guard let secret = defaults?.string(forKey: Self.key), !secret.isEmpty else {
+        guard let secret = defaults.string(forKey: Self.key), !secret.isEmpty else {
             return nil
         }
         return secret
     }
 
     public func write(_ secret: String) {
-        guard let defaults else {
-            log.error("Could not store the widget connect secret, no app group container")
-            return
-        }
         defaults.set(secret, forKey: Self.key)
-    }
-
-    public func clear() {
-        defaults?.removeObject(forKey: Self.key)
     }
 }

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Util/WidgetConnectAuthorization.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Util/WidgetConnectAuthorization.swift
@@ -1,0 +1,168 @@
+//
+//  WidgetConnectAuthorization.swift
+//  PIALibrary
+//
+//  Copyright © 2026 Private Internet Access, Inc.
+//
+//  This file is part of the Private Internet Access iOS Client.
+//
+//  The Private Internet Access iOS Client is free software: you can redistribute it and/or
+//  modify it under the terms of the GNU General Public License as published by the Free
+//  Software Foundation, either version 3 of the License, or (at your option) any later version.
+//
+//  The Private Internet Access iOS Client is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+//  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+//  details.
+//
+//  You should have received a copy of the GNU General Public License along with the Private
+//  Internet Access iOS Client.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Foundation
+import Security
+
+private let log = PIALogger.logger(for: WidgetConnectAuthorization.self)
+
+/// Where the widget connect secret is kept between the app and the widget.
+public protocol WidgetConnectSecretStore {
+    func readSecret() -> String?
+    func write(_ secret: String)
+    func clear()
+}
+
+/// Authorizes the widget initiated VPN toggle deep link.
+///
+/// Any other app can also open PIA via the `piavpn:connect` URL, forcing the user to connect or
+/// disconnect. To tell our own widget apart, the widget appends a secret shared through the app group
+/// container: only the app and its own extensions can read it, so a URL built by another app never
+/// carries a valid token.
+public final class WidgetConnectAuthorization {
+
+    public static let shared = WidgetConnectAuthorization()
+
+    private static let tokenQueryItemName = "secret"
+    private static let secretByteCount = 32
+
+    private let store: WidgetConnectSecretStore
+    private let lock = NSLock()
+
+    public init(store: WidgetConnectSecretStore = UserDefaultsWidgetConnectSecretStore()) {
+        self.store = store
+    }
+
+    /// Creates and stores the secret unless one already exists.
+    public func createSecretIfNeeded() {
+        lock.lock()
+        defer { lock.unlock() }
+
+        guard store.readSecret() == nil else { return }
+
+        guard let secret = Self.makeSecret() else { return }
+        store.write(secret)
+    }
+
+    /// Removes the secret from storage
+    public func clearSecret() {
+        lock.lock()
+        defer { lock.unlock() }
+        store.clear()
+    }
+
+    /// The URL the widget opens to toggle the VPN connection, carrying the shared secret.
+    public func makeConnectURL() -> URL? {
+        guard let secret = storedSecret(),
+            var components = URLComponents(string: AppConstants.Widget.connect)
+        else {
+            log.error("Could not build an authorized widget connect URL")
+            return nil
+        }
+        components.queryItems = [URLQueryItem(name: Self.tokenQueryItemName, value: secret)]
+        return components.url
+    }
+
+    /// Whether the given VPN toggle URL comes from our own widget.
+    public func isAuthorized(_ url: URL) -> Bool {
+        guard let secret = storedSecret() else {
+            log.error("No widget connect secret stored yet, rejecting the URL")
+            return false
+        }
+
+        guard
+            let token = URLComponents(url: url, resolvingAgainstBaseURL: false)?
+                .queryItems?
+                .first(where: { $0.name == Self.tokenQueryItemName })?
+                .value
+        else {
+            log.error("Widget connect URL without a token, rejecting it")
+            return false
+        }
+
+        return Self.areEqualInConstantTime(token, secret)
+    }
+
+    // MARK: Private
+
+    private func storedSecret() -> String? {
+        lock.lock()
+        defer { lock.unlock() }
+
+        return store.readSecret()
+    }
+
+    private static func makeSecret() -> String? {
+        var bytes = [UInt8](repeating: 0, count: secretByteCount)
+        guard SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes) == errSecSuccess else {
+            log.error("Could not generate a random widget connect secret")
+            return nil
+        }
+        return bytes.map { String(format: "%02x", $0) }.joined()
+    }
+
+    /// Compares the two secrets without leaking their content through the comparison time.
+    private static func areEqualInConstantTime(_ lhs: String, _ rhs: String) -> Bool {
+        let lhsBytes = Array(lhs.utf8)
+        let rhsBytes = Array(rhs.utf8)
+
+        guard lhsBytes.count == rhsBytes.count else {
+            return false
+        }
+
+        var difference: UInt8 = 0
+        for (lhsByte, rhsByte) in zip(lhsBytes, rhsBytes) {
+            difference |= lhsByte ^ rhsByte
+        }
+        return difference == 0
+    }
+}
+
+/// Keeps the secret in the app group container, readable by the app and its extensions only.
+public struct UserDefaultsWidgetConnectSecretStore: WidgetConnectSecretStore {
+
+    private static let key = "vpn.widget.connect.secret"
+
+    private let defaults: UserDefaults?
+
+    public init(group: String = AppConstants.appGroup) {
+        self.defaults = UserDefaults(suiteName: group)
+    }
+
+    public func readSecret() -> String? {
+        guard let secret = defaults?.string(forKey: Self.key), !secret.isEmpty else {
+            return nil
+        }
+        return secret
+    }
+
+    public func write(_ secret: String) {
+        guard let defaults else {
+            log.error("Could not store the widget connect secret, no app group container")
+            return
+        }
+        defaults.set(secret, forKey: Self.key)
+    }
+
+    public func clear() {
+        defaults?.removeObject(forKey: Self.key)
+    }
+}

--- a/LocalPackages/PIALibrary/Tests/PIALibraryTests/WidgetConnectAuthorizationTests.swift
+++ b/LocalPackages/PIALibrary/Tests/PIALibraryTests/WidgetConnectAuthorizationTests.swift
@@ -1,0 +1,121 @@
+//
+//  WidgetConnectAuthorizationTests.swift
+//  PIALibrary
+//
+//  Copyright © 2026 Private Internet Access, Inc.
+//
+
+import Foundation
+import Testing
+
+@testable import PIALibrary
+
+@Suite("Widget Connect Authorization Tests")
+struct WidgetConnectAuthorizationTests {
+
+    /// Stands in for the group keychain, so the tests need no entitlements.
+    private final class InMemorySecretStore: WidgetConnectSecretStore {
+        private var secret: String?
+        private let lock = NSLock()
+
+        init(secret: String? = nil) {
+            self.secret = secret
+        }
+
+        func readSecret() -> String? {
+            lock.lock()
+            defer { lock.unlock() }
+            return secret
+        }
+
+        func write(_ secret: String) {
+            lock.lock()
+            defer { lock.unlock() }
+            self.secret = secret
+        }
+    }
+
+    private func makeSUT(secret: String? = nil) -> (sut: WidgetConnectAuthorization, store: InMemorySecretStore) {
+        let store = InMemorySecretStore(secret: secret)
+        return (WidgetConnectAuthorization(store: store), store)
+    }
+
+    @Test("The widget URL carries a secret and is authorized")
+    func widgetURLIsAuthorized() {
+        let (sut, _) = makeSUT()
+        sut.createSecretIfNeeded()
+
+        let url = sut.makeConnectURL()!
+
+        #expect(url.absoluteString.hasPrefix(AppConstants.Widget.connect))
+        #expect(url.absoluteString.contains("secret="))
+        #expect(sut.isAuthorized(url))
+    }
+
+    @Test("The secret is created once and then reused")
+    func secretIsCreatedOnce() {
+        let (sut, store) = makeSUT()
+
+        sut.createSecretIfNeeded()
+        let created = store.readSecret()
+        sut.createSecretIfNeeded()
+
+        #expect(created != nil)
+        #expect(store.readSecret() == created)
+    }
+
+    @Test("The same secret is reused across calls")
+    func secretIsStable() {
+        let (sut, _) = makeSUT()
+        sut.createSecretIfNeeded()
+
+        #expect(sut.makeConnectURL() == sut.makeConnectURL())
+    }
+
+    @Test("The same secret authorizes the URL more than once")
+    func secretIsReusable() {
+        let (sut, _) = makeSUT()
+        sut.createSecretIfNeeded()
+        let url = sut.makeConnectURL()!
+
+        #expect(sut.isAuthorized(url))
+        #expect(sut.isAuthorized(url))
+    }
+
+    @Test("No URL is built before the app created the secret")
+    func noURLWithoutStoredSecret() {
+        let (sut, _) = makeSUT()
+
+        #expect(sut.makeConnectURL() == nil)
+    }
+
+    @Test("A URL without a secret is rejected")
+    func urlWithoutSecretIsRejected() {
+        let (sut, _) = makeSUT()
+        // Make sure a secret exists, so that the rejection is caused by the missing token.
+        sut.createSecretIfNeeded()
+
+        #expect(!sut.isAuthorized(URL(string: AppConstants.Widget.connect)!))
+    }
+
+    @Test("A URL with a forged secret is rejected")
+    func urlWithForgedSecretIsRejected() {
+        let (sut, _) = makeSUT()
+        sut.createSecretIfNeeded()
+
+        let forgedURL = URL(string: "\(AppConstants.Widget.connect)?secret=deadbeef")!
+
+        #expect(!sut.isAuthorized(forgedURL))
+    }
+
+    @Test("A URL is rejected while no secret has been created")
+    func urlIsRejectedWithoutStoredSecret() {
+        let widget = makeSUT(secret: "a-secret-from-a-previous-install").sut
+        let url = widget.makeConnectURL()!
+
+        // A fresh store has no secret, so not even a previously valid URL is accepted.
+        let (app, _) = makeSUT()
+
+        #expect(!app.isAuthorized(url))
+    }
+}

--- a/PIA VPN/AppDelegate.swift
+++ b/PIA VPN/AppDelegate.swift
@@ -192,6 +192,10 @@ final class AppDelegate: NSObject, UIApplicationDelegate {
             }
 
         } else if url.absoluteString.starts(with: AppConstants.Widget.connect) {
+            guard WidgetConnectAuthorization.shared.isAuthorized(url) else {
+                log.error("Ignoring a widget connect URL without a valid secret")
+                return false
+            }
             if Client.providers.vpnProvider.isVPNConnected {
                 disconnectAfter(milliseconds: defaultMilliseconds)
             } else {
@@ -220,11 +224,6 @@ final class AppDelegate: NSObject, UIApplicationDelegate {
 
             // in case it's too early for notification delivery (vc not loaded)
             TransientState.shouldDisplayRegionPicker = true
-
-        case VPNStatus.disconnected.rawValue:
-            if !Client.providers.vpnProvider.isVPNConnected {
-                connectAfter(milliseconds: defaultMilliseconds)
-            }
 
         default:
             return false

--- a/PIA VPN/Bootstrapper.swift
+++ b/PIA VPN/Bootstrapper.swift
@@ -97,6 +97,8 @@ final class Bootstrapper {
             Client.providers.accountProvider.cleanDatabase()
         }
 
+        WidgetConnectAuthorization.shared.createSecretIfNeeded()
+
         AppPreferences.shared.migrate()
         AppPreferences.shared.migrateNMT()
 
@@ -272,6 +274,7 @@ final class Bootstrapper {
 
     func dispose() {
         Client.dispose()
+        WidgetConnectAuthorization.shared.clearSecret()
     }
 
     private func setupExceptionHandler() {

--- a/PIA VPN/Bootstrapper.swift
+++ b/PIA VPN/Bootstrapper.swift
@@ -274,7 +274,6 @@ final class Bootstrapper {
 
     func dispose() {
         Client.dispose()
-        WidgetConnectAuthorization.shared.clearSecret()
     }
 
     private func setupExceptionHandler() {

--- a/PIA VPN/Core/Utils/TrustedNetworkHelper.swift
+++ b/PIA VPN/Core/Utils/TrustedNetworkHelper.swift
@@ -35,6 +35,6 @@ class TrustedNetworkUtils {
     }
 
     private static func reloadWidget() {
-        WidgetCenter.shared.reloadTimelines(ofKind: "PIAWidget")
+        WidgetCenter.shared.reloadTimelines(ofKind: AppConstants.Widget.kind)
     }
 }

--- a/PIA VPN/UI/Dashboard/DashboardViewController.swift
+++ b/PIA VPN/UI/Dashboard/DashboardViewController.swift
@@ -1195,7 +1195,7 @@ final class DashboardViewController: AutolayoutViewController {
     }
 
     private func reloadWidget() {
-        WidgetCenter.shared.reloadTimelines(ofKind: "PIAWidget")
+        WidgetCenter.shared.reloadTimelines(ofKind: AppConstants.Widget.kind)
     }
 
     private func handleDisconnectedAndTrustedNetwork() {

--- a/PIA VPN/UI/Settings/SettingsViewController.swift
+++ b/PIA VPN/UI/Settings/SettingsViewController.swift
@@ -391,7 +391,7 @@ final class SettingsViewController: AutolayoutViewController, SettingsDelegate {
         AppPreferences.shared.todayWidgetVpnSocket = Client.preferences.vpnType.port
         AppPreferences.shared.todayWidgetVpnPort = Client.preferences.vpnType.socket
 
-        WidgetCenter.shared.reloadTimelines(ofKind: "PIAWidget")
+        WidgetCenter.shared.reloadTimelines(ofKind: AppConstants.Widget.kind)
     }
 
     private func commitPreferences() {

--- a/PIAWidget/Domain/UI/PIAConnectionView.swift
+++ b/PIAWidget/Domain/UI/PIAConnectionView.swift
@@ -49,14 +49,17 @@ internal struct PIAConnectionView: View {
                     Spacer()
                 }
 
-                Link(destination: URL(string: AppConstants.Widget.connect)!) {
-                    PIACircleImageView(
-                        size: 54,
-                        image: context.state.connected ? Asset.connectedButton.swiftUIImage : Asset.disconnectedButton.swiftUIImage
-                    )
+                if let connectUrl = WidgetConnectAuthorization.shared.makeConnectURL() {
+                    Link(destination: connectUrl) {
+                        PIACircleImageView(
+                            size: 54,
+                            image: context.state.connected
+                                ? Asset.connectedButton.swiftUIImage
+                                : Asset.disconnectedButton.swiftUIImage
+                        )
+                    }
                 }
             }
         }
-
     }
 }

--- a/PIAWidget/Domain/UI/PIAWidgetView.swift
+++ b/PIAWidget/Domain/UI/PIAWidgetView.swift
@@ -58,8 +58,7 @@ struct PIAWidgetView: View {
                     )
                 }
             }
-
         }
-        .widgetURL(URL(string: AppConstants.Widget.connect))
+        .widgetURL(WidgetConnectAuthorization.shared.makeConnectURL())
     }
 }

--- a/PIAWidget/Domain/Widget/PIAConnectionActivityWidget.swift
+++ b/PIAWidget/Domain/Widget/PIAConnectionActivityWidget.swift
@@ -38,12 +38,13 @@ struct PIAConnectionActivityWidget: Widget {
                 }
 
                 DynamicIslandExpandedRegion(.trailing, priority: 200) {
-                    Link(destination: URL(string: AppConstants.Widget.connect)!) {
-                        PIACircleImageView(
-                            size: 50,
-                            image: context.state.connected ? Asset.connectedButton.swiftUIImage : Asset.disconnectedButton.swiftUIImage
-                        )
-
+                    if let connectUrl = WidgetConnectAuthorization.shared.makeConnectURL() {
+                        Link(destination: connectUrl) {
+                            PIACircleImageView(
+                                size: 50,
+                                image: context.state.connected ? Asset.connectedButton.swiftUIImage : Asset.disconnectedButton.swiftUIImage
+                            )
+                        }
                     }
                 }
 

--- a/PIAWidget/Domain/Widget/PIAWidget.swift
+++ b/PIAWidget/Domain/Widget/PIAWidget.swift
@@ -24,11 +24,10 @@ import Intents
 import SwiftUI
 import WidgetKit
 
-//@main
 struct PIAWidget: Widget {
 
-    let kind: String = "PIAWidget"
-    let displayName: String = "PIA VPN"
+    private let kind: String = "PIAWidget"
+    private let displayName: String = "PIA VPN"
 
     var body: some WidgetConfiguration {
         let widgetPersistenceDatasource = WidgetUserDefaultsDatasource()

--- a/PIAWidget/Domain/Widget/PIAWidget.swift
+++ b/PIAWidget/Domain/Widget/PIAWidget.swift
@@ -21,18 +21,18 @@
 
 import ActivityKit
 import Intents
+import PIALibrary
 import SwiftUI
 import WidgetKit
 
 struct PIAWidget: Widget {
 
-    private let kind: String = "PIAWidget"
     private let displayName: String = "PIA VPN"
 
     var body: some WidgetConfiguration {
         let widgetPersistenceDatasource = WidgetUserDefaultsDatasource()
         return StaticConfiguration(
-            kind: kind,
+            kind: AppConstants.Widget.kind,
             provider: PIAWidgetProvider(
                 widgetPersistenceDatasource: widgetPersistenceDatasource
             )


### PR DESCRIPTION
- Add `secret` query parameter to widget connect URL. Only the widget and the app can read the secret.
- Use new url with secret in widget, live activity, and dynamic island (long pressed).