### PR TITLE
KM-17659 Debug Menu: add Tunnel Log section

### DIFF
--- a/LocalPackages/PIADebugMenu/README.md
+++ b/LocalPackages/PIADebugMenu/README.md
@@ -91,19 +91,31 @@ The label renders in `.caption` / `.secondary` style above the value in `.body` 
 
 `DebugExportFile` is a `Transferable` wrapper used by iOS `ShareLink` buttons. It writes the given string to a named temporary file and vends it as a file transfer. It is not used on tvOS.
 
+## Architecture
+
+`DebugMenuView` is a state observer only: it owns a `@StateObject DebugMenuViewModel`, renders `viewModel.*` and forwards user actions to it. All state, polling and side effects live in `DebugMenuViewModel.swift`:
+
+- `@Published` state for every value the view renders or binds to (log snapshots, entitlement JWS, alert/sheet flags, refund transactions).
+- `onAppear()` / `onDisappear()` start and cancel a single refresh `Task` that polls the app log and the tunnel log every 5 seconds.
+- Intents: `sendReportToSupport()`, `requestRefund()`, `selectTransaction(_:)`, `handleRefundResult(_:)`, `presentManageSubscriptions()`.
+
+Read-only values derived from `PIALibrary` (`appVersion`, `username`, `logs`, previews, `buildExportContent()`, …) live in `Extensions/DebugMenuViewModel+Values.swift`.
+
 ## Adding a new section
 
-1. Add a private `var` in `DebugMenuView.swift` returning a `DebugSection`:
+1. Put any new state or side effect on `DebugMenuViewModel` (`@Published` property plus an intent method), and derived read-only values in `DebugMenuViewModel+Values.swift`.
+
+2. Add a private `var` in `DebugMenuView.swift` returning a `DebugSection` that reads from the view model:
 
 ```swift
 private var mySection: some View {
     DebugSection("My Section") {
-        DebugInfoRow(label: "Some Key", value: someValue)
+        DebugInfoRow(label: "Some Key", value: viewModel.someValue)
     }
 }
 ```
 
-2. Add it to `mainContent` in both the `#if os(tvOS)` and `#else` branches:
+3. Add it to `mainContent` in both the `#if os(tvOS)` and `#else` branches:
 
 ```swift
 // tvOS
@@ -121,4 +133,4 @@ List {
 }
 ```
 
-3. If the section is platform-specific, wrap it with `#if os(iOS)` / `#if os(tvOS)` as appropriate (see `subscriptionSection` for an example).
+4. If the section is platform-specific, wrap it with `#if os(iOS)` / `#if os(tvOS)` as appropriate (see `subscriptionSection` for an example).

--- a/LocalPackages/PIADebugMenu/Sources/PIADebugMenu/DebugMenuView.swift
+++ b/LocalPackages/PIADebugMenu/Sources/PIADebugMenu/DebugMenuView.swift
@@ -16,6 +16,7 @@ struct ReportResult: Identifiable {
 public struct DebugMenuView: View {
     private let onDismiss: () -> Void
     @State private var logSnapshot: String = ""
+    @State var tunnelLogSnapshot: String = ""
     @State private var isSendingReport = false
     @State private var reportResult: ReportResult? = nil
     @State private var isPresentingManageSubscriptions: Bool = false
@@ -69,13 +70,15 @@ public struct DebugMenuView: View {
             #endif
             .navigationTitle("Debug Menu")
             .onAppear {
-                logSnapshot = logs
+                updateLogSnapshotIfNeeded()
+                refreshTunnelLog()
             }
             .task {
                 entitlementJWS = await Client.store.currentEntitlementJWS()
             }
-            .onReceive(Timer.publish(every: 2, on: .main, in: .common).autoconnect()) { _ in
-                logSnapshot = logs
+            .onReceive(Timer.publish(every: 5, on: .main, in: .common).autoconnect()) { _ in
+                updateLogSnapshotIfNeeded()
+                refreshTunnelLog()
             }
             .toolbar {
                 ToolbarItem(placement: .navigationBarLeading) {
@@ -116,6 +119,8 @@ public struct DebugMenuView: View {
                         .focusable()
                     logsSection
                         .focusable()
+                    tunnelLogSection
+                        .focusable()
                     supportSection
                 }
                 .padding(.horizontal, 60)
@@ -127,6 +132,7 @@ public struct DebugMenuView: View {
                 accountSection
                 receiptSection
                 logsSection
+                tunnelLogSection
                 subscriptionSection
                 supportSection
             }
@@ -202,20 +208,17 @@ public struct DebugMenuView: View {
     }
 
     private var logsSection: some View {
-        DebugSection("Logs") {
-            let preview = logSnapshot.isEmpty ? "No logs" : logSnapshot.components(separatedBy: "\n").reversed().joined(separator: "\n")
-
+        DebugSection("App Logs") {
             VStack(alignment: .leading, spacing: 2) {
-                Text("Recent logs (newest on top)")
+                Text("Recent logs (newest on top, last \(Self.previewLineCount) lines)")
                     .font(.caption)
                     .foregroundStyle(.secondary)
-                ScrollView {
-                    Text(preview)
+                ScrollView(.horizontal) {
+                    Text(logSnapshot.isEmpty ? "No logs" : Self.reversedPreview(of: logSnapshot))
                         .font(.system(.caption2, design: .monospaced))
                         .foregroundStyle(.primary)
-                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .fixedSize(horizontal: true, vertical: false)
                 }
-                .frame(height: 300)
             }
             #if os(tvOS)
                 .padding(.vertical, 8)
@@ -231,12 +234,60 @@ public struct DebugMenuView: View {
                         content: logs,
                         filename: "logs_\(Int(Date().timeIntervalSince1970)).txt"
                     ),
-                    preview: SharePreview("Logs")
+                    preview: SharePreview("App Logs")
                 ) {
                     Label("Export", systemImage: "square.and.arrow.up")
                 }
             #endif
         }
+    }
+
+    private var tunnelLogSection: some View {
+        DebugSection("Tunnel Log") {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Live tunnel-extension log (newest on top, last \(Self.previewLineCount) lines)")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                ScrollView(.horizontal) {
+                    Text(tunnelLogSnapshot.isEmpty ? "No tunnel log" : Self.reversedPreview(of: tunnelLogSnapshot))
+                        .font(.system(.caption2, design: .monospaced))
+                        .foregroundStyle(.primary)
+                        .fixedSize(horizontal: true, vertical: false)
+                }
+            }
+            #if os(tvOS)
+                .padding(.vertical, 8)
+                .padding(.horizontal, 12)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            #else
+                .padding(.vertical, 2)
+            #endif
+
+            #if os(iOS)
+                ShareLink(
+                    item: DebugExportFile(
+                        content: tunnelLogSnapshot,
+                        filename: "tunnel_logs_\(Int(Date().timeIntervalSince1970)).txt"
+                    ),
+                    preview: SharePreview("Tunnel Log")
+                ) {
+                    Label("Export", systemImage: "square.and.arrow.up")
+                }
+            #endif
+        }
+    }
+
+    /// Both log sections show only the tail of the snapshot — the full content is still one tap
+    /// away via Export. Unbounded 1000-line monospaced `Text` inside a scrolling `List` is expensive
+    /// to lay out on every re-render and was a source of scroll jank.
+    private static let previewLineCount = 25
+
+    private static func reversedPreview(of content: String) -> String {
+        content
+            .components(separatedBy: "\n")
+            .reversed()
+            .prefix(previewLineCount)
+            .joined(separator: "\n")
     }
 
     private var subscriptionSection: some View {
@@ -319,6 +370,26 @@ public struct DebugMenuView: View {
                 }
             }
             .disabled(isSendingReport)
+        }
+    }
+
+    // MARK: - Logs
+
+    private func updateLogSnapshotIfNeeded() {
+        let current = logs
+        if current != logSnapshot {
+            logSnapshot = current
+        }
+    }
+
+    private func refreshTunnelLog() {
+        Client.providers.vpnProvider.requestTunnelLog { content, _ in
+            guard let content, !content.isEmpty else { return }
+            DispatchQueue.main.async {
+                if content != tunnelLogSnapshot {
+                    tunnelLogSnapshot = content
+                }
+            }
         }
     }
 

--- a/LocalPackages/PIADebugMenu/Sources/PIADebugMenu/DebugMenuView.swift
+++ b/LocalPackages/PIADebugMenu/Sources/PIADebugMenu/DebugMenuView.swift
@@ -90,6 +90,7 @@ public struct DebugMenuView: View {
         #else
             List {
                 appInfoSection
+                vpnSection
                 accountSection
                 receiptSection
                 logsSection
@@ -113,6 +114,7 @@ public struct DebugMenuView: View {
     private var vpnSection: some View {
         DebugSection("VPN") {
             DebugInfoRow(label: "Status", value: viewModel.vpnStatus)
+            DebugInfoRow(label: "Connected Via", value: viewModel.connectedVia)
             DebugInfoRow(label: "Protocol", value: viewModel.vpnProtocolName)
             DebugInfoRow(label: "Local IP", value: viewModel.publicIP)
             DebugInfoRow(label: "VPN IP", value: viewModel.vpnIP)

--- a/LocalPackages/PIADebugMenu/Sources/PIADebugMenu/DebugMenuView.swift
+++ b/LocalPackages/PIADebugMenu/Sources/PIADebugMenu/DebugMenuView.swift
@@ -1,35 +1,15 @@
-@preconcurrency import PIALibrary
-import StoreKit
 import SwiftUI
 
-import struct PIABase.JWS
-
 // MARK: - DebugMenuView
-
-struct ReportResult: Identifiable {
-    let id = UUID()
-    let title: String
-    let message: String
-}
 
 @available(iOS 16, tvOS 17, *)
 public struct DebugMenuView: View {
     private let onDismiss: () -> Void
-    @State private var logSnapshot: String = ""
-    @State var tunnelLogSnapshot: String = ""
-    @State private var isSendingReport = false
-    @State private var reportResult: ReportResult? = nil
-    @State private var isPresentingManageSubscriptions: Bool = false
-    @State private var isLoadingRefundTransaction = false
-    @State private var refundTransactionId: UInt64 = 0
-    @State private var isRefundSheetPresented = false
-    @State private var availableTransactions: [StoreKit.Transaction] = []
-    @State private var isTransactionPickerPresented = false
-    @State var entitlementJWS: JWS? = nil
+    @StateObject private var viewModel = DebugMenuViewModel()
 
     public var body: some View {
         mainContent
-            .alert(item: $reportResult) { result in
+            .alert(item: $viewModel.reportResult) { result in
                 Alert(
                     title: Text(result.title),
                     message: Text(result.message),
@@ -37,31 +17,17 @@ public struct DebugMenuView: View {
                 )
             }
             #if os(iOS)
-                .manageSubscriptionsSheet(isPresented: $isPresentingManageSubscriptions)
-                .refundRequestSheet(for: refundTransactionId, isPresented: $isRefundSheetPresented) { @MainActor result in
-                    switch result {
-                    case .success(let status):
-                        if status == .success {
-                            reportResult = ReportResult(
-                                title: "Refund Requested",
-                                message: "Your refund request was submitted to the App Store."
-                            )
-                        }
-                    case .failure(let error):
-                        reportResult = ReportResult(
-                            title: "Refund Request Failed",
-                            message: error.localizedDescription
-                        )
-                    }
+                .manageSubscriptionsSheet(isPresented: $viewModel.isPresentingManageSubscriptions)
+                .refundRequestSheet(for: viewModel.refundTransactionId, isPresented: $viewModel.isRefundSheetPresented) {
+                    @MainActor result in
+                    viewModel.handleRefundResult(result)
                 }
-                .sheet(isPresented: $isTransactionPickerPresented) {
+                .sheet(isPresented: $viewModel.isTransactionPickerPresented) {
                     List {
                         Section("Select a transaction to refund") {
-                            ForEach(availableTransactions, id: \.id) { transaction in
+                            ForEach(viewModel.availableTransactions, id: \.id) { transaction in
                                 Button(transaction.productID) {
-                                    isTransactionPickerPresented = false
-                                    refundTransactionId = transaction.id
-                                    isRefundSheetPresented = true
+                                    viewModel.selectTransaction(transaction)
                                 }
                             }
                         }
@@ -70,15 +36,10 @@ public struct DebugMenuView: View {
             #endif
             .navigationTitle("Debug Menu")
             .onAppear {
-                updateLogSnapshotIfNeeded()
-                refreshTunnelLog()
+                viewModel.onAppear()
             }
-            .task {
-                entitlementJWS = await Client.store.currentEntitlementJWS()
-            }
-            .onReceive(Timer.publish(every: 5, on: .main, in: .common).autoconnect()) { _ in
-                updateLogSnapshotIfNeeded()
-                refreshTunnelLog()
+            .onDisappear {
+                viewModel.onDisappear()
             }
             .toolbar {
                 ToolbarItem(placement: .navigationBarLeading) {
@@ -89,7 +50,7 @@ public struct DebugMenuView: View {
                     ToolbarItem(placement: .navigationBarTrailing) {
                         ShareLink(
                             item: DebugExportFile(
-                                content: buildExportContent(),
+                                content: viewModel.buildExportContent(),
                                 filename: "debug_\(Int(Date().timeIntervalSince1970)).txt"
                             ),
                             preview: SharePreview("Debug Export")
@@ -143,36 +104,36 @@ public struct DebugMenuView: View {
 
     private var appInfoSection: some View {
         DebugSection("App Info") {
-            DebugInfoRow(label: "Version", value: appVersion)
-            DebugInfoRow(label: "Environment", value: environment)
-            DebugInfoRow(label: "Base URL", value: baseUrl)
+            DebugInfoRow(label: "Version", value: viewModel.appVersion)
+            DebugInfoRow(label: "Environment", value: viewModel.environment)
+            DebugInfoRow(label: "Base URL", value: viewModel.baseUrl)
         }
     }
 
     private var vpnSection: some View {
         DebugSection("VPN") {
-            DebugInfoRow(label: "Status", value: Client.daemons.vpnStatus.rawValue)
-            DebugInfoRow(label: "Protocol", value: Client.preferences.vpnType)
-            DebugInfoRow(label: "Local IP", value: Client.daemons.publicIP ?? "---")
-            DebugInfoRow(label: "VPN IP", value: Client.daemons.vpnIP ?? "---")
+            DebugInfoRow(label: "Status", value: viewModel.vpnStatus)
+            DebugInfoRow(label: "Protocol", value: viewModel.vpnProtocolName)
+            DebugInfoRow(label: "Local IP", value: viewModel.publicIP)
+            DebugInfoRow(label: "VPN IP", value: viewModel.vpnIP)
         }
     }
 
     private var accountSection: some View {
         DebugSection("Account and Subscription") {
-            DebugInfoRow(label: "Username", value: username)
-            DebugInfoRow(label: "Plan", value: plan)
-            DebugInfoRow(label: "Product ID", value: productId)
-            DebugInfoRow(label: "Expiration Date", value: expirationFormatted)
-            DebugInfoRow(label: "Is Expired", value: isExpired)
-            DebugInfoRow(label: "Is Renewable", value: isRenewable)
-            DebugInfoRow(label: "Is Recurring", value: isRecurring)
+            DebugInfoRow(label: "Username", value: viewModel.username)
+            DebugInfoRow(label: "Plan", value: viewModel.plan)
+            DebugInfoRow(label: "Product ID", value: viewModel.productId)
+            DebugInfoRow(label: "Expiration Date", value: viewModel.expirationFormatted)
+            DebugInfoRow(label: "Is Expired", value: viewModel.isExpired)
+            DebugInfoRow(label: "Is Renewable", value: viewModel.isRenewable)
+            DebugInfoRow(label: "Is Recurring", value: viewModel.isRecurring)
         }
     }
 
     private var receiptSection: some View {
         DebugSection("Transaction (JWS)") {
-            if let transactionJWS {
+            if let transactionJWS = viewModel.transactionJWS {
                 let preview = String(transactionJWS.value.prefix(300)) + "..."
                 VStack(alignment: .leading, spacing: 2) {
                     Text("Transaction JWS (preview)")
@@ -210,11 +171,11 @@ public struct DebugMenuView: View {
     private var logsSection: some View {
         DebugSection("App Logs") {
             VStack(alignment: .leading, spacing: 2) {
-                Text("Recent logs (newest on top, last \(Self.previewLineCount) lines)")
+                Text("Recent logs (newest on top, last \(DebugMenuViewModel.previewLineCount) lines)")
                     .font(.caption)
                     .foregroundStyle(.secondary)
                 ScrollView(.horizontal) {
-                    Text(logSnapshot.isEmpty ? "No logs" : Self.reversedPreview(of: logSnapshot))
+                    Text(viewModel.logPreview)
                         .font(.system(.caption2, design: .monospaced))
                         .foregroundStyle(.primary)
                         .fixedSize(horizontal: true, vertical: false)
@@ -231,7 +192,7 @@ public struct DebugMenuView: View {
             #if os(iOS)
                 ShareLink(
                     item: DebugExportFile(
-                        content: logs,
+                        content: viewModel.logs,
                         filename: "logs_\(Int(Date().timeIntervalSince1970)).txt"
                     ),
                     preview: SharePreview("App Logs")
@@ -245,11 +206,11 @@ public struct DebugMenuView: View {
     private var tunnelLogSection: some View {
         DebugSection("Tunnel Log") {
             VStack(alignment: .leading, spacing: 2) {
-                Text("Live tunnel-extension log (newest on top, last \(Self.previewLineCount) lines)")
+                Text("Live tunnel-extension log (newest on top, last \(DebugMenuViewModel.previewLineCount) lines)")
                     .font(.caption)
                     .foregroundStyle(.secondary)
                 ScrollView(.horizontal) {
-                    Text(tunnelLogSnapshot.isEmpty ? "No tunnel log" : Self.reversedPreview(of: tunnelLogSnapshot))
+                    Text(viewModel.tunnelLogPreview)
                         .font(.system(.caption2, design: .monospaced))
                         .foregroundStyle(.primary)
                         .fixedSize(horizontal: true, vertical: false)
@@ -266,7 +227,7 @@ public struct DebugMenuView: View {
             #if os(iOS)
                 ShareLink(
                     item: DebugExportFile(
-                        content: tunnelLogSnapshot,
+                        content: viewModel.tunnelLogSnapshot,
                         filename: "tunnel_logs_\(Int(Date().timeIntervalSince1970)).txt"
                     ),
                     preview: SharePreview("Tunnel Log")
@@ -277,54 +238,17 @@ public struct DebugMenuView: View {
         }
     }
 
-    /// Both log sections show only the tail of the snapshot — the full content is still one tap
-    /// away via Export. Unbounded 1000-line monospaced `Text` inside a scrolling `List` is expensive
-    /// to lay out on every re-render and was a source of scroll jank.
-    private static let previewLineCount = 25
-
-    private static func reversedPreview(of content: String) -> String {
-        content
-            .components(separatedBy: "\n")
-            .reversed()
-            .prefix(previewLineCount)
-            .joined(separator: "\n")
-    }
-
     private var subscriptionSection: some View {
         DebugSection("Subscription") {
             Button("Manage Subscriptions") {
-                isPresentingManageSubscriptions = true
+                viewModel.presentManageSubscriptions()
             }
             Button {
-                isLoadingRefundTransaction = true
-                Task { @MainActor in
-                    defer {
-                        isLoadingRefundTransaction = false
-                    }
-
-                    var transactions: [StoreKit.Transaction] = []
-                    for await result in Transaction.currentEntitlements {
-                        if case .verified(let transaction) = result {
-                            transactions.append(transaction)
-                        }
-                    }
-
-                    switch transactions.count {
-                    case 0:
-                        reportResult = ReportResult(
-                            title: "No Transaction Found",
-                            message: "No active transaction found to request a refund for."
-                        )
-                    case 1:
-                        refundTransactionId = transactions[0].id
-                        isRefundSheetPresented = true
-                    default:
-                        availableTransactions = transactions
-                        isTransactionPickerPresented = true
-                    }
+                Task {
+                    await viewModel.requestRefund()
                 }
             } label: {
-                if isLoadingRefundTransaction {
+                if viewModel.isLoadingRefundTransaction {
                     HStack {
                         ProgressView()
                         Text("Looking up transaction...")
@@ -333,34 +257,18 @@ public struct DebugMenuView: View {
                     Text("Test Refund Request")
                 }
             }
-            .disabled(isLoadingRefundTransaction)
+            .disabled(viewModel.isLoadingRefundTransaction)
         }
     }
 
     private var supportSection: some View {
         DebugSection("Support") {
             Button {
-                isSendingReport = true
-                Task { @MainActor in
-                    defer {
-                        isSendingReport = false
-                    }
-
-                    do {
-                        let reportId = try await Client.submitDebugReport(includeDebug: true, redactIPs: false)
-                        reportResult = ReportResult(
-                            title: "Debug information submitted",
-                            message: "Report ID: \(reportId)\nPlease note this ID — support will need it to locate your submission."
-                        )
-                    } catch {
-                        reportResult = ReportResult(
-                            title: "Submission failed",
-                            message: "Debug information could not be submitted."
-                        )
-                    }
+                Task {
+                    await viewModel.sendReportToSupport()
                 }
             } label: {
-                if isSendingReport {
+                if viewModel.isSendingReport {
                     HStack {
                         ProgressView()
                         Text("Sending...")
@@ -369,27 +277,7 @@ public struct DebugMenuView: View {
                     Text("Send to Support (CSI)")
                 }
             }
-            .disabled(isSendingReport)
-        }
-    }
-
-    // MARK: - Logs
-
-    private func updateLogSnapshotIfNeeded() {
-        let current = logs
-        if current != logSnapshot {
-            logSnapshot = current
-        }
-    }
-
-    private func refreshTunnelLog() {
-        Client.providers.vpnProvider.requestTunnelLog { content, _ in
-            guard let content, !content.isEmpty else { return }
-            DispatchQueue.main.async {
-                if content != tunnelLogSnapshot {
-                    tunnelLogSnapshot = content
-                }
-            }
+            .disabled(viewModel.isSendingReport)
         }
     }
 

--- a/LocalPackages/PIADebugMenu/Sources/PIADebugMenu/DebugMenuViewModel.swift
+++ b/LocalPackages/PIADebugMenu/Sources/PIADebugMenu/DebugMenuViewModel.swift
@@ -24,6 +24,7 @@ final class DebugMenuViewModel: ObservableObject {
     @Published var isRefundSheetPresented = false
     @Published var availableTransactions: [StoreKit.Transaction] = []
     @Published var isTransactionPickerPresented = false
+    @Published private(set) var vpnConnection: VPNConnectionState = .unknown
 
     private static let refreshInterval: UInt64 = 5 * NSEC_PER_SEC
     private var refreshTask: Task<Void, Never>?
@@ -64,7 +65,8 @@ final class DebugMenuViewModel: ObservableObject {
             let reportId = try await Client.submitDebugReport(
                 includeDebug: true,
                 redactIPs: false,
-                includeTunnelLog: true
+                includeTunnelLog: true,
+                vpnConnection: VPNConnectionInformation(status: vpnStatus, connectedVia: connectedVia)
             )
             reportResult = ReportResult(
                 title: "Debug information submitted",
@@ -142,7 +144,15 @@ final class DebugMenuViewModel: ObservableObject {
 
     private func refresh() async {
         updateLogSnapshotIfNeeded()
+        await updateVPNConnectionIfNeeded()
         await refreshTunnelLog()
+    }
+
+    private func updateVPNConnectionIfNeeded() async {
+        let current = await VPNConnectionState.current()
+        if current != vpnConnection {
+            vpnConnection = current
+        }
     }
 
     private func updateLogSnapshotIfNeeded() {

--- a/LocalPackages/PIADebugMenu/Sources/PIADebugMenu/DebugMenuViewModel.swift
+++ b/LocalPackages/PIADebugMenu/Sources/PIADebugMenu/DebugMenuViewModel.swift
@@ -1,0 +1,170 @@
+@preconcurrency import PIALibrary
+import StoreKit
+import SwiftUI
+
+import struct PIABase.JWS
+
+struct ReportResult: Identifiable {
+    let id = UUID()
+    let title: String
+    let message: String
+}
+
+@available(iOS 16, tvOS 17, *)
+@MainActor
+final class DebugMenuViewModel: ObservableObject {
+    @Published var logSnapshot: String = ""
+    @Published var tunnelLogSnapshot: String = ""
+    @Published var entitlementJWS: JWS? = nil
+    @Published var isSendingReport = false
+    @Published var reportResult: ReportResult? = nil
+    @Published var isPresentingManageSubscriptions = false
+    @Published var isLoadingRefundTransaction = false
+    @Published var refundTransactionId: UInt64 = 0
+    @Published var isRefundSheetPresented = false
+    @Published var availableTransactions: [StoreKit.Transaction] = []
+    @Published var isTransactionPickerPresented = false
+
+    private static let refreshInterval: UInt64 = 5 * NSEC_PER_SEC
+    private var refreshTask: Task<Void, Never>?
+
+    // MARK: - Lifecycle
+
+    func onAppear() {
+        guard refreshTask == nil else { return }
+
+        refreshTask = Task { [weak self] in
+            await self?.loadEntitlementJWSIfNeeded()
+
+            while !Task.isCancelled {
+                await self?.refresh()
+                try? await Task.sleep(nanoseconds: Self.refreshInterval)
+            }
+        }
+    }
+
+    func onDisappear() {
+        refreshTask?.cancel()
+        refreshTask = nil
+    }
+
+    // MARK: - Actions
+
+    func presentManageSubscriptions() {
+        isPresentingManageSubscriptions = true
+    }
+
+    func sendReportToSupport() async {
+        isSendingReport = true
+        defer {
+            isSendingReport = false
+        }
+
+        do {
+            let reportId = try await Client.submitDebugReport(
+                includeDebug: true,
+                redactIPs: false,
+                includeTunnelLog: true
+            )
+            reportResult = ReportResult(
+                title: "Debug information submitted",
+                message: "Report ID: \(reportId)\nPlease note this ID — support will need it to locate your submission."
+            )
+        } catch {
+            reportResult = ReportResult(
+                title: "Submission failed",
+                message: "Debug information could not be submitted."
+            )
+        }
+    }
+
+    func requestRefund() async {
+        isLoadingRefundTransaction = true
+        defer {
+            isLoadingRefundTransaction = false
+        }
+
+        var transactions: [StoreKit.Transaction] = []
+        for await result in Transaction.currentEntitlements {
+            if case .verified(let transaction) = result {
+                transactions.append(transaction)
+            }
+        }
+
+        switch transactions.count {
+        case 0:
+            reportResult = ReportResult(
+                title: "No Transaction Found",
+                message: "No active transaction found to request a refund for."
+            )
+        case 1:
+            refundTransactionId = transactions[0].id
+            isRefundSheetPresented = true
+        default:
+            availableTransactions = transactions
+            isTransactionPickerPresented = true
+        }
+    }
+
+    func selectTransaction(_ transaction: StoreKit.Transaction) {
+        isTransactionPickerPresented = false
+        refundTransactionId = transaction.id
+        isRefundSheetPresented = true
+    }
+
+    #if os(iOS)
+        func handleRefundResult(
+            _ result: Result<StoreKit.Transaction.RefundRequestStatus, StoreKit.Transaction.RefundRequestError>
+        ) {
+            switch result {
+            case .success(let status):
+                if status == .success {
+                    reportResult = ReportResult(
+                        title: "Refund Requested",
+                        message: "Your refund request was submitted to the App Store."
+                    )
+                }
+            case .failure(let error):
+                reportResult = ReportResult(
+                    title: "Refund Request Failed",
+                    message: error.localizedDescription
+                )
+            }
+        }
+    #endif
+
+    // MARK: - Refresh
+
+    private func loadEntitlementJWSIfNeeded() async {
+        guard entitlementJWS == nil else { return }
+        entitlementJWS = await Client.store.currentEntitlementJWS()
+    }
+
+    private func refresh() async {
+        updateLogSnapshotIfNeeded()
+        await refreshTunnelLog()
+    }
+
+    private func updateLogSnapshotIfNeeded() {
+        let current = logs
+        if current != logSnapshot {
+            logSnapshot = current
+        }
+    }
+
+    private func refreshTunnelLog() async {
+        // On WireGuard the extension returns only the entries since the previous fetch, so this
+        // poll and the fetch performed while submitting a CSI report compete for the same cursor.
+        guard !isSendingReport else {
+            return
+        }
+
+        guard let content = await Client.providers.vpnProvider.tunnelLog(), !content.isEmpty else {
+            return
+        }
+
+        if content != tunnelLogSnapshot {
+            tunnelLogSnapshot = content
+        }
+    }
+}

--- a/LocalPackages/PIADebugMenu/Sources/PIADebugMenu/Extensions/DebugMenuView+Values.swift
+++ b/LocalPackages/PIADebugMenu/Sources/PIADebugMenu/Extensions/DebugMenuView+Values.swift
@@ -79,8 +79,11 @@ extension DebugMenuView {
         lines.append("=== Transaction (JWS) ===")
         lines.append(transactionJWS?.value ?? "Not available")
         lines.append("")
-        lines.append("=== Logs ===")
+        lines.append("=== App Logs ===")
         lines.append(logs)
+        lines.append("")
+        lines.append("=== Tunnel Log ===")
+        lines.append(tunnelLogSnapshot.isEmpty ? "No tunnel log" : tunnelLogSnapshot)
         return lines.joined(separator: "\n")
     }
 }

--- a/LocalPackages/PIADebugMenu/Sources/PIADebugMenu/Extensions/DebugMenuViewModel+Values.swift
+++ b/LocalPackages/PIADebugMenu/Sources/PIADebugMenu/Extensions/DebugMenuViewModel+Values.swift
@@ -58,7 +58,11 @@ extension DebugMenuViewModel {
     }
 
     var vpnStatus: String {
-        Client.daemons.vpnStatus.rawValue
+        vpnConnection.status
+    }
+
+    var connectedVia: String {
+        vpnConnection.connectedVia
     }
 
     var vpnProtocolName: String {

--- a/LocalPackages/PIADebugMenu/Sources/PIADebugMenu/Extensions/DebugMenuViewModel+Values.swift
+++ b/LocalPackages/PIADebugMenu/Sources/PIADebugMenu/Extensions/DebugMenuViewModel+Values.swift
@@ -3,8 +3,8 @@ import Foundation
 
 import struct PIABase.JWS
 
-@available(iOS 16, *)
-extension DebugMenuView {
+@available(iOS 16, tvOS 17, *)
+extension DebugMenuViewModel {
     var appVersion: String {
         Macros.versionFullString() ?? "—"
     }
@@ -57,8 +57,45 @@ extension DebugMenuView {
         entitlementJWS
     }
 
+    var vpnStatus: String {
+        Client.daemons.vpnStatus.rawValue
+    }
+
+    var vpnProtocolName: String {
+        Client.preferences.vpnType
+    }
+
+    var publicIP: String {
+        Client.daemons.publicIP ?? "---"
+    }
+
+    var vpnIP: String {
+        Client.daemons.vpnIP ?? "---"
+    }
+
     var logs: String {
         PIALogHandler.logStorage.getAllLogs(includeDebug: true)
+    }
+
+    /// Both log sections show only the tail of the snapshot — the full content is still one tap
+    /// away via Export. Unbounded 1000-line monospaced `Text` inside a scrolling `List` is expensive
+    /// to lay out on every re-render and was a source of scroll jank.
+    static let previewLineCount = 25
+
+    var logPreview: String {
+        logSnapshot.isEmpty ? "No logs" : Self.reversedPreview(of: logSnapshot)
+    }
+
+    var tunnelLogPreview: String {
+        tunnelLogSnapshot.isEmpty ? "No tunnel log" : Self.reversedPreview(of: tunnelLogSnapshot)
+    }
+
+    private static func reversedPreview(of content: String) -> String {
+        content
+            .components(separatedBy: "\n")
+            .reversed()
+            .prefix(previewLineCount)
+            .joined(separator: "\n")
     }
 
     func buildExportContent() -> String {

--- a/LocalPackages/PIADebugMenu/Sources/PIADebugMenu/VPNConnectionState.swift
+++ b/LocalPackages/PIADebugMenu/Sources/PIADebugMenu/VPNConnectionState.swift
@@ -1,0 +1,168 @@
+import CFNetwork
+import Foundation
+import NetworkExtension
+
+/// What the device's VPN is doing, and whether PIA owns it.
+///
+/// Neither half can be answered alone. NetworkExtension only ever exposes the configurations this
+/// app created, so it identifies our tunnel — and its transitions — but is blind to a VPN installed
+/// by another app. The tunnel interfaces see every VPN on the device but carry no ownership
+/// information, since PIA's own tunnel appears among them identically. Reading both and checking
+/// ours first is what separates "PIA" from "somebody else".
+struct VPNConnectionState: Equatable {
+    static let unknown = VPNConnectionState(profileState: .unavailable, isTunnelActive: false)
+
+    let profileState: VPNProfileState
+    let isTunnelActive: Bool
+
+    static func current() async -> VPNConnectionState {
+        VPNConnectionState(
+            profileState: await PIAProfiles.currentState(),
+            isTunnelActive: TunnelInterfaces.areActive
+        )
+    }
+
+    /// Device-level, so a tunnel owned by another app still reads as connected.
+    var status: String {
+        switch profileState {
+        case .connected, .connecting, .reasserting, .disconnecting:
+            profileState.displayName
+        case .disconnected, .unavailable:
+            isTunnelActive ? VPNProfileState.connected.displayName : VPNProfileState.disconnected.displayName
+        }
+    }
+
+    /// "Not PIA" means a tunnel is carrying traffic that isn't ours; which app owns it is not
+    /// knowable, since an app can only see the VPN configurations it created.
+    var connectedVia: String {
+        if profileState.isCarryingTraffic {
+            return "PIA"
+        }
+        return isTunnelActive ? "Not PIA" : "---"
+    }
+}
+
+/// State of the VPN profiles installed by *this* app.
+enum VPNProfileState: Equatable {
+    case connected
+    case connecting
+    case reasserting
+    case disconnecting
+    case disconnected
+    /// No profile of ours is installed, or its configuration could not be loaded.
+    case unavailable
+
+    var displayName: String {
+        switch self {
+        case .connected: "connected"
+        case .connecting: "connecting"
+        case .reasserting: "reasserting"
+        case .disconnecting: "disconnecting"
+        case .disconnected: "disconnected"
+        case .unavailable: "unavailable"
+        }
+    }
+
+    /// Whether a tunnel of ours is carrying traffic. `reasserting` counts: the tunnel is up and
+    /// re-establishing after a network change, not gone.
+    var isCarryingTraffic: Bool {
+        self == .connected || self == .reasserting
+    }
+}
+
+// MARK: - Sources
+
+/// Reads PIA's own profiles first-hand, so the menu reports what the system believes rather than
+/// what the library's daemon last recorded.
+private enum PIAProfiles {
+
+    static func currentState() async -> VPNProfileState {
+        var states: [VPNProfileState] = []
+
+        // Covers the OpenVPN and WireGuard Network Extensions.
+        if let managers = try? await NETunnelProviderManager.loadAllFromPreferences() {
+            states.append(contentsOf: managers.map { state(of: $0.connection.status) })
+        }
+
+        // Covers IKEv2, which uses the personal VPN configuration instead of a tunnel provider.
+        let personalVPN = NEVPNManager.shared()
+        if (try? await personalVPN.loadFromPreferences()) != nil {
+            states.append(state(of: personalVPN.connection.status))
+        }
+
+        // Several profiles can be installed at once, so the liveliest one describes the device.
+        return states.max { priority(of: $0) < priority(of: $1) } ?? .unavailable
+    }
+
+    private static func state(of status: NEVPNStatus) -> VPNProfileState {
+        switch status {
+        case .connected: .connected
+        case .connecting: .connecting
+        case .reasserting: .reasserting
+        case .disconnecting: .disconnecting
+        case .disconnected: .disconnected
+        case .invalid: .unavailable
+        @unknown default: .unavailable
+        }
+    }
+
+    private static func priority(of state: VPNProfileState) -> Int {
+        switch state {
+        case .connected: 5
+        case .reasserting: 4
+        case .connecting: 3
+        case .disconnecting: 2
+        case .disconnected: 1
+        case .unavailable: 0
+        }
+    }
+}
+
+/// Detects a tunnel from the network interfaces, which is the only way to see a VPN installed by
+/// another app. `NWPath`'s `.other` interface type was tried first and proved unreliable.
+private enum TunnelInterfaces {
+
+    // `utun` is deliberately absent from the interface scan: iOS keeps unnumbered `utun` devices up
+    // for Handoff, AirPlay and Personal Hotspot, so their mere existence proves nothing. Inside
+    // `__SCOPED__` they are meaningful, because that dictionary only lists interfaces that
+    // currently carry network configuration — which a tunnel does only while established.
+    private static let scopedPrefixes = ["tap", "tun", "ppp", "ipsec", "utun"]
+    private static let interfacePrefixes = ["tap", "tun", "ppp", "ipsec"]
+
+    static var areActive: Bool {
+        hasScopedTunnel || hasRunningTunnel
+    }
+
+    private static var hasScopedTunnel: Bool {
+        guard
+            let settings = CFNetworkCopySystemProxySettings()?.takeRetainedValue() as? [String: Any],
+            let scoped = settings["__SCOPED__"] as? [String: Any]
+        else {
+            return false
+        }
+
+        return scoped.keys.contains { name in
+            scopedPrefixes.contains { name.hasPrefix($0) }
+        }
+    }
+
+    // Catches the protocols some clients bring up without registering scoped proxy settings.
+    private static var hasRunningTunnel: Bool {
+        var addresses: UnsafeMutablePointer<ifaddrs>?
+        guard getifaddrs(&addresses) == 0, let first = addresses else {
+            return false
+        }
+        defer { freeifaddrs(addresses) }
+
+        return sequence(first: first, next: { $0.pointee.ifa_next })
+            .contains { interface in
+                let flags = Int32(interface.pointee.ifa_flags)
+                guard flags & IFF_UP == IFF_UP, flags & IFF_RUNNING == IFF_RUNNING else {
+                    return false
+                }
+
+                let name = String(cString: interface.pointee.ifa_name)
+                return interfacePrefixes.contains { name.hasPrefix($0) }
+            }
+    }
+}

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Client+DebugReport.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Client+DebugReport.swift
@@ -1,5 +1,17 @@
 import Foundation
 
+/// The connection state as observed by the caller. Both values are supplied rather than read from
+/// `Client.daemons`, because only the caller can see tunnels installed by other apps.
+public struct VPNConnectionInformation: Sendable {
+    public let status: String
+    public let connectedVia: String
+
+    public init(status: String, connectedVia: String) {
+        self.status = status
+        self.connectedVia = connectedVia
+    }
+}
+
 extension Client {
     /// Submits a CSI debug report directly, bypassing the VPN provider.
     /// Use this instead of `providers.vpnProvider.submitDebugReport` when a VPN
@@ -12,17 +24,20 @@ extension Client {
     /// Submits a CSI debug report with explicit control over log verbosity and IP redaction.
     /// Use this overload when the caller needs to override the defaults, e.g. internal debug tools
     /// that always include debug logs and don't need IP redaction.
-    /// `includeTunnelLog` adds a `tunnel.log` section fetched from the Network Extension; it
-    /// defaults to `false` so the user-facing report is unaffected.
+    /// `includeTunnelLog` adds a `tunnel.log` section fetched from the Network Extension, and
+    /// `vpnConnection` a `vpn_status` section. Both are omitted by default so the user-facing
+    /// report is unaffected.
     public static func submitDebugReport(
         includeDebug: Bool,
         redactIPs: Bool,
-        includeTunnelLog: Bool = false
+        includeTunnelLog: Bool = false,
+        vpnConnection: VPNConnectionInformation? = nil
     ) async throws -> String {
         try await PIAWebServices().submitDebugReport(
             includeDebug: includeDebug,
             redactIPs: redactIPs,
-            includeTunnelLog: includeTunnelLog
+            includeTunnelLog: includeTunnelLog,
+            vpnConnection: vpnConnection
         )
     }
 }

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Client+DebugReport.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Client+DebugReport.swift
@@ -12,7 +12,17 @@ extension Client {
     /// Submits a CSI debug report with explicit control over log verbosity and IP redaction.
     /// Use this overload when the caller needs to override the defaults, e.g. internal debug tools
     /// that always include debug logs and don't need IP redaction.
-    public static func submitDebugReport(includeDebug: Bool, redactIPs: Bool) async throws -> String {
-        try await PIAWebServices().submitDebugReport(includeDebug: includeDebug, redactIPs: redactIPs)
+    /// `includeTunnelLog` adds a `tunnel.log` section fetched from the Network Extension; it
+    /// defaults to `false` so the user-facing report is unaffected.
+    public static func submitDebugReport(
+        includeDebug: Bool,
+        redactIPs: Bool,
+        includeTunnelLog: Bool = false
+    ) async throws -> String {
+        try await PIAWebServices().submitDebugReport(
+            includeDebug: includeDebug,
+            redactIPs: redactIPs,
+            includeTunnelLog: includeTunnelLog
+        )
     }
 }

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Mock/MockVPNProvider.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Mock/MockVPNProvider.swift
@@ -150,6 +150,11 @@ public final class MockVPNProvider: VPNProvider, ConfigurationAccess, DatabaseAc
         callback?(nil, ClientError.unsupported)
     }
 
+    /// :nodoc:
+    public func requestTunnelLog(_ callback: LibraryCallback<String>?) {
+        callback?(nil, ClientError.unsupported)
+    }
+
     public func needsMigrationToGEN4() -> Bool {
         return false
     }

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Providers/CSI/PIACSITunnelLogInformationProvider.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Providers/CSI/PIACSITunnelLogInformationProvider.swift
@@ -1,0 +1,39 @@
+//
+//  PIACSITunnelLogInformationProvider.swift
+//  PIALibrary
+//
+//  Created by Diego Trevisan on 07.08.26.
+//  Copyright © 2026 Private Internet Access, Inc.
+//
+//  This file is part of the Private Internet Access iOS Client.
+//
+//  The Private Internet Access iOS Client is free software: you can redistribute it and/or
+//  modify it under the terms of the GNU General Public License as published by the Free
+//  Software Foundation, either version 3 of the License, or (at your option) any later version.
+//
+//  The Private Internet Access iOS Client is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+//  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+//  details.
+//
+//  You should have received a copy of the GNU General Public License along with the Private
+//  Internet Access iOS Client.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Foundation
+import PIACSI
+
+struct PIACSITunnelLogInformationProvider: CSIDataProvider {
+    var sectionName: String { "tunnel.log" }
+    var content: String? { getTunnelLogs() }
+    let log: String?
+    let redactIPs: Bool
+
+    private func getTunnelLogs() -> String {
+        guard let logs = log, !logs.isEmpty else {
+            return "No tunnel logs available"
+        }
+
+        return redactIPs ? logs.redactIPs() : logs
+    }
+}

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Providers/CSI/PIACSIVPNStatusInformationProvider.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Providers/CSI/PIACSIVPNStatusInformationProvider.swift
@@ -1,0 +1,65 @@
+//
+//  PIACSIVPNStatusInformationProvider.swift
+//  PIALibrary
+//
+//  Created by Diego Trevisan on 07.08.26.
+//  Copyright © 2026 Private Internet Access, Inc.
+//
+//  This file is part of the Private Internet Access iOS Client.
+//
+//  The Private Internet Access iOS Client is free software: you can redistribute it and/or
+//  modify it under the terms of the GNU General Public License as published by the Free
+//  Software Foundation, either version 3 of the License, or (at your option) any later version.
+//
+//  The Private Internet Access iOS Client is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+//  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+//  details.
+//
+//  You should have received a copy of the GNU General Public License along with the Private
+//  Internet Access iOS Client.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Foundation
+import PIACSI
+
+// Mirrors the VPN section of the debug menu. The values are transient or live outside the
+// `user_settings` whitelist, so nothing else in the report carries them.
+struct PIACSIVPNStatusInformationProvider: CSIDataProvider {
+    var sectionName: String { "vpn_status" }
+    var content: String? { vpnStatusInformation() }
+
+    let status: String
+    let connectedVia: String
+    let vpnType: String
+    let publicIP: String?
+    let vpnIP: String?
+    let redactIPs: Bool
+
+    private static let unavailable = "---"
+
+    private func vpnStatusInformation() -> String {
+        let information = [
+            "Status: \(status)",
+            "Connected Via: \(connectedVia)",
+            "Protocol: \(vpnType)",
+            "Public IP: \(publicIP ?? Self.unavailable)",
+            "VPN IP: \(vpnIP ?? Self.unavailable)"
+        ].joined(separator: "\n")
+
+        return redactIPs ? information.redactIPs() : information
+    }
+}
+
+extension PIACSIVPNStatusInformationProvider {
+    init(connection: VPNConnectionInformation, redactIPs: Bool) {
+        self.init(
+            status: connection.status,
+            connectedVia: connection.connectedVia,
+            vpnType: Client.preferences.vpnType,
+            publicIP: Client.daemons.publicIP,
+            vpnIP: Client.daemons.vpnIP,
+            redactIPs: redactIPs
+        )
+    }
+}

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/VPN/DefaultVPNProvider.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/VPN/DefaultVPNProvider.swift
@@ -391,6 +391,18 @@ public final class DefaultVPNProvider: VPNProvider, ConfigurationAccess, Databas
         }
     }
 
+    public func requestTunnelLog(_ callback: LibraryCallback<String>?) {
+        guard let activeProfile else {
+            callback?(nil, ClientError.vpnProfileUnavailable)
+            return
+        }
+        guard let configuration = vpnClientConfiguration() else {
+            callback?(nil, ClientError.vpnProfileUnavailable)
+            return
+        }
+        activeProfile.requestLog(withCustomConfiguration: configuration.customConfiguration, callback)
+    }
+
     private func isLegacyProfile() -> Bool {
         return DefaultVPNProvider.legacyProtocols.contains(accessedPreferences.vpnType)
     }

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/VPN/VPNProvider+TunnelLog.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/VPN/VPNProvider+TunnelLog.swift
@@ -1,0 +1,53 @@
+//
+//  VPNProvider+TunnelLog.swift
+//  PIALibrary
+//
+//  Created by Diego Trevisan on 07.08.26.
+//  Copyright © 2026 Private Internet Access, Inc.
+//
+//  This file is part of the Private Internet Access iOS Client.
+//
+//  The Private Internet Access iOS Client is free software: you can redistribute it and/or
+//  modify it under the terms of the GNU General Public License as published by the Free
+//  Software Foundation, either version 3 of the License, or (at your option) any later version.
+//
+//  The Private Internet Access iOS Client is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+//  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+//  details.
+//
+//  You should have received a copy of the GNU General Public License along with the Private
+//  Internet Access iOS Client.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Foundation
+
+extension VPNProvider {
+
+    // Resolves to nil on error or timeout. The tunnel never replies to the provider message when
+    // its process is wedged (e.g. after a network change), so an unguarded bridge would suspend
+    // forever; the caller treats a missing log as a non-fatal, reportable condition.
+    public func tunnelLog(timeout: TimeInterval = 5) async -> String? {
+        // Whichever of the tunnel reply and the timeout arrives first wins. `AsyncStream` is what
+        // makes that safe: yielding to a finished continuation is a no-op, whereas resuming a
+        // `CheckedContinuation` twice would trap when a slow tunnel replies after the timeout.
+        let results = AsyncStream<String?> { continuation in
+            requestTunnelLog { log, _ in
+                continuation.yield(log)
+                continuation.finish()
+            }
+
+            Task {
+                try await Task.sleep(nanoseconds: UInt64(timeout * 1_000_000_000))
+                continuation.yield(nil)
+                continuation.finish()
+            }
+        }
+
+        for await log in results {
+            return log
+        }
+
+        return nil
+    }
+}

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/VPN/VPNProvider.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/VPN/VPNProvider.swift
@@ -131,6 +131,15 @@ public protocol VPNProvider: AnyObject {
     func dataUsage(_ callback: LibraryCallback<Usage>?)
 
     /**
+     Requests the active tunnel's own debug log (distinct from the app-process log in
+     `PIALogHandler`). Best-effort: returns `nil` when there is no active profile, or when the
+     tunnel can't produce a log (e.g. disconnected, or an unresponsive Network Extension process).
+
+     - Parameter callback: Returns the log content on success.
+     */
+    func requestTunnelLog(_ callback: LibraryCallback<String>?)
+
+    /**
      Check if the VPN profile needs to be migrated to GEN4.
      - Precondition: isVPNConnected == true
      - Returns: `Bool`

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/WebServices/PIAWebServices+Ephemeral.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/WebServices/PIAWebServices+Ephemeral.swift
@@ -40,8 +40,8 @@ extension PIAWebServices {
         try await submitDebugReport(includeDebug: Client.preferences.debugLogging, redactIPs: true)
     }
 
-    func submitDebugReport(includeDebug: Bool, redactIPs: Bool) async throws -> String {
-        let providers: [CSIDataProvider] = [
+    func submitDebugReport(includeDebug: Bool, redactIPs: Bool, includeTunnelLog: Bool = false) async throws -> String {
+        var providers: [CSIDataProvider] = [
             PIACSIProtocolInformationProvider(),
             PIACSIDeviceInformationProvider(),
             PIACSILogInformationProvider(includeDebug: includeDebug, redactIPs: redactIPs),
@@ -50,6 +50,11 @@ extension PIAWebServices {
             PIACSIUserInformationProvider(redactIPs: redactIPs),
             PIACSILastKnownExceptionProvider()
         ]
+
+        if includeTunnelLog {
+            let tunnelLog = await Client.providers.vpnProvider.tunnelLog()
+            providers.append(PIACSITunnelLogInformationProvider(log: tunnelLog, redactIPs: redactIPs))
+        }
 
         let sections = providers.compactMap { provider -> CSIReportSection? in
             guard let content = provider.content else { return nil }

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/WebServices/PIAWebServices+Ephemeral.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/WebServices/PIAWebServices+Ephemeral.swift
@@ -40,7 +40,12 @@ extension PIAWebServices {
         try await submitDebugReport(includeDebug: Client.preferences.debugLogging, redactIPs: true)
     }
 
-    func submitDebugReport(includeDebug: Bool, redactIPs: Bool, includeTunnelLog: Bool = false) async throws -> String {
+    func submitDebugReport(
+        includeDebug: Bool,
+        redactIPs: Bool,
+        includeTunnelLog: Bool = false,
+        vpnConnection: VPNConnectionInformation? = nil
+    ) async throws -> String {
         var providers: [CSIDataProvider] = [
             PIACSIProtocolInformationProvider(),
             PIACSIDeviceInformationProvider(),
@@ -54,6 +59,12 @@ extension PIAWebServices {
         if includeTunnelLog {
             let tunnelLog = await Client.providers.vpnProvider.tunnelLog()
             providers.append(PIACSITunnelLogInformationProvider(log: tunnelLog, redactIPs: redactIPs))
+        }
+
+        if let vpnConnection {
+            providers.append(
+                PIACSIVPNStatusInformationProvider(connection: vpnConnection, redactIPs: redactIPs)
+            )
         }
 
         let sections = providers.compactMap { provider -> CSIReportSection? in

--- a/LocalPackages/PIALibrary/Tests/PIALibraryTests/PIACSITunnelLogInformationProviderTests.swift
+++ b/LocalPackages/PIALibrary/Tests/PIALibraryTests/PIACSITunnelLogInformationProviderTests.swift
@@ -1,0 +1,71 @@
+//
+//  PIACSITunnelLogInformationProviderTests.swift
+//  PIALibrary
+//
+//  Created by Diego Trevisan on 07.08.26.
+//  Copyright © 2026 Private Internet Access, Inc.
+//
+//  This file is part of the Private Internet Access iOS Client.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+
+import Foundation
+import Testing
+
+@testable import PIALibrary
+
+@Suite("PIACSITunnelLogInformationProvider Tests")
+struct PIACSITunnelLogInformationProviderTests {
+
+    private static let placeholder = "No tunnel logs available"
+
+    @Test("Section name matches the CSI report contract")
+    func sectionName() {
+        let provider = PIACSITunnelLogInformationProvider(log: "anything", redactIPs: false)
+        #expect(provider.sectionName == "tunnel.log")
+    }
+
+    @Test("Missing log yields a placeholder", arguments: [nil, ""] as [String?])
+    func missingLog(log: String?) {
+        let provider = PIACSITunnelLogInformationProvider(log: log, redactIPs: false)
+        #expect(provider.content == Self.placeholder, "an empty section is ambiguous for support")
+    }
+
+    @Test("A populated log is passed through untouched")
+    func populatedLogIsUntouched() {
+        let log = "first\nsecond\nthird"
+        let provider = PIACSITunnelLogInformationProvider(log: log, redactIPs: false)
+        #expect(provider.content == log)
+    }
+
+    @Test("IPv4 addresses are redacted when requested")
+    func redactsIPs() {
+        let log = "handshake with 10.0.12.34:1337 completed"
+        let provider = PIACSITunnelLogInformationProvider(log: log, redactIPs: true)
+        #expect(provider.content == "handshake with REDACTED:1337 completed")
+    }
+
+    @Test("IPv4 addresses are preserved when redaction is off")
+    func preservesIPs() {
+        let log = "handshake with 10.0.12.34:1337 completed"
+        let provider = PIACSITunnelLogInformationProvider(log: log, redactIPs: false)
+        #expect(provider.content == log)
+    }
+}

--- a/LocalPackages/PIALibrary/Tests/PIALibraryTests/PIACSIVPNStatusInformationProviderTests.swift
+++ b/LocalPackages/PIALibrary/Tests/PIALibraryTests/PIACSIVPNStatusInformationProviderTests.swift
@@ -1,0 +1,101 @@
+//
+//  PIACSIVPNStatusInformationProviderTests.swift
+//  PIALibrary
+//
+//  Created by Diego Trevisan on 07.08.26.
+//  Copyright © 2026 Private Internet Access, Inc.
+//
+//  This file is part of the Private Internet Access iOS Client.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+
+import Foundation
+import Testing
+
+@testable import PIALibrary
+
+@Suite("PIACSIVPNStatusInformationProvider Tests")
+struct PIACSIVPNStatusInformationProviderTests {
+
+    private func makeProvider(
+        status: String = "connected",
+        connectedVia: String = "PIA",
+        vpnType: String = "WireGuard",
+        publicIP: String? = "10.0.12.34",
+        vpnIP: String? = "10.9.8.7",
+        redactIPs: Bool = false
+    ) -> PIACSIVPNStatusInformationProvider {
+        PIACSIVPNStatusInformationProvider(
+            status: status,
+            connectedVia: connectedVia,
+            vpnType: vpnType,
+            publicIP: publicIP,
+            vpnIP: vpnIP,
+            redactIPs: redactIPs
+        )
+    }
+
+    @Test("Section name matches the CSI report contract")
+    func sectionName() {
+        #expect(makeProvider().sectionName == "vpn_status")
+    }
+
+    @Test("Every row of the debug menu VPN section is reported")
+    func reportsAllRows() {
+        let content = makeProvider().content
+        #expect(
+            content
+                == "Status: connected\nConnected Via: PIA\nProtocol: WireGuard\nPublic IP: 10.0.12.34\nVPN IP: 10.9.8.7"
+        )
+    }
+
+    @Test("Unknown IPs are reported as placeholders")
+    func missingIPs() {
+        let content = makeProvider(publicIP: nil, vpnIP: nil).content
+        #expect(content == "Status: connected\nConnected Via: PIA\nProtocol: WireGuard\nPublic IP: ---\nVPN IP: ---")
+    }
+
+    @Test("IP addresses are redacted when requested")
+    func redactsIPs() {
+        let content = makeProvider(redactIPs: true).content
+        #expect(
+            content
+                == "Status: connected\nConnected Via: PIA\nProtocol: WireGuard\nPublic IP: REDACTED\nVPN IP: REDACTED"
+        )
+    }
+
+    @Test("A tunnel owned by another app is reported while PIA reads as disconnected")
+    func foreignTunnel() {
+        let content = makeProvider(status: "disconnected", connectedVia: "Not PIA", vpnIP: nil).content
+        #expect(
+            content
+                == "Status: disconnected\nConnected Via: Not PIA\nProtocol: WireGuard\nPublic IP: 10.0.12.34\nVPN IP: ---"
+        )
+    }
+
+    @Test("No tunnel at all falls back to the placeholder")
+    func noTunnel() {
+        let content = makeProvider(status: "disconnected", connectedVia: "---", vpnIP: nil).content
+        #expect(
+            content
+                == "Status: disconnected\nConnected Via: ---\nProtocol: WireGuard\nPublic IP: 10.0.12.34\nVPN IP: ---"
+        )
+    }
+}

--- a/PIA VPN/Core/Extensions/AppDelegate+DebugMenu.swift
+++ b/PIA VPN/Core/Extensions/AppDelegate+DebugMenu.swift
@@ -37,12 +37,16 @@ extension AppDelegate {
             }))
 
         let appearance = UINavigationBarAppearance()
-        appearance.configureWithDefaultBackground()
+        appearance.configureWithOpaqueBackground()
+        appearance.backgroundColor = .systemBackground
 
         navVC.setViewControllers([hostingVC], animated: false)
         navVC.navigationBar.standardAppearance = appearance
         navVC.navigationBar.scrollEdgeAppearance = appearance
         navVC.navigationBar.compactAppearance = appearance
+        navVC.navigationBar.setBackgroundImage(nil, for: .default)
+        navVC.navigationBar.shadowImage = nil
+        navVC.navigationBar.isTranslucent = false
         navVC.modalPresentationStyle = .overCurrentContext
         top.present(navVC, animated: true)
     }


### PR DESCRIPTION
## Summary
- Adds a "Tunnel Log" section to the Debug Menu, showing the Network Extension's own log (separate from the existing "App Logs" section), fetched live via `VPNProvider.requestTunnelLog(_:)`.
- Preview is capped at 25 lines (non-wrapping, horizontally scrollable) and auto-refreshes every 5s; full content is available via the section's Export button.