### PR TITLE
KM-17635: Turn on kill switch from Automation screen

### DIFF
--- a/PIA VPN/UI/Dashboard/DashboardViewController.swift
+++ b/PIA VPN/UI/Dashboard/DashboardViewController.swift
@@ -680,9 +680,6 @@ final class DashboardViewController: AutolayoutViewController {
 
         if let sideMenu = segue.destination as? SideMenuNavigationController {
             setMenuDelegate(menuNavigationController: sideMenu)
-        } else if let nmt = segue.destination as? TrustedNetworksViewController {
-            nmt.shouldReconnectAutomatically = true
-            nmt.persistentConnectionValue = Client.preferences.isPersistentConnection
         } else if let vc = segue.destination as? AddEmailToAccountViewController {
             vc.modalPresentationStyle = .fullScreen
         } else if let vc = segue.destination as? RegionsViewController {

--- a/PIA VPN/UI/Menu/TrustedNetworksViewController.swift
+++ b/PIA VPN/UI/Menu/TrustedNetworksViewController.swift
@@ -37,8 +37,6 @@ final class TrustedNetworksViewController: AutolayoutViewController {
     private var data = [Rule]()
 
     private var hotspotHelper: PIAHotspotHelper!
-    private var persistentConnectionValue: Bool { pendingPreferences?.isPersistentConnection ?? false }
-    private var vpnType: String { pendingPreferences?.vpnType ?? "" }
 
     weak var pendingPreferences: Client.Preferences.Editable?
 
@@ -56,6 +54,8 @@ final class TrustedNetworksViewController: AutolayoutViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        assert(pendingPreferences != nil, "pendingPreferences not set in TrustedNetworksViewController")
+
         reloadRulesData()
         self.hotspotHelper = PIAHotspotHelper(withDelegate: self)
 
@@ -71,12 +71,9 @@ final class TrustedNetworksViewController: AutolayoutViewController {
 
         configureCollectionView()
 
-        if !persistentConnectionValue,
-            Client.preferences.nmtRulesEnabled
-        {
+        if let pendingPreferences, !pendingPreferences.isPersistentConnection, Client.preferences.nmtRulesEnabled {
             presentKillSwitchAlert()
         }
-
     }
 
     override func viewWillAppear(_ animated: Bool) {

--- a/PIA VPN/UI/Menu/TrustedNetworksViewController.swift
+++ b/PIA VPN/UI/Menu/TrustedNetworksViewController.swift
@@ -37,10 +37,10 @@ final class TrustedNetworksViewController: AutolayoutViewController {
     private var data = [Rule]()
 
     private var hotspotHelper: PIAHotspotHelper!
-    var shouldReconnectAutomatically = false
-    var hasUpdatedPreferences = false
-    var persistentConnectionValue = false
-    var vpnType = ""
+    private var persistentConnectionValue: Bool { pendingPreferences?.isPersistentConnection ?? false }
+    private var vpnType: String { pendingPreferences?.vpnType ?? "" }
+
+    weak var pendingPreferences: Client.Preferences.Editable?
 
     private struct Cells {
         static let network = "NetworkCollectionViewCell"
@@ -84,18 +84,6 @@ final class TrustedNetworksViewController: AutolayoutViewController {
         filterAvailableNetworks()
     }
 
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
-        if shouldReconnectAutomatically,
-            hasUpdatedPreferences
-        {
-            NotificationCenter.default.post(
-                name: .PIASettingsHaveChanged,
-                object: self,
-                userInfo: nil)
-        }
-    }
-
     deinit {
         NotificationCenter.default.removeObserver(self)
     }
@@ -119,14 +107,8 @@ final class TrustedNetworksViewController: AutolayoutViewController {
     private func presentKillSwitchAlert() {
         let alert = Macros.alert(nil, L10n.Settings.Nmt.Killswitch.disabled)
         alert.addCancelAction(L10n.Global.close)
-        alert.addActionWithTitle(L10n.Global.enable) {
-            let preferences = Client.preferences.editable()
-            preferences.isPersistentConnection = true
-            preferences.commit()
-            NotificationCenter.default.post(
-                name: .PIAPersistentConnectionSettingHaveChanged,
-                object: self,
-                userInfo: nil)
+        alert.addActionWithTitle(L10n.Global.enable) { [weak pendingPreferences] in
+            pendingPreferences?.isPersistentConnection = true
         }
         present(alert, animated: true, completion: nil)
     }

--- a/PIA VPN/UI/Settings/AutomationSettingsViewController.swift
+++ b/PIA VPN/UI/Settings/AutomationSettingsViewController.swift
@@ -57,8 +57,7 @@ final class AutomationSettingsViewController: PIABaseSettingsViewController {
 
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         if let trustedNetworksVC = segue.destination as? TrustedNetworksViewController {
-            trustedNetworksVC.persistentConnectionValue = pendingPreferences.isPersistentConnection
-            trustedNetworksVC.vpnType = pendingPreferences.vpnType
+            trustedNetworksVC.pendingPreferences = pendingPreferences
         }
     }
 

--- a/PIA VPN/UI/Settings/DevelopmentSettingsViewController.swift
+++ b/PIA VPN/UI/Settings/DevelopmentSettingsViewController.swift
@@ -67,8 +67,7 @@
 
         override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
             if let trustedNetworksVC = segue.destination as? TrustedNetworksViewController {
-                trustedNetworksVC.persistentConnectionValue = pendingPreferences.isPersistentConnection
-                trustedNetworksVC.vpnType = pendingPreferences.vpnType
+                trustedNetworksVC.pendingPreferences = pendingPreferences
             }
         }
 

--- a/PIA VPN/UI/Settings/HelpSettingsViewController.swift
+++ b/PIA VPN/UI/Settings/HelpSettingsViewController.swift
@@ -69,12 +69,6 @@ final class HelpSettingsViewController: PIABaseSettingsViewController {
         self.tableView.reloadData()
     }
 
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        if let trustedNetworksVC = segue.destination as? TrustedNetworksViewController, let pendingPreferences {
-            trustedNetworksVC.pendingPreferences = pendingPreferences
-        }
-    }
-
     @objc private func reloadSettings() {
         tableView.reloadData()
     }

--- a/PIA VPN/UI/Settings/HelpSettingsViewController.swift
+++ b/PIA VPN/UI/Settings/HelpSettingsViewController.swift
@@ -29,7 +29,6 @@ private let log = PIALogger.logger(for: HelpSettingsViewController.self)
 
 final class HelpSettingsViewController: PIABaseSettingsViewController {
 
-
     private lazy var switchDebugLogging = UISwitch()
     private lazy var switchShareServiceQualityData = UISwitch()
 
@@ -72,8 +71,7 @@ final class HelpSettingsViewController: PIABaseSettingsViewController {
 
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         if let trustedNetworksVC = segue.destination as? TrustedNetworksViewController, let pendingPreferences {
-            trustedNetworksVC.persistentConnectionValue = pendingPreferences.isPersistentConnection
-            trustedNetworksVC.vpnType = pendingPreferences.vpnType
+            trustedNetworksVC.pendingPreferences = pendingPreferences
         }
     }
 


### PR DESCRIPTION
- Build `TrustedNetworksViewController` with single required `pendingPreferences` property.
- Update pending peferences instead of the actual ones. Settings will apply them later.
- Remove from `DashboardViewController.prepare(for:)` since there's no segue from dashboard. Remove unused `shouldReconnectAutomatically` property that was only set here.