### PR TITLE
KM-17473: Reload bundled servers when targetServer finds the cache empty

### DIFF
--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Server/DefaultServerProvider.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Server/DefaultServerProvider.swift
@@ -30,6 +30,7 @@ public final class DefaultServerProvider: ServerProvider, ConfigurationAccess, D
     private let renewDedicatedIP: RenewDedicatedIPUseCaseType
     private let getDedicatedIPs: GetDedicatedIPsUseCaseType
     private let dedicatedIPServerMapper: DedicatedIPServerMapperType
+    private let bundledServersReloadLock = Mutex<Void>(())
 
     init(webServices: WebServices? = nil, renewDedicatedIP: RenewDedicatedIPUseCaseType, getDedicatedIPs: GetDedicatedIPsUseCaseType, dedicatedIPServerMapper: DedicatedIPServerMapperType) {
         if let webServices = webServices {
@@ -122,9 +123,7 @@ public final class DefaultServerProvider: ServerProvider, ConfigurationAccess, D
     public var targetServer: Server {
         get throws {
             guard let server = accessedPreferences.preferredServer ?? bestServer ?? accessedDatabase.plain.lastConnectedRegion else {
-                if currentServers.isEmpty, let bundledServersJSON = accessedConfiguration.bundledServersJSON {
-                    loadLocalJSON(fromJSON: bundledServersJSON)
-                }
+                reloadBundledServersIfEmpty()
                 guard let fallbackServer = currentServers.first else {
                     log.error("No servers available")
                     throw ClientError.noServersAvailable
@@ -132,6 +131,18 @@ public final class DefaultServerProvider: ServerProvider, ConfigurationAccess, D
                 return fallbackServer
             }
             return server
+        }
+    }
+
+    /// Serializes the check-and-reload so concurrent `targetServer` reads from different
+    /// threads (`VPNDaemon`, `DefaultVPNProvider`) can't all see an empty cache at once and
+    /// each independently reload the bundle, duplicating the write, notification, and ping sweep.
+    private func reloadBundledServersIfEmpty() {
+        bundledServersReloadLock.withLock { _ in
+            guard currentServers.isEmpty, let bundledServersJSON = accessedConfiguration.bundledServersJSON else {
+                return
+            }
+            loadLocalJSON(fromJSON: bundledServersJSON)
         }
     }
 

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Server/DefaultServerProvider.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Server/DefaultServerProvider.swift
@@ -30,7 +30,7 @@ public final class DefaultServerProvider: ServerProvider, ConfigurationAccess, D
     private let renewDedicatedIP: RenewDedicatedIPUseCaseType
     private let getDedicatedIPs: GetDedicatedIPsUseCaseType
     private let dedicatedIPServerMapper: DedicatedIPServerMapperType
-    private let bundledServersReloadLock = Mutex<Void>(())
+    private let bundledServersReloadLock = NSRecursiveLock()
 
     init(webServices: WebServices? = nil, renewDedicatedIP: RenewDedicatedIPUseCaseType, getDedicatedIPs: GetDedicatedIPsUseCaseType, dedicatedIPServerMapper: DedicatedIPServerMapperType) {
         if let webServices = webServices {
@@ -140,16 +140,13 @@ public final class DefaultServerProvider: ServerProvider, ConfigurationAccess, D
         accessedPreferences.preferredServer ?? bestServer ?? accessedDatabase.plain.lastConnectedRegion
     }
 
-    /// Serializes the check-and-reload so concurrent `targetServer` reads from different
-    /// threads (`VPNDaemon`, `DefaultVPNProvider`) can't all see an empty cache at once and
-    /// each independently reload the bundle, duplicating the write, notification, and ping sweep.
     private func reloadBundledServersIfEmpty() {
-        bundledServersReloadLock.withLock { _ in
-            guard currentServers.isEmpty, let bundledServersJSON = accessedConfiguration.bundledServersJSON else {
-                return
-            }
-            loadLocalJSON(fromJSON: bundledServersJSON)
+        bundledServersReloadLock.lock()
+        defer { bundledServersReloadLock.unlock() }
+        guard currentServers.isEmpty, let bundledServersJSON = accessedConfiguration.bundledServersJSON else {
+            return
         }
+        loadLocalJSON(fromJSON: bundledServersJSON)
     }
 
     public var dipTokens: [String]? {

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Server/DefaultServerProvider.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Server/DefaultServerProvider.swift
@@ -122,6 +122,9 @@ public final class DefaultServerProvider: ServerProvider, ConfigurationAccess, D
     public var targetServer: Server {
         get throws {
             guard let server = accessedPreferences.preferredServer ?? bestServer ?? accessedDatabase.plain.lastConnectedRegion else {
+                if currentServers.isEmpty, let bundledServersJSON = accessedConfiguration.bundledServersJSON {
+                    loadLocalJSON(fromJSON: bundledServersJSON)
+                }
                 guard let fallbackServer = currentServers.first else {
                     log.error("No servers available")
                     throw ClientError.noServersAvailable

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Server/DefaultServerProvider.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Server/DefaultServerProvider.swift
@@ -122,9 +122,11 @@ public final class DefaultServerProvider: ServerProvider, ConfigurationAccess, D
 
     public var targetServer: Server {
         get throws {
-            guard let server = accessedPreferences.preferredServer ?? bestServer ?? accessedDatabase.plain.lastConnectedRegion else {
+            guard let server = resolvedTargetServer else {
                 reloadBundledServersIfEmpty()
-                guard let fallbackServer = currentServers.first else {
+                // Re-resolve: the preferred/last-connected region may now be found in the
+                // freshly-reloaded cache, instead of falling back to an arbitrary server.
+                guard let fallbackServer = resolvedTargetServer ?? currentServers.first else {
                     log.error("No servers available")
                     throw ClientError.noServersAvailable
                 }
@@ -132,6 +134,10 @@ public final class DefaultServerProvider: ServerProvider, ConfigurationAccess, D
             }
             return server
         }
+    }
+
+    private var resolvedTargetServer: Server? {
+        accessedPreferences.preferredServer ?? bestServer ?? accessedDatabase.plain.lastConnectedRegion
     }
 
     /// Serializes the check-and-reload so concurrent `targetServer` reads from different

--- a/LocalPackages/PIALibrary/Tests/PIALibraryTests/DefaultServerProviderTargetServerTests.swift
+++ b/LocalPackages/PIALibrary/Tests/PIALibraryTests/DefaultServerProviderTargetServerTests.swift
@@ -26,18 +26,21 @@ import XCTest
 class DefaultServerProviderTargetServerTests: XCTestCase {
 
     private var originalServerProvider: ServerProvider!
+    private var serverProvider: DefaultServerProvider!
 
-    override func setUp() {
-        super.setUp()
+    override func setUpWithError() throws {
+        try super.setUpWithError()
         originalServerProvider = Client.providers.serverProvider
         Client.database = Client.Database(group: "group.com.privateinternetaccess").truncate()
-        Client.providers.serverProvider = ServerProviderFactory.makeDefaultServerProvider()
+        serverProvider = try XCTUnwrap(ServerProviderFactory.makeDefaultServerProvider() as? DefaultServerProvider)
+        Client.providers.serverProvider = serverProvider
     }
 
     override func tearDown() {
         Client.configuration.bundledServersJSON = nil
         Client.database.truncate()
         Client.providers.serverProvider = originalServerProvider
+        serverProvider = nil
         super.tearDown()
     }
 
@@ -45,22 +48,18 @@ class DefaultServerProviderTargetServerTests: XCTestCase {
         // GIVEN an empty cache (no preferred/best/last-connected server either) and a
         // bundled servers JSON available
         Client.configuration.bundledServersJSON = try minimalBundleJSON(regionIdentifiers: ["region-a", "region-b"])
-        XCTAssertTrue(Client.providers.serverProvider.currentServers.isEmpty)
+        XCTAssertTrue(serverProvider.currentServers.isEmpty)
 
         // WHEN resolving targetServer, which would otherwise throw noServersAvailable
-        let server = try Client.providers.serverProvider.targetServer
+        let server = try serverProvider.targetServer
 
         // THEN it self-heals from the bundle, returning one of the reloaded servers
-        let reloaded = Client.providers.serverProvider.currentServers
+        let reloaded = serverProvider.currentServers
         XCTAssertFalse(reloaded.isEmpty)
         XCTAssertTrue(reloaded.contains { $0.identifier == server.identifier })
     }
 
     func test_targetServer_doesNotReload_whenCacheIsAlreadyPopulated() throws {
-        guard let serverProvider = Client.providers.serverProvider as? DefaultServerProvider else {
-            return XCTFail("Expected the real DefaultServerProvider")
-        }
-
         // GIVEN a cache that's already populated, and a different bundle available
         let existing = Server(
             serial: "",
@@ -82,10 +81,6 @@ class DefaultServerProviderTargetServerTests: XCTestCase {
     }
 
     func test_targetServer_reResolvesPreferredServer_afterReload() throws {
-        guard let serverProvider = Client.providers.serverProvider as? DefaultServerProvider else {
-            return XCTFail("Expected the real DefaultServerProvider")
-        }
-
         // GIVEN a bundle with more than one server, and a persisted preferred server
         // that isn't first in the bundle
         let bundleJSON = try minimalBundleJSON(regionIdentifiers: ["first", "preferred"])
@@ -108,10 +103,6 @@ class DefaultServerProviderTargetServerTests: XCTestCase {
     }
 
     func test_targetServer_reResolvesLastConnectedRegion_afterReload() throws {
-        guard let serverProvider = Client.providers.serverProvider as? DefaultServerProvider else {
-            return XCTFail("Expected the real DefaultServerProvider")
-        }
-
         // GIVEN a bundle with more than one server, and a persisted "last connected" region
         // that isn't the first server in the bundle
         let bundleJSON = try minimalBundleJSON(regionIdentifiers: ["first", "last-connected"])
@@ -136,12 +127,42 @@ class DefaultServerProviderTargetServerTests: XCTestCase {
     func test_targetServer_stillThrows_whenNoBundledServersJSONAvailable() {
         // GIVEN an empty cache and no bundled servers JSON configured
         Client.configuration.bundledServersJSON = nil
-        XCTAssertTrue(Client.providers.serverProvider.currentServers.isEmpty)
+        XCTAssertTrue(serverProvider.currentServers.isEmpty)
 
         // WHEN/THEN resolving targetServer still throws noServersAvailable
-        XCTAssertThrowsError(try Client.providers.serverProvider.targetServer) { error in
+        XCTAssertThrowsError(try serverProvider.targetServer) { error in
             XCTAssertEqual(error as? ClientError, ClientError.noServersAvailable)
         }
+    }
+
+    func test_targetServer_fallsBackToArbitraryRegion_whenPreferredServerIsDIP_afterReload() throws {
+        // GIVEN a persisted preferred server that's a DIP (dedicated IP) server — matched by
+        // both identifier and dipToken — which never appears in the bundled servers JSON
+        let dipServer = Server(
+            serial: "",
+            name: "My Dedicated IP",
+            country: "us",
+            hostname: "dip-server.invalid",
+            pingAddress: nil,
+            dipToken: "dip-token-123",
+            regionIdentifier: "dip-server"
+        )
+        Client.database.plain.preferredServer = dipServer
+
+        // AND the cache is empty again (e.g. right after logout, before the daemon re-downloads)
+        serverProvider.currentServers = []
+        Client.configuration.bundledServersJSON = try minimalBundleJSON(regionIdentifiers: ["region-a", "region-b"])
+        XCTAssertTrue(serverProvider.currentServers.isEmpty)
+
+        // WHEN resolving targetServer, which reloads the bundle
+        let resolved = try serverProvider.targetServer
+
+        // THEN the DIP preference can't be re-resolved — bundled servers never carry a
+        // dipToken — so it silently falls through to an arbitrary regular region instead
+        // of the user's dedicated IP. This pins current behavior; it isn't necessarily the
+        // desired one.
+        XCTAssertNotEqual(resolved.identifier, dipServer.identifier)
+        XCTAssertEqual(resolved.identifier, serverProvider.currentServers.first?.identifier)
     }
 
     /// Builds a minimal `ServersBundle`-shaped JSON with no server addresses, so loading it

--- a/LocalPackages/PIALibrary/Tests/PIALibraryTests/DefaultServerProviderTargetServerTests.swift
+++ b/LocalPackages/PIALibrary/Tests/PIALibraryTests/DefaultServerProviderTargetServerTests.swift
@@ -1,31 +1,110 @@
+//
+//  DefaultServerProviderTargetServerTests.swift
+//  PIALibraryTests
+//
+//  Copyright © 2026 Private Internet Access, Inc.
+//
+//  This file is part of the Private Internet Access iOS Client.
+//
+//  The Private Internet Access iOS Client is free software: you can redistribute it and/or
+//  modify it under the terms of the GNU General Public License as published by the Free
+//  Software Foundation, either version 3 of the License, or (at your option) any later version.
+//
+//  The Private Internet Access iOS Client is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+//  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+//  details.
+//
+//  You should have received a copy of the GNU General Public License along with the Private
+//  Internet Access iOS Client.  If not, see <https://www.gnu.org/licenses/>.
+//
+
 import XCTest
 
 @testable import PIALibrary
 
 class DefaultServerProviderTargetServerTests: XCTestCase {
 
+    private var originalServerProvider: ServerProvider!
+
     override func setUp() {
         super.setUp()
+        originalServerProvider = Client.providers.serverProvider
         Client.database = Client.Database(group: "group.com.privateinternetaccess").truncate()
+        Client.providers.serverProvider = ServerProviderFactory.makeDefaultServerProvider()
     }
 
     override func tearDown() {
         Client.configuration.bundledServersJSON = nil
+        Client.database.truncate()
+        Client.providers.serverProvider = originalServerProvider
         super.tearDown()
     }
 
     func test_targetServer_reloadsBundledServers_whenCacheIsEmpty() throws {
         // GIVEN an empty cache (no preferred/best/last-connected server either) and a
         // bundled servers JSON available
-        Client.configuration.bundledServersJSON = bundledServersJSON()
+        Client.configuration.bundledServersJSON = try minimalBundleJSON(regionIdentifiers: ["region-a", "region-b"])
         XCTAssertTrue(Client.providers.serverProvider.currentServers.isEmpty)
 
         // WHEN resolving targetServer, which would otherwise throw noServersAvailable
         let server = try Client.providers.serverProvider.targetServer
 
-        // THEN it self-heals from the bundle instead of throwing
-        XCTAssertNotNil(server)
-        XCTAssertFalse(Client.providers.serverProvider.currentServers.isEmpty)
+        // THEN it self-heals from the bundle, returning one of the reloaded servers
+        let reloaded = Client.providers.serverProvider.currentServers
+        XCTAssertFalse(reloaded.isEmpty)
+        XCTAssertTrue(reloaded.contains { $0.identifier == server.identifier })
+    }
+
+    func test_targetServer_doesNotReload_whenCacheIsAlreadyPopulated() throws {
+        guard let serverProvider = Client.providers.serverProvider as? DefaultServerProvider else {
+            return XCTFail("Expected the real DefaultServerProvider")
+        }
+
+        // GIVEN a cache that's already populated, and a different bundle available
+        let existing = Server(
+            serial: "",
+            name: "Existing",
+            country: "us",
+            hostname: "existing.invalid",
+            pingAddress: nil,
+            regionIdentifier: "existing"
+        )
+        serverProvider.currentServers = [existing]
+        Client.configuration.bundledServersJSON = try minimalBundleJSON(regionIdentifiers: ["from-bundle"])
+
+        // WHEN resolving targetServer with nothing else to resolve against
+        let resolved = try serverProvider.targetServer
+
+        // THEN the already-cached server is left untouched — the bundle is never reloaded
+        XCTAssertEqual(resolved.identifier, existing.identifier)
+        XCTAssertEqual(serverProvider.currentServers.map(\.identifier), [existing.identifier])
+    }
+
+    func test_targetServer_reResolvesPreferredServer_afterReload() throws {
+        guard let serverProvider = Client.providers.serverProvider as? DefaultServerProvider else {
+            return XCTFail("Expected the real DefaultServerProvider")
+        }
+
+        // GIVEN a bundle with more than one server, and a persisted preferred server
+        // that isn't first in the bundle
+        let bundleJSON = try minimalBundleJSON(regionIdentifiers: ["first", "preferred"])
+        Client.configuration.bundledServersJSON = bundleJSON
+        serverProvider.loadLocalJSON(fromJSON: bundleJSON)
+        let allServers = serverProvider.currentServers
+        let preferred = try XCTUnwrap(allServers.first { $0.identifier == "preferred" })
+        Client.database.plain.preferredServer = preferred
+
+        // AND the cache is empty again (e.g. right after logout, before the daemon re-downloads)
+        serverProvider.currentServers = []
+        XCTAssertTrue(serverProvider.currentServers.isEmpty)
+
+        // WHEN resolving targetServer, which reloads the bundle
+        let resolved = try serverProvider.targetServer
+
+        // THEN it re-resolves the persisted preferred server instead of returning an
+        // arbitrary server from the freshly-reloaded cache
+        XCTAssertEqual(resolved.identifier, preferred.identifier)
     }
 
     func test_targetServer_reResolvesLastConnectedRegion_afterReload() throws {
@@ -35,12 +114,11 @@ class DefaultServerProviderTargetServerTests: XCTestCase {
 
         // GIVEN a bundle with more than one server, and a persisted "last connected" region
         // that isn't the first server in the bundle
-        let serversJSON = bundledServersJSON()
-        Client.configuration.bundledServersJSON = serversJSON
-        serverProvider.loadLocalJSON(fromJSON: serversJSON)
+        let bundleJSON = try minimalBundleJSON(regionIdentifiers: ["first", "last-connected"])
+        Client.configuration.bundledServersJSON = bundleJSON
+        serverProvider.loadLocalJSON(fromJSON: bundleJSON)
         let allServers = serverProvider.currentServers
-        let lastConnected = try XCTUnwrap(allServers.dropFirst().first, "fixture needs at least 2 servers")
-        XCTAssertNotEqual(lastConnected.identifier, allServers.first?.identifier)
+        let lastConnected = try XCTUnwrap(allServers.first { $0.identifier == "last-connected" })
         Client.database.plain.lastConnectedRegion = lastConnected
 
         // AND the cache is empty again (e.g. right after logout, before the daemon re-downloads)
@@ -66,19 +144,19 @@ class DefaultServerProviderTargetServerTests: XCTestCase {
         }
     }
 
-    private func bundledServersJSON() -> Data {
-        let testBundle = Bundle(for: DefaultServerProviderTargetServerTests.self)
-        // The Xcode-native SPM integration nests package test resources inside a
-        // "PIALibrary_PIALibraryTests.bundle" sub-bundle rather than the test bundle root.
-        let candidateBundles = [
-            testBundle,
-            testBundle.url(forResource: "PIALibrary_PIALibraryTests", withExtension: "bundle")
-                .flatMap(Bundle.init(url:))
-        ].compactMap { $0 }
-        guard let url = candidateBundles.compactMap({ $0.url(forResource: "server", withExtension: "json") }).first
-        else {
-            fatalError("Could not find bundled regions fixture")
+    /// Builds a minimal `ServersBundle`-shaped JSON with no server addresses, so loading it
+    /// never triggers `ServersPinger`'s real network ping sweep (`Server.addresses()` is empty
+    /// when no protocol addresses are decoded).
+    private func minimalBundleJSON(regionIdentifiers: [String]) throws -> Data {
+        let regions = regionIdentifiers.map { identifier in
+            [
+                "id": identifier,
+                "name": identifier,
+                "country": "us",
+                "dns": "\(identifier).invalid"
+            ]
         }
-        return try! Data(contentsOf: url)
+        let payload: [String: Any] = ["groups": [String: Any](), "regions": regions]
+        return try JSONSerialization.data(withJSONObject: payload)
     }
 }

--- a/LocalPackages/PIALibrary/Tests/PIALibraryTests/DefaultServerProviderTargetServerTests.swift
+++ b/LocalPackages/PIALibrary/Tests/PIALibraryTests/DefaultServerProviderTargetServerTests.swift
@@ -28,6 +28,33 @@ class DefaultServerProviderTargetServerTests: XCTestCase {
         XCTAssertFalse(Client.providers.serverProvider.currentServers.isEmpty)
     }
 
+    func test_targetServer_reResolvesLastConnectedRegion_afterReload() throws {
+        guard let serverProvider = Client.providers.serverProvider as? DefaultServerProvider else {
+            return XCTFail("Expected the real DefaultServerProvider")
+        }
+
+        // GIVEN a bundle with more than one server, and a persisted "last connected" region
+        // that isn't the first server in the bundle
+        let serversJSON = bundledServersJSON()
+        Client.configuration.bundledServersJSON = serversJSON
+        serverProvider.loadLocalJSON(fromJSON: serversJSON)
+        let allServers = serverProvider.currentServers
+        let lastConnected = try XCTUnwrap(allServers.dropFirst().first, "fixture needs at least 2 servers")
+        XCTAssertNotEqual(lastConnected.identifier, allServers.first?.identifier)
+        Client.database.plain.lastConnectedRegion = lastConnected
+
+        // AND the cache is empty again (e.g. right after logout, before the daemon re-downloads)
+        serverProvider.currentServers = []
+        XCTAssertTrue(serverProvider.currentServers.isEmpty)
+
+        // WHEN resolving targetServer, which reloads the bundle
+        let resolved = try serverProvider.targetServer
+
+        // THEN it re-resolves the persisted last-connected region instead of returning an
+        // arbitrary server from the freshly-reloaded cache
+        XCTAssertEqual(resolved.identifier, lastConnected.identifier)
+    }
+
     func test_targetServer_stillThrows_whenNoBundledServersJSONAvailable() {
         // GIVEN an empty cache and no bundled servers JSON configured
         Client.configuration.bundledServersJSON = nil

--- a/LocalPackages/PIALibrary/Tests/PIALibraryTests/DefaultServerProviderTargetServerTests.swift
+++ b/LocalPackages/PIALibrary/Tests/PIALibraryTests/DefaultServerProviderTargetServerTests.swift
@@ -1,0 +1,57 @@
+import XCTest
+
+@testable import PIALibrary
+
+class DefaultServerProviderTargetServerTests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        Client.database = Client.Database(group: "group.com.privateinternetaccess").truncate()
+    }
+
+    override func tearDown() {
+        Client.configuration.bundledServersJSON = nil
+        super.tearDown()
+    }
+
+    func test_targetServer_reloadsBundledServers_whenCacheIsEmpty() throws {
+        // GIVEN an empty cache (no preferred/best/last-connected server either) and a
+        // bundled servers JSON available
+        Client.configuration.bundledServersJSON = bundledServersJSON()
+        XCTAssertTrue(Client.providers.serverProvider.currentServers.isEmpty)
+
+        // WHEN resolving targetServer, which would otherwise throw noServersAvailable
+        let server = try Client.providers.serverProvider.targetServer
+
+        // THEN it self-heals from the bundle instead of throwing
+        XCTAssertNotNil(server)
+        XCTAssertFalse(Client.providers.serverProvider.currentServers.isEmpty)
+    }
+
+    func test_targetServer_stillThrows_whenNoBundledServersJSONAvailable() {
+        // GIVEN an empty cache and no bundled servers JSON configured
+        Client.configuration.bundledServersJSON = nil
+        XCTAssertTrue(Client.providers.serverProvider.currentServers.isEmpty)
+
+        // WHEN/THEN resolving targetServer still throws noServersAvailable
+        XCTAssertThrowsError(try Client.providers.serverProvider.targetServer) { error in
+            XCTAssertEqual(error as? ClientError, ClientError.noServersAvailable)
+        }
+    }
+
+    private func bundledServersJSON() -> Data {
+        let testBundle = Bundle(for: DefaultServerProviderTargetServerTests.self)
+        // The Xcode-native SPM integration nests package test resources inside a
+        // "PIALibrary_PIALibraryTests.bundle" sub-bundle rather than the test bundle root.
+        let candidateBundles = [
+            testBundle,
+            testBundle.url(forResource: "PIALibrary_PIALibraryTests", withExtension: "bundle")
+                .flatMap(Bundle.init(url:))
+        ].compactMap { $0 }
+        guard let url = candidateBundles.compactMap({ $0.url(forResource: "server", withExtension: "json") }).first
+        else {
+            fatalError("Could not find bundled regions fixture")
+        }
+        return try! Data(contentsOf: url)
+    }
+}


### PR DESCRIPTION
## Summary
- After logout/reset, the server list can stay empty until the next daemon-driven download lands, so a `connect()` right after can fail with `vpnClientConfigurationUnavailable`.
- `targetServer` now reloads the bundled `Regions.json` right before it would throw `noServersAvailable`, so it self-heals regardless of why the cache is empty. Fixes both iOS and tvOS from one shared place.

## Test plan
- Added `DefaultServerProviderTargetServerTests`: self-heals when a bundle is available, still throws `noServersAvailable` when it isn't.
- Ran `PIALibraryTests` (new tests + `ServerTests`) — passing.