### PR TITLE
KM-17732: Report platform and version on every KPI event

### DIFF
--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Macros.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Macros.swift
@@ -35,6 +35,26 @@ public class Macros {
     }
 
     /**
+     Returns the Apple platform the app is running on.
+
+     Mac Catalyst is reported as macOS even though it compiles as iOS, since it
+     is a Mac build to anyone reading the data.
+
+     - Returns: The platform name, as reported to backend services.
+     */
+    public static func platformName() -> String {
+        #if targetEnvironment(macCatalyst)
+            return "macOS"
+        #elseif os(macOS)
+            return "macOS"
+        #elseif os(tvOS)
+            return "tvOS"
+        #else
+            return "iOS"
+        #endif
+    }
+
+    /**
      Returns a full version string.
 
      - Returns: The full version string, including both x.y.z version and build number.

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/ServiceQuality/ServiceQualityManager.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/ServiceQuality/ServiceQualityManager.swift
@@ -69,6 +69,14 @@ public final class ServiceQualityManager: NSObject {
     }
 
     /**
+     * Property keys reported on every event, whatever its type.
+     */
+    private enum KPICommonPropertyKey: String {
+        case platform
+        case version
+    }
+
+    /**
      * Enum defining the in-app-purchase processing events.
      * These track the KapeClientSDK receipt-verification funnel.
      */
@@ -105,6 +113,11 @@ public final class ServiceQualityManager: NSObject {
         case restore
         case update
     }
+
+    private static let commonEventProperties: [String: String] = [
+        KPICommonPropertyKey.platform.rawValue: Macros.platformName(),
+        KPICommonPropertyKey.version.rawValue: Macros.versionString() ?? "Unknown"
+    ]
 
     public override init() {
         super.init()
@@ -201,73 +214,40 @@ public final class ServiceQualityManager: NSObject {
 
     public func connectionAttemptEvent() {
         let connectionSource = connectionSource()
-        guard connectionSource == .manual, isAppActive, let kpiManager else { return }
+        guard connectionSource == .manual, isAppActive else { return }
 
-        let event = KPIClientEvent(
-            eventCountry: nil,
-            eventName: KPIConnectionEvent.vpnConnectionAttempt.rawValue,
-            eventProperties: [
+        submitEvent(
+            named: KPIConnectionEvent.vpnConnectionAttempt.rawValue,
+            properties: [
                 KPIEventPropertyKey.connectionSource.rawValue: connectionSource.rawValue,
                 KPIEventPropertyKey.userAgent.rawValue: PIAWebServices.userAgent,
                 KPIEventPropertyKey.vpnProtocol.rawValue: currentProtocol().rawValue
-            ],
-            eventInstant: Date()
+            ]
         )
-
-        Task {
-            do {
-                try await kpiManager.submit(event: event)
-                log.debug("KPI event submitted \(event)")
-            } catch {
-                log.error("\(error)")
-            }
-        }
     }
 
     public func connectionEstablishedEvent() {
         let connectionSource = connectionSource()
-        guard connectionSource == .manual, isAppActive, let kpiManager else { return }
+        guard connectionSource == .manual, isAppActive else { return }
 
-        let event = KPIClientEvent(
-            eventCountry: nil,
-            eventName: KPIConnectionEvent.vpnConnectionEstablished.rawValue,
-            eventProperties: createEstablishedEventProperties(),
-            eventInstant: Date()
+        submitEvent(
+            named: KPIConnectionEvent.vpnConnectionEstablished.rawValue,
+            properties: createEstablishedEventProperties()
         )
-
-        Task {
-            do {
-                try await kpiManager.submit(event: event)
-                log.debug("KPI event submitted \(event)")
-            } catch {
-                log.error("\(error)")
-            }
-        }
     }
 
     public func connectionCancelledEvent() {
         let disconnectionSource = disconnectionSource()
-        guard disconnectionSource == .manual, isAppActive, let kpiManager else { return }
+        guard disconnectionSource == .manual, isAppActive else { return }
 
-        let event = KPIClientEvent(
-            eventCountry: nil,
-            eventName: KPIConnectionEvent.vpnConnectionCancelled.rawValue,
-            eventProperties: [
+        submitEvent(
+            named: KPIConnectionEvent.vpnConnectionCancelled.rawValue,
+            properties: [
                 KPIEventPropertyKey.connectionSource.rawValue: disconnectionSource.rawValue,
                 KPIEventPropertyKey.userAgent.rawValue: PIAWebServices.userAgent,
                 KPIEventPropertyKey.vpnProtocol.rawValue: currentProtocol().rawValue
-            ],
-            eventInstant: Date()
+            ]
         )
-
-        Task {
-            do {
-                try await kpiManager.submit(event: event)
-                log.debug("KPI event submitted \(event)")
-            } catch {
-                log.error("\(error)")
-            }
-        }
     }
 
     // MARK: IAP processing events
@@ -323,8 +303,10 @@ public final class ServiceQualityManager: NSObject {
             default: return String(describing: clientError)
             }
         default:
-            let nsError = error as NSError
-            return "\(nsError.domain)_\(nsError.code)"
+            // Describing the error keeps the case name readable; bridging to
+            // NSError would report the case index instead, which says nothing
+            // to whoever reads the event.
+            return String(describing: error)
         }
     }
 
@@ -349,19 +331,25 @@ public final class ServiceQualityManager: NSObject {
     }
 
     private func submitIapEvent(_ event: KPIIapEvent, properties: [String: String]) {
-        guard Client.preferences.shareServiceQualityData, let kpiManager else { return }
+        guard Client.preferences.shareServiceQualityData else { return }
+        submitEvent(named: event.rawValue, properties: properties)
+    }
 
-        let clientEvent = KPIClientEvent(
+    /// Single submission path for every event, stamping the common properties.
+    private func submitEvent(named name: String, properties: [String: String]) {
+        guard let kpiManager else { return }
+
+        let event = KPIClientEvent(
             eventCountry: nil,
-            eventName: event.rawValue,
-            eventProperties: properties,
+            eventName: name,
+            eventProperties: properties.merging(Self.commonEventProperties) { current, _ in current },
             eventInstant: Date()
         )
 
         Task {
             do {
-                try await kpiManager.submit(event: clientEvent)
-                log.debug("KPI event submitted \(clientEvent)")
+                try await kpiManager.submit(event: event)
+                log.debug("KPI event submitted \(event)")
             } catch {
                 log.error("\(error)")
             }

--- a/LocalPackages/PIALibrary/Tests/PIALibraryTests/ServiceQualityManagerTests.swift
+++ b/LocalPackages/PIALibrary/Tests/PIALibraryTests/ServiceQualityManagerTests.swift
@@ -143,6 +143,88 @@ final class ServiceQualityManagerTests: XCTestCase {
         XCTAssertEqual(event?.eventProperties["internalError"], "boom")
     }
 
+    // MARK: Common properties
+
+    func testIapEventsCarryPlatformAndVersion() {
+        let event = firstSubmittedEvent {
+            sut.iapProcessingPurchaseEvent(origin: .signup)
+        }
+
+        XCTAssertEqual(event?.eventProperties["platform"], Self.expectedPlatform)
+        XCTAssertEqual(event?.eventProperties["version"], Macros.versionString() ?? "Unknown")
+    }
+
+    /// The ticket puts these properties on every event, not only the IAP ones.
+    func testConnectionEventsCarryPlatformAndVersion() {
+        Client.configuration.connectedManually = true
+        defer { Client.configuration.connectedManually = false }
+
+        let event = firstSubmittedEvent {
+            sut.connectionAttemptEvent()
+        }
+
+        XCTAssertEqual(event?.eventName, "VPN_CONNECTION_ATTEMPT")
+        XCTAssertEqual(event?.eventProperties["platform"], Self.expectedPlatform)
+        XCTAssertEqual(event?.eventProperties["version"], Macros.versionString() ?? "Unknown")
+        // The pre-existing connection properties must survive the change.
+        XCTAssertEqual(event?.eventProperties["connection_source"], "Manual")
+        XCTAssertNotNil(event?.eventProperties["vpn_protocol"])
+    }
+
+    /// Spelled out rather than delegating to `Macros`, so the wire values stay
+    /// asserted against literals.
+    private static var expectedPlatform: String {
+        #if targetEnvironment(macCatalyst)
+            return "macOS"
+        #elseif os(macOS)
+            return "macOS"
+        #elseif os(tvOS)
+            return "tvOS"
+        #else
+            return "iOS"
+        #endif
+    }
+
+    // MARK: Error detail
+
+    /// A non-`ClientError` enum must report its case name, not the opaque case
+    /// index that `NSError` bridging produces.
+    func testNonClientErrorReportsCaseName() {
+        let event = firstSubmittedEvent {
+            sut.iapProcessingFailureEvent(origin: .renew, error: SampleError.receiptRejected)
+        }
+
+        XCTAssertEqual(event?.eventProperties["error"], "receiptRejected")
+    }
+
+    /// Associated values are described inline, so the value is not a bare case name.
+    func testNonClientErrorWithAssociatedValueReportsCaseName() {
+        let event = firstSubmittedEvent {
+            sut.iapProcessingFailureEvent(origin: .renew, error: SampleError.rejected(status: 409))
+        }
+
+        XCTAssertEqual(event?.eventProperties["error"], "rejected(status: 409)")
+    }
+
+    /// A genuine `NSError` is described rather than reduced to domain/code.
+    /// The error is held as `Error` on purpose: `String(describing:)` renders a
+    /// bridged type differently once its static type is the existential, which
+    /// is how the production call site receives it.
+    func testNSErrorIsDescribed() {
+        let urlError: Error = URLError(.notConnectedToInternet)
+        let event = firstSubmittedEvent {
+            sut.iapProcessingFailureEvent(origin: .renew, error: urlError)
+        }
+
+        XCTAssertEqual(event?.eventProperties["error"], String(describing: urlError))
+        XCTAssertEqual(event?.eventProperties["error"], "Error Domain=NSURLErrorDomain Code=-1009 \"(null)\"")
+    }
+
+    private enum SampleError: Error {
+        case receiptRejected
+        case rejected(status: Int)
+    }
+
     func testEventSuppressedWhenConsentDisabled() {
         setConsent(false)
 


### PR DESCRIPTION
Implements [KM-17732](https://polymoon.atlassian.net/browse/KM-17732). Builds on #375.

- Every KPI event now carries `platform` and `version`, stamped in one shared
  `submitEvent(named:properties:)`. Covers the `VPN_CONNECTION_*` events too,
  per "on all events" in the ticket.
- Mac Catalyst reports `macOS`, tvOS reports `tvOS`.
- `iap_processing_failure` describes its `error` instead of bridging it to an
  `NSError`, whose code for a Swift enum is the case index.

189 tests, 0 failures.

Note: `PaymentError` from the ticket exists nowhere in this codebase, so that
sample likely came from another platform — worth confirming the real iOS values
in Mixpanel. @juan.docal
