### PR TITLE
KM-17721: Intro offers

### DIFF
--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Account/AccountProvider.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Account/AccountProvider.swift
@@ -27,10 +27,8 @@ import StoreKit
 /// Business interface related to user account.
 public protocol AccountProvider: AnyObject {
 
-    #if os(iOS) || os(tvOS)
-        /// The in-app products required to purchase a `Plan`.
-        var planProducts: [Plan: any InAppProduct]? { get }
-    #endif
+    /// The in-app products required to purchase a `Plan`.
+    var planProducts: [Plan: any InAppProduct]? { get }
 
     /// Returns `true` if accountInfo is nil and loggedIn true.
     var shouldCleanAccount: Bool { get }

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Account/DefaultAccountProvider.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Account/DefaultAccountProvider.swift
@@ -46,21 +46,19 @@ public final class DefaultAccountProvider: AccountProvider, ConfigurationAccess,
 
     // MARK: AccountProvider
 
-    #if os(iOS) || os(tvOS)
-        public var planProducts: [Plan: any InAppProduct]? {
-            guard let products = accessedStore.availableProducts else {
-                return nil
-            }
-            var map = [Plan: any InAppProduct]()
-            for product in products {
-                guard let plan = accessedConfiguration.plan(forProductIdentifier: product.identifier) else {
-                    continue
-                }
-                map[plan] = product
-            }
-            return map
+    public var planProducts: [Plan: any InAppProduct]? {
+        guard let products = accessedStore.availableProducts else {
+            return nil
         }
-    #endif
+        var map = [Plan: any InAppProduct]()
+        for product in products {
+            guard let plan = accessedConfiguration.plan(forProductIdentifier: product.identifier) else {
+                continue
+            }
+            map[plan] = product
+        }
+        return map
+    }
 
     public var isLoggedIn: Bool {
         guard let username = accessedDatabase.secure.username() else {
@@ -403,15 +401,14 @@ public final class DefaultAccountProvider: AccountProvider, ConfigurationAccess,
         public func listPlanProducts() async -> Result<[Plan: any InAppProduct], StoreKitError> {
             log.debug("Fetching available products...")
 
-            if let products = planProducts {
+            if let products = planProducts, !products.isEmpty {
                 log.debug("Available products in cache: \(products)")
                 Macros.postNotification(.__InAppDidFetchProducts, [.products: products])
                 return .success(products)
             }
 
             log.debug("No available products in cache, requesting from store...")
-
-            let identifiers = accessedConfiguration.allProductIdentifiers()
+            let identifiers = await accessedConfiguration.allProductIdentifiers(timeout: 10_000)  // 10s
             switch await accessedStore.fetchProducts(identifiers: identifiers) {
             case .failure(let error):
                 log.error("Unable to fetch products from store: \(error)")
@@ -420,6 +417,7 @@ public final class DefaultAccountProvider: AccountProvider, ConfigurationAccess,
                 log.debug("Available products from store: \(products)")
                 if products.isEmpty {
                     log.warning("No products returned from store")
+                    return .failure(.unknown)
                 }
                 let planProducts = self.planProducts
                 if planProducts == nil {

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Client+Configuration.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Client+Configuration.swift
@@ -22,7 +22,7 @@
 
 import Foundation
 
-fileprivate let log = PIALogger.logger(for: Client.Configuration.self)
+private let log = PIALogger.logger(for: Client.Configuration.self)
 
 extension Client {
     /// Encapsulates internal and public parameters of the client. When not specified otherwise, time intervals are in milliseconds.
@@ -135,16 +135,7 @@ extension Client {
         /// The default delay of VPN reconnection attempts.
         public var vpnReconnectionDelay: Int
 
-        #if os(iOS) || os(tvOS)
-
-            // MARK: InApp
-
-            private var inAppPlans: [String: Plan]
-
-            /// Enables background server pinging.
-            public var eligibleForTrial: Bool
-
-        #endif
+        private var inAppPlans: [String: Plan]? = nil
 
         /// The value of the max of servers appearing in the quick connect tile.
         public var maxQuickConnectServers: Int
@@ -216,11 +207,6 @@ extension Client {
             maceHostname = "209.222.18.222"
             macePort = 1111
             maceDelay = 5000
-
-            #if os(iOS) || os(tvOS)
-                inAppPlans = [:]
-                eligibleForTrial = true
-            #endif
 
             maxQuickConnectServers = 6
             tempAccountPassword = ""
@@ -296,28 +282,51 @@ extension Client {
             }
         }
 
-        #if os(iOS) || os(tvOS)
+        // MARK: InApp
 
-            // MARK: InApp
+        /// Defines multiple ``Plan``s for corresponding product identifiers.
+        public func setPlans(_ plans: [String: Plan]) {
+            inAppPlans = plans
+        }
 
-            /**
-             Defines the `Plan` that a product identifier is able to purchase.
+        public func setDefaultPlanProducts() {
+            log.debug("Using fallback product identifiers")
+            setPlans([
+                AppConstants.InApp.yearlyProductIdentifier: .yearly,
+                AppConstants.InApp.monthlyProductIdentifier: .monthly
+            ])
+        }
 
-             - Parameter plan: The `Plan` to associate with a product.
-             - Parameter productIdentifier: The identifier of the in-app product.
-             */
-            public func setPlan(_ plan: Plan, forProductIdentifier productIdentifier: String) {
-                inAppPlans[productIdentifier] = plan
+        func plan(forProductIdentifier productIdentifier: String) -> Plan? {
+            guard let inAppPlans else {
+                log.warning("inAppPlans wasn't loaded yet, returning nil Plan")
+                return nil
             }
+            return inAppPlans[productIdentifier]
+        }
 
-            func plan(forProductIdentifier productIdentifier: String) -> Plan? {
-                return inAppPlans[productIdentifier]
+        /// Product identifiers to show, loaded from the backend.
+        ///
+        /// Waits `timeout` milliseconds. If it timeuts, it sets and returns the default
+        /// plan products hardcoded in the app, instead of the backend loades ones.
+        ///
+        /// - Parameter timeout: Time to wait in milliseconds.
+        func allProductIdentifiers(timeout: UInt64) async -> Set<String> {
+            var millisecondsWaited: UInt64 = 0
+            waitForInAppPlans: while inAppPlans == nil {
+                if millisecondsWaited >= timeout {
+                    setDefaultPlanProducts()
+                    break waitForInAppPlans
+                }
+                let wait: UInt64 = 100
+                millisecondsWaited += wait
+                try? await Task.sleep(nanoseconds: wait * 1_000_000)
             }
-
-            func allProductIdentifiers() -> Set<String> {
-                return Set(inAppPlans.keys)
+            guard let inAppPlans else {
+                log.warning("inAppPlans wasn't loaded yet, returning empty set")
+                return []
             }
-
-        #endif
+            return Set(inAppPlans.keys)
+        }
     }
 }

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Client+Configuration.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Client+Configuration.swift
@@ -285,8 +285,14 @@ extension Client {
         // MARK: InApp
 
         /// Defines multiple ``Plan``s for corresponding product identifiers.
+        ///
+        /// If `plans` is empty, the default product identifiers are used instead.
         public func setPlans(_ plans: [String: Plan]) {
-            inAppPlans = plans
+            if plans.isEmpty {
+                setDefaultPlanProducts()
+            } else {
+                inAppPlans = plans
+            }
         }
 
         public func setDefaultPlanProducts() {

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/InApp/AppStoreProduct.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/InApp/AppStoreProduct.swift
@@ -23,7 +23,7 @@
 import Foundation
 import StoreKit
 
-struct AppStoreProduct: InAppProduct<Product> {
+struct AppStoreProduct: InAppProduct<Product>, Hashable {
     var identifier: String {
         return native.id
     }
@@ -38,10 +38,7 @@ struct AppStoreProduct: InAppProduct<Product> {
 
     let native: Native
 
-    let hasIntroOffer: Bool
-
-    init(native: Native, hasIntroOffer: Bool) {
+    init(native: Native) {
         self.native = native
-        self.hasIntroOffer = hasIntroOffer
     }
 }

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/InApp/AppStoreProvider.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/InApp/AppStoreProvider.swift
@@ -138,16 +138,36 @@ final class AppStoreProvider: NSObject, InAppProvider {
         availableProducts = products
     }
 
-    func isEligibleForIntroOffer(for product: any InAppProduct) async -> Bool {
-        guard let native = product.native as? Product else {
+    func eligibleDaysForIntroOffer(for product: any InAppProduct) async -> Int {
+        guard let product = product.native as? Product else {
             log.error("Product must be a StoreKit.Product, but got \(type(of: product.native))")
-            return false
+            return 0
         }
-        guard let subscription = native.subscription else {
-            log.debug("Product \(native.id) is not a subscription, so it has no intro offer")
-            return false
+        guard let subscription = product.subscription else {
+            log.debug("Product \(product.id) is not a subscription, so it has no intro offer")
+            return 0
         }
-        return await Product.SubscriptionInfo.isEligibleForIntroOffer(for: subscription.subscriptionGroupID)
+
+        var days = 0
+        if let offer = subscription.introductoryOffer {
+            days = offer.period.value
+            switch offer.period.unit {
+            case .day:
+                days *= 1
+            case .week:
+                days *= 7
+            case .month:
+                days *= 30
+            case .year:
+                days *= 365
+            @unknown default:
+                log.error("Unknown offer period unit: \(offer.period.unit)")
+                break
+            }
+        }
+
+        let isEligible = await subscription.isEligibleForIntroOffer
+        return isEligible ? days : 0
     }
 
     func purchase(product: any InAppProduct) async -> Result<any InAppTransaction, ClientError> {

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/InApp/AppStoreProvider.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/InApp/AppStoreProvider.swift
@@ -118,22 +118,7 @@ final class AppStoreProvider: NSObject, InAppProvider {
             return .failure(.unknown)
         }
 
-        var introOffers: [String: Bool] = [:]
-        var result: [AppStoreProduct] = []
-        for product in products {
-            var hasIntroOffer: Bool = false
-            if let subscription = product.subscription {
-                if let has = introOffers[subscription.subscriptionGroupID] {
-                    hasIntroOffer = has
-                } else {
-                    hasIntroOffer = await subscription.isEligibleForIntroOffer
-                    introOffers[subscription.subscriptionGroupID] = hasIntroOffer
-                }
-            }
-            let appStoreProduct = AppStoreProduct(native: product, hasIntroOffer: hasIntroOffer)
-            result.append(appStoreProduct)
-        }
-
+        let result = products.map { AppStoreProduct(native: $0) }
         cacheAvailableProducts(result)
         return .success(result)
     }

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/InApp/InAppProduct.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/InApp/InAppProduct.swift
@@ -37,9 +37,6 @@ public protocol InAppProduct<Native>: CustomStringConvertible, Equatable, Sendab
 
     /// The underlying native product implementation.
     var native: Native { get }
-
-    /// `true` if the user is eligible for an intro offer.
-    var hasIntroOffer: Bool { get }
 }
 
 extension InAppProduct {

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/InApp/InAppProvider.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/InApp/InAppProvider.swift
@@ -35,13 +35,7 @@ public protocol InAppProvider: AnyObject {
 
     func purchase(product: any InAppProduct) async -> Result<any InAppTransaction, ClientError>
 
-    /// Asks the App Store whether the account is eligible for an introductory offer on the
-    /// subscription group `product` belongs to, **at the moment of the call**.
-    ///
-    /// Prefer this over `InAppProduct.hasIntroOffer`, which is resolved once when products are
-    /// fetched and then frozen for the lifetime of the process. Eligibility can change while the
-    /// app is running (the user subscribes on another device, or a trial is consumed elsewhere),
-    /// so any screen that advertises a free trial should re-ask before it renders.
+    /// The number of free-trial days the account is eligible for. 0 if not.
     func eligibleDaysForIntroOffer(for product: any InAppProduct) async -> Int
 
     func finishTransaction(_ transaction: any InAppTransaction, success: Bool)

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/InApp/InAppProvider.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/InApp/InAppProvider.swift
@@ -42,7 +42,7 @@ public protocol InAppProvider: AnyObject {
     /// fetched and then frozen for the lifetime of the process. Eligibility can change while the
     /// app is running (the user subscribes on another device, or a trial is consumed elsewhere),
     /// so any screen that advertises a free trial should re-ask before it renders.
-    func isEligibleForIntroOffer(for product: any InAppProduct) async -> Bool
+    func eligibleDaysForIntroOffer(for product: any InAppProduct) async -> Int
 
     func finishTransaction(_ transaction: any InAppTransaction, success: Bool)
 

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/InApp/PurchasePlan.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/InApp/PurchasePlan.swift
@@ -35,8 +35,6 @@ public final class PurchasePlan: NSObject {
         let priceLocale = Locale.current
 
         let native: Native = .none
-
-        let hasIntroOffer: Bool = false
     }
 
     private static let formatter: NumberFormatter = {

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Mock/MockAccountProvider.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Mock/MockAccountProvider.swift
@@ -129,7 +129,7 @@ public final class MockAccountProvider: AccountProvider, WebServicesConsumer {
                         price: "3.99",
                         legacy: false)
                 ],
-                eligibleForTrial: true)
+            )
         }
         webServices.appstoreInformationEligibleButDisabledFromBackend = {
             return AppStoreInformation(
@@ -140,7 +140,7 @@ public final class MockAccountProvider: AccountProvider, WebServicesConsumer {
                         price: "3.99",
                         legacy: false)
                 ],
-                eligibleForTrial: false)
+            )
         }
         webServices.appstoreInformationNotEligible = {
             return AppStoreInformation(
@@ -151,18 +151,16 @@ public final class MockAccountProvider: AccountProvider, WebServicesConsumer {
                         price: "3.99",
                         legacy: false)
                 ],
-                eligibleForTrial: false)
+            )
         }
     }
 
     // MARK: AccountProvider
 
-    #if os(iOS) || os(tvOS)
-        /// :nodoc:
-        public var planProducts: [Plan: any InAppProduct]? {
-            return delegate.planProducts
-        }
-    #endif
+    /// :nodoc:
+    public var planProducts: [Plan: any InAppProduct]? {
+        return delegate.planProducts
+    }
 
     /// :nodoc:
     public var shouldCleanAccount: Bool {

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Mock/MockInAppProvider.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Mock/MockInAppProvider.swift
@@ -83,8 +83,8 @@ import StoreKit
             return .success(availableProducts ?? [])
         }
 
-        func isEligibleForIntroOffer(for product: any InAppProduct) async -> Bool {
-            return isEligibleForIntroOffer
+        func eligibleDaysForIntroOffer(for product: any InAppProduct) async -> Int {
+            return isEligibleForIntroOffer ? 7 : 0
         }
 
         func purchase(product: any InAppProduct) async -> Result<any InAppTransaction, ClientError> {

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Mock/MockInAppProvider.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Mock/MockInAppProvider.swift
@@ -36,8 +36,6 @@ import StoreKit
 
         let native: Native = .none
 
-        var hasIntroOffer: Bool { false }
-
         init(_ identifier: String, _ price: Decimal) {
             self.identifier = identifier
             self.price = price
@@ -78,7 +76,7 @@ import StoreKit
 
         func fetchProducts(identifiers: Set<String>) async -> Result<[any InAppProduct], StoreKitError> {
             availableProducts = []
-            for (i, identifier) in accessedConfiguration.allProductIdentifiers().enumerated() {
+            for (i, identifier) in await accessedConfiguration.allProductIdentifiers(timeout: 0).enumerated() {
                 let price = (Decimal(i + 1) * 50.0)
                 availableProducts?.append(MockProduct(identifier, price))
             }

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Mock/MockWebServices.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Mock/MockWebServices.swift
@@ -116,8 +116,6 @@ final class MockWebServices: WebServices {
             }
         }
 
-        Client.configuration.eligibleForTrial = result()!.eligibleForTrial
-
         return result()
     }
 

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/WebServices/AppStoreInformation.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/WebServices/AppStoreInformation.swift
@@ -24,15 +24,12 @@ import Foundation
 
 public struct AppStoreInformation: Codable, Sendable {
     public let products: [PIAProduct]
-    public let eligibleForTrial: Bool
 
     enum CodingKeys: String, CodingKey {
         case products = "available_products"
-        case eligibleForTrial = "eligible_for_trial"
     }
 
-    public init(products: [PIAProduct], eligibleForTrial: Bool) {
+    public init(products: [PIAProduct]) {
         self.products = products
-        self.eligibleForTrial = eligibleForTrial
     }
 }

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/WebServices/PIAWebServices.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/WebServices/PIAWebServices.swift
@@ -388,11 +388,7 @@ final class PIAWebServices: WebServices, ConfigurationAccess {
                 )
             }
 
-            let info = AppStoreInformation(
-                products: products,
-                eligibleForTrial: response.eligibleForTrial
-            )
-            Client.configuration.eligibleForTrial = info.eligibleForTrial
+            let info = AppStoreInformation(products: products)
 
             return info
         } catch {

--- a/LocalPackages/PIALibrary/Tests/PIALibraryTests/AccountSignupTests.swift
+++ b/LocalPackages/PIALibrary/Tests/PIALibraryTests/AccountSignupTests.swift
@@ -24,7 +24,7 @@ import XCTest
 
 @testable import PIALibrary
 
-class AccountSignupTests: XCTestCase {
+final class AccountSignupTests: XCTestCase {
     private var observers = [NSObjectProtocol]()
 
     private let live = Client.providers
@@ -33,8 +33,10 @@ class AccountSignupTests: XCTestCase {
         super.setUp()
 
         Client.store = MockInAppProvider()
-        Client.configuration.setPlan(.monthly, forProductIdentifier: "com.example.first")
-        Client.configuration.setPlan(.yearly, forProductIdentifier: "com.example.second")
+        Client.configuration.setPlans([
+            "com.example.first": .monthly,
+            "com.example.second": .yearly
+        ])
         Client.database = Client.Database(group: "group.com.privateinternetaccess").truncate()
         Client.bootstrap()
         Client.refreshProducts()

--- a/LocalPackages/PIALibrary/Tests/PIALibraryTests/Accounts/SubscriptionsUseCaseTests.swift
+++ b/LocalPackages/PIALibrary/Tests/PIALibraryTests/Accounts/SubscriptionsUseCaseTests.swift
@@ -2,7 +2,7 @@ import XCTest
 
 @testable import PIALibrary
 
-class SubscriptionsUseCaseTests: XCTestCase {
+final class SubscriptionsUseCaseTests: XCTestCase {
     class Fixture {
         let networkClientMock = NetworkRequestClientMock()
         let refreshAuthTokensCheckerMock = RefreshAuthTokensCheckerMock()
@@ -10,8 +10,7 @@ class SubscriptionsUseCaseTests: XCTestCase {
             products: [
                 PIAProduct(identifier: "id1", plan: .monthly, price: "10", legacy: true),
                 PIAProduct(identifier: "id2", plan: .yearly, price: "100", legacy: true)
-            ],
-            eligibleForTrial: true
+            ]
         )
 
         let receiptBase64 = Data().base64EncodedString()
@@ -99,8 +98,6 @@ class SubscriptionsUseCaseTests: XCTestCase {
 
         // AND the AppStoreInformation is returned with 2 products
         XCTAssertEqual(capturedAppStoreInformation!.products.count, 2)
-        // AND eligible for free trial
-        XCTAssertTrue(capturedAppStoreInformation!.eligibleForTrial)
 
     }
 
@@ -144,8 +141,6 @@ class SubscriptionsUseCaseTests: XCTestCase {
 
         // AND the AppStoreInformation is returned with 2 products
         XCTAssertEqual(capturedAppStoreInformation!.products.count, 2)
-        // AND eligible for free trial
-        XCTAssertTrue(capturedAppStoreInformation!.eligibleForTrial)
 
     }
 
@@ -311,9 +306,5 @@ class SubscriptionsUseCaseTests: XCTestCase {
 
         // AND the AppStoreInformation is returned with 2 products
         XCTAssertEqual(capturedAppStoreInformation!.products.count, 2)
-        // AND eligible for free trial
-        XCTAssertTrue(capturedAppStoreInformation!.eligibleForTrial)
-
     }
-
 }

--- a/LocalPackages/PIALibrary/Tests/PIALibraryTests/ProductTests.swift
+++ b/LocalPackages/PIALibrary/Tests/PIALibraryTests/ProductTests.swift
@@ -24,7 +24,7 @@ import XCTest
 
 @testable import PIALibrary
 
-class ProductTests: XCTestCase {
+final class ProductTests: XCTestCase {
 
     private let mock = MockProviders()
     private let subscriptionProductIds = [
@@ -76,7 +76,6 @@ class ProductTests: XCTestCase {
                 XCTAssert(false)
                 return
             }
-            XCTAssertFalse(Client.configuration.eligibleForTrial)
             expUpdate.fulfill()
         }
 
@@ -100,7 +99,6 @@ class ProductTests: XCTestCase {
                 XCTAssert(false)
                 return
             }
-            XCTAssertTrue(Client.configuration.eligibleForTrial)
             expUpdate.fulfill()
         }
 
@@ -124,7 +122,6 @@ class ProductTests: XCTestCase {
                 XCTAssert(false)
                 return
             }
-            XCTAssertFalse(Client.configuration.eligibleForTrial)
             expUpdate.fulfill()
         }
 

--- a/LocalPackages/PIALocalizations/Sources/PIALocalizations/Generated/L10n.swift
+++ b/LocalPackages/PIALocalizations/Sources/PIALocalizations/Generated/L10n.swift
@@ -1222,8 +1222,10 @@ public enum L10n {
         public static let otherPlans = L10n.tr("Localizable", "signup.paywall.cta.other_plans", fallback: "See Other Plans")
         /// Restore Purchases
         public static let restore = L10n.tr("Localizable", "signup.paywall.cta.restore", fallback: "Restore Purchases")
-        /// Start My 7-day Free Trial
-        public static let startTrial = L10n.tr("Localizable", "signup.paywall.cta.start_trial", fallback: "Start My 7-day Free Trial")
+        /// Start My %d-day Free Trial
+        public static func startTrial(_ p1: Int) -> String {
+          return L10n.tr("Localizable", "signup.paywall.cta.start_trial", p1, fallback: "Start My %d-day Free Trial")
+        }
         /// Subscribe • %@
         public static func subscribe(_ p1: Any) -> String {
           return L10n.tr("Localizable", "signup.paywall.cta.subscribe", String(describing: p1), fallback: "Subscribe • %@")
@@ -1243,9 +1245,9 @@ public enum L10n {
         public enum Trial {
           /// You will be charged on the last day of your trial, unless you cancel before your free trial ends.
           public static let detail = L10n.tr("Localizable", "signup.paywall.disclaimer.trial.detail", fallback: "You will be charged on the last day of your trial, unless you cancel before your free trial ends.")
-          /// Free for 7 days, then %@. Cancel anytime.
-          public static func headline(_ p1: Any) -> String {
-            return L10n.tr("Localizable", "signup.paywall.disclaimer.trial.headline", String(describing: p1), fallback: "Free for 7 days, then %@. Cancel anytime.")
+          /// Free for %d days, then %@. Cancel anytime.
+          public static func headline(_ p1: Int, _ p2: Any) -> String {
+            return L10n.tr("Localizable", "signup.paywall.disclaimer.trial.headline", p1, String(describing: p2), fallback: "Free for %d days, then %@. Cancel anytime.")
           }
         }
         public enum Yearly {
@@ -1273,8 +1275,10 @@ public enum L10n {
         public enum Badge {
           /// Best Value
           public static let bestValue = L10n.tr("Localizable", "signup.paywall.plans.badge.best_value", fallback: "Best Value")
-          /// Best Value – 7-day Free Trial
-          public static let bestValueTrial = L10n.tr("Localizable", "signup.paywall.plans.badge.best_value_trial", fallback: "Best Value – 7-day Free Trial")
+          /// Best Value – %d-day Free Trial
+          public static func bestValueTrial(_ p1: Int) -> String {
+            return L10n.tr("Localizable", "signup.paywall.plans.badge.best_value_trial", p1, fallback: "Best Value – %d-day Free Trial")
+          }
         }
         public enum Billing {
           /// Billed monthly
@@ -1307,8 +1311,10 @@ public enum L10n {
         public enum Step2 {
           /// Subscription begins, cancel anytime
           public static let description = L10n.tr("Localizable", "signup.paywall.trial.step2.description", fallback: "Subscription begins, cancel anytime")
-          /// Day 7
-          public static let title = L10n.tr("Localizable", "signup.paywall.trial.step2.title", fallback: "Day 7")
+          /// Day %d
+          public static func title(_ p1: Int) -> String {
+            return L10n.tr("Localizable", "signup.paywall.trial.step2.title", p1, fallback: "Day %d")
+          }
         }
       }
     }

--- a/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/en.lproj/Localizable.strings
+++ b/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/en.lproj/Localizable.strings
@@ -579,16 +579,16 @@
 "signup.paywall.trial.card.title"= "How your free trial works";
 "signup.paywall.trial.step1.title"= "Today";
 "signup.paywall.trial.step1.description"= "Full access unlocked instantly";
-"signup.paywall.trial.step2.title"= "Day 7";
+"signup.paywall.trial.step2.title"= "Day %d";
 "signup.paywall.trial.step2.description"= "Subscription begins, cancel anytime";
 
-"signup.paywall.disclaimer.trial.headline"= "Free for 7 days, then %@. Cancel anytime.";
+"signup.paywall.disclaimer.trial.headline"= "Free for %d days, then %@. Cancel anytime.";
 "signup.paywall.disclaimer.trial.detail"= "You will be charged on the last day of your trial, unless you cancel before your free trial ends.";
 "signup.paywall.disclaimer.monthly.headline"= "%@ per month, billed monthly.";
 "signup.paywall.disclaimer.yearly.headline"= "%@ per year, billed annually.";
 "signup.paywall.disclaimer.renewal.detail"= "Renews automatically unless cancelled at least 24 hours before expiry date.";
 
-"signup.paywall.cta.start_trial"= "Start My 7-day Free Trial";
+"signup.paywall.cta.start_trial"= "Start My %d-day Free Trial";
 "signup.paywall.cta.subscribe"= "Subscribe • %@";
 "signup.paywall.cta.other_plans"= "See Other Plans";
 "signup.paywall.cta.restore"= "Restore Purchases";
@@ -601,7 +601,7 @@
 "signup.paywall.plans.billing.yearly"= "Billed annually";
 "signup.paywall.plans.billing.monthly"= "Billed monthly";
 "signup.paywall.plans.badge.best_value"= "Best Value";
-"signup.paywall.plans.badge.best_value_trial"= "Best Value – 7-day Free Trial";
+"signup.paywall.plans.badge.best_value_trial"= "Best Value – %d-day Free Trial";
 
 "signup.paywall.error.products_unavailable"= "We couldn't load the subscription options. Please check your connection and try again.";
 "signup.paywall.error.retry"= "Try again";

--- a/LocalPackages/PIAPaywall/Sources/PIAPaywall/Domain/PaywallTrialOffer.swift
+++ b/LocalPackages/PIAPaywall/Sources/PIAPaywall/Domain/PaywallTrialOffer.swift
@@ -1,0 +1,32 @@
+//
+//  PaywallTrialOffer.swift
+//  PIAPaywall
+//
+//  Created by Mario on 10/08/2026.
+//  Copyright © 2026 Private Internet Access, Inc.
+//
+//  This file is part of the Private Internet Access iOS Client.
+//
+//  The Private Internet Access iOS Client is free software: you can redistribute it and/or
+//  modify it under the terms of the GNU General Public License as published by the Free
+//  Software Foundation, either version 3 of the License, or (at your option) any later version.
+//
+//  The Private Internet Access iOS Client is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+//  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+//  details.
+//
+//  You should have received a copy of the GNU General Public License along with the Private
+//  Internet Access iOS Client.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+public struct PaywallTrialOffer: Equatable, Sendable {
+    public let days: Int
+
+    public init?(days: Int) {
+        if days <= 0 {
+            return nil
+        }
+        self.days = days
+    }
+}

--- a/LocalPackages/PIAPaywall/Sources/PIAPaywall/Domain/PaywallTrialOffer.swift
+++ b/LocalPackages/PIAPaywall/Sources/PIAPaywall/Domain/PaywallTrialOffer.swift
@@ -20,6 +20,7 @@
 //  Internet Access iOS Client.  If not, see <https://www.gnu.org/licenses/>.
 //
 
+/// Available introductory offer period for subscriptions.
 public struct PaywallTrialOffer: Equatable, Sendable {
     public let days: Int
 

--- a/LocalPackages/PIAPaywall/Sources/PIAPaywall/Presentation/PaywallAction.swift
+++ b/LocalPackages/PIAPaywall/Sources/PIAPaywall/Presentation/PaywallAction.swift
@@ -62,10 +62,10 @@ public enum PaywallAction: Equatable {
 /// What a successful catalogue load produced.
 public struct OffersPayload: Equatable, Sendable {
     public let offers: [PaywallPlanID: PaywallOffer]
-    public let isEligibleForIntroOffer: Bool
+    public let trialOffer: PaywallTrialOffer?
 
-    public init(offers: [PaywallPlanID: PaywallOffer], isEligibleForIntroOffer: Bool) {
+    public init(offers: [PaywallPlanID: PaywallOffer], trialOffer: PaywallTrialOffer?) {
         self.offers = offers
-        self.isEligibleForIntroOffer = isEligibleForIntroOffer
+        self.trialOffer = trialOffer
     }
 }

--- a/LocalPackages/PIAPaywall/Sources/PIAPaywall/Presentation/PaywallDependencies+Live.swift
+++ b/LocalPackages/PIAPaywall/Sources/PIAPaywall/Presentation/PaywallDependencies+Live.swift
@@ -41,18 +41,12 @@ public extension PaywallDependencies {
                 case .success(let products):
                     let offers = makeOffers(from: products)
                     guard !offers.isEmpty else { return .failure(.productsUnavailable) }
-
-                    // Ask the App Store now rather than trusting the flag captured when products
-                    // were first fetched: eligibility can change while the app is running, and a
-                    // backend override must never promise a trial Apple will not grant.
-                    let eligible: Bool
+                    var trialOffer: PaywallTrialOffer? = nil
                     if let product = products[.yearly] ?? products[.monthly] {
-                        eligible = await store.isEligibleForIntroOffer(for: product)
-                    } else {
-                        eligible = false
+                        let days = await store.eligibleDaysForIntroOffer(for: product)
+                        trialOffer = PaywallTrialOffer(days: days)
                     }
-
-                    return .success(OffersPayload(offers: offers, isEligibleForIntroOffer: eligible))
+                    return .success(OffersPayload(offers: offers, trialOffer: trialOffer))
                 }
             },
 

--- a/LocalPackages/PIAPaywall/Sources/PIAPaywall/Presentation/PaywallReducer.swift
+++ b/LocalPackages/PIAPaywall/Sources/PIAPaywall/Presentation/PaywallReducer.swift
@@ -56,7 +56,7 @@ public enum PaywallReducer {
                 return .none
             }
             state.offers = payload.offers
-            state.isEligibleForIntroOffer = payload.isEligibleForIntroOffer
+            state.trialOffer = payload.trialOffer
             state.defaultPlan = payload.offers[.yearly] != nil ? .yearly : .monthly
             state.sheetSelection = state.defaultPlan
             state.phase = .ready

--- a/LocalPackages/PIAPaywall/Sources/PIAPaywall/Presentation/PaywallState+Derived.swift
+++ b/LocalPackages/PIAPaywall/Sources/PIAPaywall/Presentation/PaywallState+Derived.swift
@@ -45,13 +45,10 @@ public extension PaywallState {
     /// The plan the sheet's call to action buys.
     var sheetOffer: PaywallOffer? { offers[sheetSelection] }
 
-    /// Whether a free trial is advertised for `plan`.
-    ///
-    /// The App Store resolves eligibility per subscription group, so both plans share one answer —
-    /// but the design only ever sells the trial on the yearly plan. Monthly is always presented as a
-    /// straight subscription.
-    func isTrialOffered(for plan: PaywallPlanID) -> Bool {
-        isEligibleForIntroOffer && plan == .yearly
+    /// Trial offered for `plan`, if any.
+    func trialOffered(for plan: PaywallPlanID) -> PaywallTrialOffer? {
+        guard plan == .yearly else { return nil }
+        return trialOffer
     }
 
     // MARK: Screen state
@@ -71,9 +68,6 @@ public extension PaywallState {
     /// A one-row sheet is worse than no sheet, so the entry point only appears with a real choice.
     var showsOtherPlansButton: Bool { offers.count > 1 }
 
-    /// The "How your free trial works" card only makes sense when a trial is actually on offer.
-    var showsTrialTimeline: Bool { isTrialOffered(for: defaultPlan) }
-
     // MARK: Copy
 
     /// The main screen's call to action.
@@ -87,12 +81,13 @@ public extension PaywallState {
     var sheetDisclaimer: PaywallDisclaimer? { disclaimer(for: sheetSelection) }
 
     func buttonTitle(for plan: PaywallPlanID) -> String {
-        guard !isTrialOffered(for: plan) else {
-            return L10n.Signup.Paywall.Cta.startTrial
+        if let introOffer = trialOffered(for: plan) {
+            // Show "free trial" copy
+            return L10n.Signup.Paywall.Cta.startTrial(introOffer.days)
         }
         guard let offer = offers[plan] else {
             // Only reachable in the skeleton state, where the label is redacted anyway.
-            return L10n.Signup.Paywall.Cta.startTrial
+            return L10n.Signup.Paywall.Cta.subscribe("--")
         }
         return L10n.Signup.Paywall.Cta.subscribe(L10n.Welcome.Plan.priceFormat(offer.monthlyPriceString))
     }
@@ -100,9 +95,9 @@ public extension PaywallState {
     func disclaimer(for plan: PaywallPlanID) -> PaywallDisclaimer? {
         guard let offer = offers[plan] else { return nil }
 
-        if isTrialOffered(for: plan) {
+        if let introOffer = trialOffered(for: plan) {
             return PaywallDisclaimer(
-                headline: L10n.Signup.Paywall.Disclaimer.Trial.headline(priceString(for: offer)),
+                headline: L10n.Signup.Paywall.Disclaimer.Trial.headline(introOffer.days, priceString(for: offer)),
                 detail: L10n.Signup.Paywall.Disclaimer.Trial.detail
             )
         }
@@ -148,8 +143,9 @@ public extension PaywallState {
     /// The badge on a plan card, or `nil` when it carries none.
     func badgeTitle(for plan: PaywallPlanID) -> String? {
         guard plan == .yearly else { return nil }
-        return isTrialOffered(for: .yearly)
-            ? L10n.Signup.Paywall.Plans.Badge.bestValueTrial
-            : L10n.Signup.Paywall.Plans.Badge.bestValue
+        if let introOffer = trialOffered(for: plan) {
+            return L10n.Signup.Paywall.Plans.Badge.bestValueTrial(introOffer.days)
+        }
+        return L10n.Signup.Paywall.Plans.Badge.bestValue
     }
 }

--- a/LocalPackages/PIAPaywall/Sources/PIAPaywall/Presentation/PaywallState.swift
+++ b/LocalPackages/PIAPaywall/Sources/PIAPaywall/Presentation/PaywallState.swift
@@ -62,7 +62,7 @@ public struct PaywallState: Equatable {
     ///
     /// Captured when the offers load and then left alone: re-deciding mid-session would swap the
     /// call to action from "Start My Free Trial" to "Subscribe" under the customer's finger.
-    public var isEligibleForIntroOffer: Bool
+    public var trialOffer: PaywallTrialOffer?
 
     /// The plan the main screen sells. Not changed by the sheet.
     public var defaultPlan: PaywallPlanID
@@ -83,7 +83,7 @@ public struct PaywallState: Equatable {
         phase: Phase = .loadingProducts,
         activity: Activity = .idle,
         offers: [PaywallPlanID: PaywallOffer] = [:],
-        isEligibleForIntroOffer: Bool = false,
+        trialOffer: PaywallTrialOffer? = nil,
         defaultPlan: PaywallPlanID = .yearly,
         sheetSelection: PaywallPlanID = .yearly,
         isPlanSheetPresented: Bool = false,
@@ -94,7 +94,7 @@ public struct PaywallState: Equatable {
         self.phase = phase
         self.activity = activity
         self.offers = offers
-        self.isEligibleForIntroOffer = isEligibleForIntroOffer
+        self.trialOffer = trialOffer
         self.defaultPlan = defaultPlan
         self.sheetSelection = sheetSelection
         self.isPlanSheetPresented = isPlanSheetPresented

--- a/LocalPackages/PIAPaywall/Sources/PIAPaywall/UI/ChoosePlan/ChoosePlanSheetContent.swift
+++ b/LocalPackages/PIAPaywall/Sources/PIAPaywall/UI/ChoosePlan/ChoosePlanSheetContent.swift
@@ -112,11 +112,11 @@ struct ChoosePlanSheetContent: View {
             initialState: PaywallState(
                 phase: .ready,
                 offers: offers,
-                isEligibleForIntroOffer: true,
+                trialOffer: PaywallTrialOffer(days: 7),
                 sheetSelection: .yearly
             ),
             dependencies: PaywallDependencies(
-                loadOffers: { .success(OffersPayload(offers: offers, isEligibleForIntroOffer: true)) },
+                loadOffers: { .success(OffersPayload(offers: offers, trialOffer: PaywallTrialOffer(days: 7))) },
                 hasExistingEntitlement: { false },
                 purchase: { _ in .failure(.userCancelled) },
                 finishTransaction: { _ in },

--- a/LocalPackages/PIAPaywall/Sources/PIAPaywall/UI/Components/TrialTimelineCard.swift
+++ b/LocalPackages/PIAPaywall/Sources/PIAPaywall/UI/Components/TrialTimelineCard.swift
@@ -29,6 +29,7 @@ import SwiftUI
 /// something that is not going to happen.
 struct TrialTimelineCard: View {
     let layout: PaywallLayout
+    let trialDays: Int
 
     private enum Metrics {
         static let gutterWidth: CGFloat = 30
@@ -95,7 +96,7 @@ struct TrialTimelineCard: View {
                     description: L10n.Signup.Paywall.Trial.Step1.description
                 )
                 step(
-                    title: L10n.Signup.Paywall.Trial.Step2.title,
+                    title: L10n.Signup.Paywall.Trial.Step2.title(trialDays),
                     description: L10n.Signup.Paywall.Trial.Step2.description
                 )
             }

--- a/LocalPackages/PIAPaywall/Sources/PIAPaywall/UI/Components/TrialTimelineCard.swift
+++ b/LocalPackages/PIAPaywall/Sources/PIAPaywall/UI/Components/TrialTimelineCard.swift
@@ -173,13 +173,13 @@ struct TrialTimelineCard: View {
 }
 
 #Preview("Compact") {
-    TrialTimelineCard(layout: .compact)
+    TrialTimelineCard(layout: .compact, trialDays: 7)
         .padding(PIASpacing.s24)
         .background(Color.pia.background)
 }
 
 #Preview("Wide") {
-    TrialTimelineCard(layout: .wide)
+    TrialTimelineCard(layout: .wide, trialDays: 7)
         .padding(PIASpacing.s24)
         .background(Color.pia.background)
 }
@@ -187,7 +187,7 @@ struct TrialTimelineCard: View {
 /// Where a hardcoded connector height would show up: the gutter has to stretch to whatever height
 /// the step text needs, and the tail has to keep the Day 7 node level with its heading.
 #Preview("Largest accessibility text size") {
-    TrialTimelineCard(layout: .compact)
+    TrialTimelineCard(layout: .compact, trialDays: 7)
         .environment(\.sizeCategory, .accessibilityExtraExtraExtraLarge)
         .padding(PIASpacing.s24)
         .background(Color.pia.background)

--- a/LocalPackages/PIAPaywall/Sources/PIAPaywall/UI/SignupPaywallView.swift
+++ b/LocalPackages/PIAPaywall/Sources/PIAPaywall/UI/SignupPaywallView.swift
@@ -151,8 +151,8 @@ public struct SignupPaywallView: View {
             BenefitsList(layout: .compact)
                 .padding(.horizontal, Metrics.headerMargin)
 
-            if store.state.showsTrialTimeline {
-                TrialTimelineCard(layout: .compact)
+            if let trialDays = store.state.trialOffer?.days {
+                TrialTimelineCard(layout: .compact, trialDays: trialDays)
                     .padding(.horizontal, Metrics.contentMargin)
             }
 
@@ -170,8 +170,8 @@ public struct SignupPaywallView: View {
             hero
             BenefitsList(layout: .wide)
 
-            if store.state.showsTrialTimeline {
-                TrialTimelineCard(layout: .wide)
+            if let trialDays = store.state.trialOffer?.days {
+                TrialTimelineCard(layout: .wide, trialDays: trialDays)
             }
 
             actions

--- a/LocalPackages/PIAPaywall/Sources/PIAPaywall/UI/SignupPaywallView.swift
+++ b/LocalPackages/PIAPaywall/Sources/PIAPaywall/UI/SignupPaywallView.swift
@@ -386,10 +386,10 @@ public enum PaywallAccessibility {
             initialState: PaywallState(
                 phase: .ready,
                 offers: offers,
-                isEligibleForIntroOffer: true
+                trialOffer: PaywallTrialOffer(days: 7)
             ),
             dependencies: PaywallDependencies(
-                loadOffers: { .success(OffersPayload(offers: offers, isEligibleForIntroOffer: true)) },
+                loadOffers: { .success(OffersPayload(offers: offers, trialOffer: PaywallTrialOffer(days: 7))) },
                 hasExistingEntitlement: { false },
                 purchase: { _ in .failure(.userCancelled) },
                 finishTransaction: { _ in },

--- a/LocalPackages/PIAPaywall/Tests/PIAPaywallTests/Mocks/PaywallTestDoubles.swift
+++ b/LocalPackages/PIAPaywall/Tests/PIAPaywallTests/Mocks/PaywallTestDoubles.swift
@@ -52,7 +52,7 @@ enum Stub {
         offers: [PaywallPlanID: PaywallOffer] = Stub.bothOffers,
         isEligibleForIntroOffer: Bool = true
     ) -> OffersPayload {
-        OffersPayload(offers: offers, isEligibleForIntroOffer: isEligibleForIntroOffer)
+        OffersPayload(offers: offers, introOffer: isEligibleForIntroOffer ? .days(7) : nil)
     }
 
     static let user = UserAccount(
@@ -69,7 +69,7 @@ enum Stub {
         PaywallState(
             phase: .ready,
             offers: offers,
-            isEligibleForIntroOffer: isEligibleForIntroOffer,
+            introOffer: isEligibleForIntroOffer ? .days(7) : nil,
             defaultPlan: defaultPlan,
             sheetSelection: defaultPlan
         )

--- a/LocalPackages/PIAPaywall/Tests/PIAPaywallTests/Mocks/PaywallTestDoubles.swift
+++ b/LocalPackages/PIAPaywall/Tests/PIAPaywallTests/Mocks/PaywallTestDoubles.swift
@@ -52,7 +52,7 @@ enum Stub {
         offers: [PaywallPlanID: PaywallOffer] = Stub.bothOffers,
         isEligibleForIntroOffer: Bool = true
     ) -> OffersPayload {
-        OffersPayload(offers: offers, introOffer: isEligibleForIntroOffer ? .days(7) : nil)
+        OffersPayload(offers: offers, trialOffer: isEligibleForIntroOffer ? .init(days: 7) : nil)
     }
 
     static let user = UserAccount(
@@ -69,7 +69,7 @@ enum Stub {
         PaywallState(
             phase: .ready,
             offers: offers,
-            introOffer: isEligibleForIntroOffer ? .days(7) : nil,
+            trialOffer: isEligibleForIntroOffer ? .init(days: 7) : nil,
             defaultPlan: defaultPlan,
             sheetSelection: defaultPlan
         )

--- a/LocalPackages/PIAPaywall/Tests/PIAPaywallTests/PaywallReducerTests.swift
+++ b/LocalPackages/PIAPaywall/Tests/PIAPaywallTests/PaywallReducerTests.swift
@@ -66,7 +66,7 @@ final class PaywallReducerTests: XCTestCase {
         XCTAssertEqual(state.phase, .ready)
         XCTAssertEqual(state.defaultPlan, .yearly)
         XCTAssertEqual(state.sheetSelection, .yearly)
-        XCTAssertTrue(state.isEligibleForIntroOffer)
+        XCTAssertEqual(state.trialOffer, PaywallTrialOffer(days: 7))
     }
 
     func test_offersResponse_WHEN_onlyMonthlyReturned_THEN_monthlyBecomesDefaultAndSheetIsHidden() {

--- a/LocalPackages/PIAPaywall/Tests/PIAPaywallTests/PaywallStateDerivedTests.swift
+++ b/LocalPackages/PIAPaywall/Tests/PIAPaywallTests/PaywallStateDerivedTests.swift
@@ -34,28 +34,8 @@ final class PaywallStateDerivedTests: XCTestCase {
         let state = Stub.readyState(isEligibleForIntroOffer: true)
 
         // THEN the trial is sold on yearly; monthly is always a straight subscription
-        XCTAssertTrue(state.isTrialOffered(for: .yearly))
-        XCTAssertFalse(state.isTrialOffered(for: .monthly))
-    }
-
-    func test_trial_WHEN_notEligible_THEN_timelineIsHiddenAndCtaSells() {
-        // GIVEN an account that already used its trial
-        let state = Stub.readyState(isEligibleForIntroOffer: false)
-
-        // THEN the "How your free trial works" card is hidden, because it would be untrue
-        XCTAssertFalse(state.showsTrialTimeline)
-
-        // AND the call to action sells the subscription instead
-        XCTAssertEqual(state.primaryButtonTitle, "Subscribe • $6.08/mo")
-    }
-
-    func test_trial_WHEN_eligible_THEN_timelineIsShownAndCtaStartsTheTrial() {
-        // GIVEN an eligible account
-        let state = Stub.readyState(isEligibleForIntroOffer: true)
-
-        // THEN the trial is explained and offered
-        XCTAssertTrue(state.showsTrialTimeline)
-        XCTAssertEqual(state.primaryButtonTitle, "Start My 7-day Free Trial")
+        XCTAssertEqual(state.trialOffered(for: .yearly), PaywallTrialOffer(days: 7))
+        XCTAssertNil(state.trialOffered(for: .monthly))
     }
 
     // MARK: - Call to action

--- a/PIA VPN-tvOS/Signup/CompositionRoot/SignupFactory.swift
+++ b/PIA VPN-tvOS/Signup/CompositionRoot/SignupFactory.swift
@@ -107,7 +107,8 @@ extension DefaultAccountProvider: ProductsProviderType {
     }
 }
 
-extension Client.Configuration: ProductConfigurationType {}
+extension Client.Configuration: ProductConfigurationType {
+}
 
 extension DefaultAccountProvider: PurchaseProductsAccountProviderType {
     func purchase(plan: Plan, _ callback: LibraryCallback<InAppTransaction>?) {

--- a/PIA VPN-tvOS/Signup/Data/DecoratorProductsProvider.swift
+++ b/PIA VPN-tvOS/Signup/Data/DecoratorProductsProvider.swift
@@ -9,7 +9,7 @@
 import Foundation
 import PIALibrary
 
-class DecoratorProductsProvider: ProductsProviderType {
+final class DecoratorProductsProvider: ProductsProviderType {
     private let subscriptionInformationProvider: SubscriptionInformationProviderType
     private let decoratee: ProductsProviderType
     private let store: InAppProvider
@@ -29,24 +29,21 @@ class DecoratorProductsProvider: ProductsProviderType {
     }
 
     private func setupProducts(completion: @escaping () -> Void) {
-        subscriptionInformationProvider.subscriptionInformation { [weak self] (info, error) in
-            if let _ = error {
-                self?.setDefaultPlanProducts()
+        subscriptionInformationProvider.subscriptionInformation { [weak self] info, error in
+            if error != nil {
+                self?.productConfiguration.setDefaultPlanProducts()
             }
 
-            if let info = info {
+            if let info {
+                var plans: [String: Plan] = [:]
                 for product in info.products where !product.legacy {
-                    self?.productConfiguration.setPlan(product.plan, forProductIdentifier: product.identifier)
+                    plans[product.identifier] = product.plan
                 }
+                self?.productConfiguration.setPlans(plans)
             }
 
             self?.store.startObservingTransactions()
             completion()
         }
-    }
-
-    private func setDefaultPlanProducts() {
-        productConfiguration.setPlan(.yearly, forProductIdentifier: AppConstants.InApp.yearlyProductIdentifier)
-        productConfiguration.setPlan(.monthly, forProductIdentifier: AppConstants.InApp.monthlyProductIdentifier)
     }
 }

--- a/PIA VPN-tvOS/Signup/Domain/Interfaces/ProductConfigurationType.swift
+++ b/PIA VPN-tvOS/Signup/Domain/Interfaces/ProductConfigurationType.swift
@@ -10,5 +10,6 @@ import Foundation
 import PIALibrary
 
 protocol ProductConfigurationType {
-    func setPlan(_ plan: Plan, forProductIdentifier productIdentifier: String)
+    func setPlans(_ plans: [String: Plan])
+    func setDefaultPlanProducts()
 }

--- a/PIA VPN-tvOSTests/Signup/Data/DecoratorProductsProviderTests.swift
+++ b/PIA VPN-tvOSTests/Signup/Data/DecoratorProductsProviderTests.swift
@@ -44,7 +44,7 @@ final class DecoratorProductsProviderTests: XCTestCase {
     func test_listPlanProducts_adds_nonLegacy_products_to_productConfiguration_when_there_is_valid_appstoreInformation() {
         // GIVEN subscriptionInformationProvider completes with valid AppStoreInformation with legacy products
         let productsStub = PIAProduct.makeStubs()
-        let appStoreInformation = AppStoreInformation(products: productsStub, eligibleForTrial: false)
+        let appStoreInformation = AppStoreInformation(products: productsStub)
         let error: Error? = nil
 
         instantiateSut(
@@ -58,7 +58,7 @@ final class DecoratorProductsProviderTests: XCTestCase {
 
         // THEN productConfigurationSpy captures non legacy products provided by subscriptionInformationProvider
         wait(for: [expectation], timeout: 1.0)
-        XCTAssertEqual(fixture.productConfigurationSpy.setPlanCalledAttempt, 2)
+        XCTAssertEqual(fixture.productConfigurationSpy.setPlanCalledAttempt, 1)
         XCTAssertEqual(fixture.productConfigurationSpy.capturedProducts.count, 2)
         XCTAssertEqual(fixture.productConfigurationSpy.capturedProducts[.monthly], productsStub[0].identifier)
         XCTAssertEqual(fixture.productConfigurationSpy.capturedProducts[.yearly], productsStub[1].identifier)
@@ -83,7 +83,7 @@ final class DecoratorProductsProviderTests: XCTestCase {
 
         // THEN productConfigurationSpy captures default products provided
         wait(for: [expectation], timeout: 1.0)
-        XCTAssertEqual(fixture.productConfigurationSpy.setPlanCalledAttempt, 2)
+        XCTAssertEqual(fixture.productConfigurationSpy.setPlanCalledAttempt, 1)
         XCTAssertEqual(fixture.productConfigurationSpy.capturedProducts.count, 2)
         XCTAssertEqual(fixture.productConfigurationSpy.capturedProducts[.monthly], AppConstants.InApp.monthlyProductIdentifier)
         XCTAssertEqual(fixture.productConfigurationSpy.capturedProducts[.yearly], AppConstants.InApp.yearlyProductIdentifier)

--- a/PIA VPN-tvOSTests/Signup/Mocks/InAppProductMock.swift
+++ b/PIA VPN-tvOSTests/Signup/Mocks/InAppProductMock.swift
@@ -16,7 +16,6 @@ struct InAppProductMock: InAppProduct {
     let price: Decimal
     let priceLocale: Locale
     let native: Native
-    let hasIntroOffer: Bool = false
     let description: String
 
     init(identifier: String, price: Decimal, priceLocale: Locale, native: Native, description: String) {

--- a/PIA VPN-tvOSTests/Signup/Mocks/InAppProviderSpy.swift
+++ b/PIA VPN-tvOSTests/Signup/Mocks/InAppProviderSpy.swift
@@ -11,7 +11,7 @@ import PIABase
 import PIALibrary
 import StoreKit
 
-class InAppProviderSpy: InAppProvider {
+final class InAppProviderSpy: InAppProvider {
     var startObservingTransactionsCalledAttempt = 0
     var availableProducts: [any InAppProduct]?
     var entitlementJWS: JWS?
@@ -28,9 +28,9 @@ class InAppProviderSpy: InAppProvider {
         return .success([])
     }
 
-    func isEligibleForIntroOffer(for product: any InAppProduct) async -> Bool {
+    func eligibleDaysForIntroOffer(for product: any InAppProduct) async -> Int {
         isEligibleForIntroOfferCalledAttempt += 1
-        return isEligibleForIntroOfferResult
+        return isEligibleForIntroOfferResult ? 7 : 0
     }
 
     func purchase(product: any InAppProduct) async -> Result<any InAppTransaction, ClientError> {

--- a/PIA VPN-tvOSTests/Signup/Mocks/ProductConfigurationSpy.swift
+++ b/PIA VPN-tvOSTests/Signup/Mocks/ProductConfigurationSpy.swift
@@ -11,12 +11,21 @@ import PIALibrary
 
 @testable import PIA_VPN_tvOS
 
-class ProductConfigurationSpy: ProductConfigurationType {
+final class ProductConfigurationSpy: ProductConfigurationType {
     var setPlanCalledAttempt = 0
     var capturedProducts = [Plan: String]()
 
-    func setPlan(_ plan: Plan, forProductIdentifier productIdentifier: String) {
-        capturedProducts[plan] = productIdentifier
+    func setPlans(_ plans: [String: Plan]) {
+        for (identifier, plan) in plans {
+            capturedProducts[plan] = identifier
+        }
         setPlanCalledAttempt += 1
+    }
+
+    func setDefaultPlanProducts() {
+        setPlans([
+            AppConstants.InApp.monthlyProductIdentifier: .monthly,
+            AppConstants.InApp.yearlyProductIdentifier: .yearly
+        ])
     }
 }

--- a/PIA VPN/Bootstrapper.swift
+++ b/PIA VPN/Bootstrapper.swift
@@ -182,22 +182,19 @@ final class Bootstrapper {
         #endif
 
         Client.observeTransactions()
-        Client.providers.accountProvider.subscriptionInformation { [weak self] (info, error) in
-
-            if let _ = error {
-                self?.setDefaultPlanProducts()
+        Client.providers.accountProvider.subscriptionInformation { info, error in
+            if let error {
+                log.error("Failed to load subscription information: \(error)")
+                Client.configuration.setDefaultPlanProducts()
+                return
             }
 
-            if let info = info {
-
-                if info.products.count > 0 {
-                    for product in info.products {
-                        if !product.legacy {
-                            Client.configuration.setPlan(product.plan, forProductIdentifier: product.identifier)
-                        }
-                    }
+            if let info {
+                var plans: [String: Plan] = [:]
+                for product in info.products where !product.legacy {
+                    plans[product.identifier] = product.plan
                 }
-
+                Client.configuration.setPlans(plans)
             }
 
             Client.refreshProducts()
@@ -265,12 +262,6 @@ final class Bootstrapper {
         }
 
         setupExceptionHandler()
-    }
-
-    private func setDefaultPlanProducts() {
-        log.debug("Using fallback product identifiers")
-        Client.configuration.setPlan(.yearly, forProductIdentifier: AppConstants.InApp.yearlyProductIdentifier)
-        Client.configuration.setPlan(.monthly, forProductIdentifier: AppConstants.InApp.monthlyProductIdentifier)
     }
 
     func dispose() {

--- a/PIA VPN/UI/PurchasePlanCell.swift
+++ b/PIA VPN/UI/PurchasePlanCell.swift
@@ -66,11 +66,10 @@ final class PurchasePlanCell: UICollectionViewCell, Restylable {
         log.debug(
             #function,
             metadata: [
-                "isEligibleForIntroOffer": .stringConvertible(plan.product.hasIntroOffer),
-                "eligibleForTrial": .stringConvertible(Client.configuration.eligibleForTrial),
                 "plan": .stringConvertible(plan)
             ])
-        let showFreeTrialLabel = plan.product.hasIntroOffer && Client.configuration.eligibleForTrial
+        // legacy, hardcode to false, is replaced with SwiftUI view
+        let showFreeTrialLabel = false
         labelBestValue.text =
             showFreeTrialLabel
             ? "\(L10n.Welcome.Plan.bestValue.uppercased()) - FREE TRIAL"


### PR DESCRIPTION
- Load "intro offer" directly on the paywall.
- Read dynamically how many days of trial there are.
- Wait until product identifiers are loaded from the backend, with 10 second timeout.