### PR TITLE
KM-17628 Fix crash in ServersDaemon

### DIFF
--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Client.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Client.swift
@@ -83,10 +83,14 @@ public final class Client {
     public static func resetServers(completionBlock: @escaping (Error?) -> Void) {
         Task {
             await ServersPinger.shared.reset()
+            await ServersDaemon.shared.reset()
+            do {
+                try await ServersDaemon.shared.forceUpdates()
+                completionBlock(nil)
+            } catch {
+                completionBlock(error)
+            }
         }
-
-        ServersDaemon.shared.reset()
-        ServersDaemon.shared.forceUpdates(completionBlock: completionBlock)
     }
 
     public static func resetWebServices() {

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Daemons/Daemon.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Daemons/Daemon.swift
@@ -23,8 +23,6 @@
 import Foundation
 
 protocol Daemon: AnyObject {
-    var hasEnabledUpdates: Bool { get }
-
     func start()
 
     func enableUpdates()

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Daemons/ServersDaemon.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Daemons/ServersDaemon.swift
@@ -55,6 +55,7 @@ internal actor ServersDaemon: Daemon, ConfigurationAccess, DatabaseAccess, Provi
 
     private let downloadServers: DownloadServers
     private let sleep: Sleep
+    private let downloadTimeout: UInt64
 
     private var hasEnabledUpdates = false
     private var lastUpdateDate: Date?
@@ -69,10 +70,12 @@ internal actor ServersDaemon: Daemon, ConfigurationAccess, DatabaseAccess, Provi
 
     init(
         downloadServers: DownloadServers? = nil,
-        sleep: Sleep? = nil
+        sleep: Sleep? = nil,
+        downloadTimeout: UInt64? = nil
     ) {
         self.downloadServers = downloadServers ?? Self.downloadFromCurrentProvider
         self.sleep = sleep ?? { try? await Task.sleep(nanoseconds: $0) }
+        self.downloadTimeout = downloadTimeout ?? Constants.downloadTimeout
     }
 
     // MARK: - Daemon
@@ -238,34 +241,32 @@ internal actor ServersDaemon: Daemon, ConfigurationAccess, DatabaseAccess, Provi
     }
 
     private func downloadWithWatchdog() async -> DownloadResult {
-        await withTaskGroup(of: DownloadResult?.self) { group in
-            group.addTask { [downloadServers] in
-                await downloadServers()
-            }
+        let outcome = DownloadOutcome()
 
-            group.addTask {
-                try? await Task.sleep(nanoseconds: Constants.downloadTimeout)
-                return nil
-            }
-
-            let first = await group.next() ?? nil
-            group.cancelAll()
-
-            guard let first else {
-                log.error("Servers download did not call back within the timeout")
-                return (nil, ClientError.libraryError(message: "Servers download timed out"))
-            }
-            return first
+        let download = Task { [downloadServers] in
+            outcome.resume(with: await downloadServers())
         }
+
+        let watchdog = Task { [downloadTimeout] in
+            try? await Task.sleep(nanoseconds: downloadTimeout)
+            log.error("Servers download did not call back within the timeout")
+            outcome.resume(with: (nil, ClientError.libraryError(message: "Servers download timed out")))
+        }
+
+        let result = await outcome.value()
+
+        download.cancel()
+        watchdog.cancel()
+
+        return result
     }
 
     private static let downloadFromCurrentProvider: DownloadServers = {
-        await withCheckedContinuation { continuation in
-            let once = DownloadContinuation(continuation)
-            Client.providers.serverProvider.download { servers, error in
-                once.resume(with: (servers, error))
-            }
+        let outcome = DownloadOutcome()
+        Client.providers.serverProvider.download { servers, error in
+            outcome.resume(with: (servers, error))
         }
+        return await outcome.value()
     }
 
     // MARK: - Pings
@@ -346,17 +347,41 @@ internal actor ServersDaemon: Daemon, ConfigurationAccess, DatabaseAccess, Provi
     }
 }
 
-private final class DownloadContinuation: @unchecked Sendable {
-    private var continuation: Mutex<CheckedContinuation<ServersDaemon.DownloadResult, Never>?>
+private final class DownloadOutcome: @unchecked Sendable {
+    private struct State {
+        var continuation: CheckedContinuation<ServersDaemon.DownloadResult, Never>?
+        var pending: ServersDaemon.DownloadResult?
+        var isResolved = false
+    }
 
-    init(_ continuation: CheckedContinuation<ServersDaemon.DownloadResult, Never>) {
-        self.continuation = .init(continuation)
+    private var state = Mutex(State())
+
+    func value() async -> ServersDaemon.DownloadResult {
+        await withCheckedContinuation { continuation in
+            state.withLock { state in
+                guard let pending = state.pending else {
+                    state.continuation = continuation
+                    return
+                }
+                state.pending = nil
+                state.isResolved = true
+                continuation.resume(returning: pending)
+            }
+        }
     }
 
     func resume(with result: ServersDaemon.DownloadResult) {
-        continuation.withLock { continuation in
-            continuation?.resume(returning: result)
-            continuation = nil
+        state.withLock { state in
+            guard !state.isResolved, state.pending == nil else {
+                return
+            }
+            guard let continuation = state.continuation else {
+                state.pending = result
+                return
+            }
+            state.continuation = nil
+            state.isResolved = true
+            continuation.resume(returning: result)
         }
     }
 }

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Daemons/ServersDaemon.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Daemons/ServersDaemon.swift
@@ -21,93 +21,147 @@
 //
 
 import Foundation
-import UIKit
+
+#if os(iOS)
+    import UIKit
+#endif
 
 private let log = PIALogger.logger(for: ServersDaemon.self)
 
-final class ServersDaemon: Daemon, ConfigurationAccess, DatabaseAccess, ProvidersAccess {
+extension ServersDaemon {
+    private enum Constants {
+        static let downloadTimeout: UInt64 = 60 * NSEC_PER_SEC
+    }
+
+    private enum WakeSignal {
+        case serversMayBeStale
+        case pingOnly
+    }
+
+    typealias DownloadResult = (servers: [Server]?, error: Error?)
+    typealias DownloadServers = @Sendable () async -> DownloadResult
+    typealias Sleep = @Sendable (UInt64) async -> Void
+}
+
+/// Keeps the server list fresh.
+///
+/// The cadence is owned by a single `loopTask` that alternates between evaluating staleness and
+/// sleeping. Notifications and callers never reschedule anything themselves; they only `wake()` the
+/// loop, which then re-evaluates. The previous design recreated a `DispatchSourceTimer` from five
+/// call sites across two thread families, and racing threads would release a source that had not
+/// been resumed yet — a libdispatch trap.
+internal actor ServersDaemon: Daemon, ConfigurationAccess, DatabaseAccess, ProvidersAccess {
     static let shared = ServersDaemon()
 
-    private(set) var hasEnabledUpdates: Bool
+    private let downloadServers: DownloadServers
+    private let sleep: Sleep
 
-    private(set) var updating: Bool
-
+    private var hasEnabledUpdates = false
     private var lastUpdateDate: Date?
-
     private var lastPingDate: Date?
 
-    private var pendingUpdateTimer: DispatchSourceTimer?
+    private var loopTask: Task<Void, Never>?
+    private var sleepTask: Task<Void, Never>?
 
-    private init() {
-        hasEnabledUpdates = false
-        updating = false
+    private var inflightUpdate: Task<DownloadResult, Never>?
+    private var inflightGeneration = 0
+    private var observationTasks: [Task<Void, Never>] = []
+
+    init(
+        downloadServers: DownloadServers? = nil,
+        sleep: Sleep? = nil
+    ) {
+        self.downloadServers = downloadServers ?? Self.downloadFromCurrentProvider
+        self.sleep = sleep ?? { try? await Task.sleep(nanoseconds: $0) }
     }
 
-    func start() {
-        let nc = NotificationCenter.default
-        #if os(iOS)
-            nc.addObserver(self, selector: #selector(applicationDidBecomeActive(notification:)), name: UIApplication.didBecomeActiveNotification, object: nil)
-        #endif
-        nc.addObserver(self, selector: #selector(handleReachable), name: .ConnectivityDaemonDidGetReachable, object: nil)
-        nc.addObserver(self, selector: #selector(vpnStatusDidChange(notification:)), name: .PIADaemonsDidUpdateVPNStatus, object: nil)
+    // MARK: - Daemon
+
+    nonisolated func start() {
+        Task {
+            await beginObserving()
+        }
     }
 
-    func enableUpdates() {
+    nonisolated func enableUpdates() {
+        Task {
+            await enableUpdatesIfNeeded()
+        }
+    }
+
+    // MARK: - Lifecycle
+
+    func forceUpdates() async throws {
         guard !hasEnabledUpdates else {
+            log.debug("Updates already enabled, skipping forced update")
             return
         }
         hasEnabledUpdates = true
 
-        checkOutdatedServers()
-    }
-
-    func forceUpdates(completionBlock: @escaping (Error?) -> Void) {
-        guard !hasEnabledUpdates else {
-            return
-        }
-        hasEnabledUpdates = true
-        let pollInterval = accessedDatabase.transient.serversConfiguration.pollInterval
-        accessedProviders.serverProvider.download { (servers, error) in
-            self.lastUpdateDate = Date()
-            log.debug("Servers updated on \(self.lastUpdateDate!), will repeat in \(pollInterval) milliseconds")
-            self.scheduleServersUpdate(withDelay: pollInterval)
-
-            guard let servers = servers else {
-                if let error = error as? ClientError, error == ClientError.noRegions {
-                    self.pingIfOffline(servers: Client.providers.serverProvider.currentServers)
-                }
-                completionBlock(error)
-                return
-            }
-            self.pingIfOffline(servers: servers)
-            completionBlock(error)
+        defer {
+            startUpdateLoop()
         }
 
+        try await refresh()
     }
 
-    func reset() {
+    func reset() async {
+        loopTask?.cancel()
+        loopTask = nil
+        sleepTask?.cancel()
+        sleepTask = nil
+        inflightUpdate?.cancel()
+        inflightUpdate = nil
+        inflightGeneration += 1
         lastUpdateDate = nil
         lastPingDate = nil
         hasEnabledUpdates = false
     }
 
-    @objc private func checkOutdatedServers() {
-
-        if updating {
+    private func enableUpdatesIfNeeded() {
+        guard !hasEnabledUpdates else {
             return
         }
+        hasEnabledUpdates = true
 
+        startUpdateLoop()
+    }
+
+    private func startUpdateLoop() {
+        loopTask?.cancel()
+        sleepTask?.cancel()
+
+        loopTask = Task {
+            await runUpdateLoop()
+        }
+    }
+
+    // MARK: - Update loop
+
+    private func runUpdateLoop() async {
+        while !Task.isCancelled {
+            let delay = await nextUpdateDelay()
+
+            guard !Task.isCancelled else {
+                return
+            }
+            await sleepInterruptibly(milliseconds: delay)
+        }
+    }
+
+    private func nextUpdateDelay() async -> Int {
         let pollInterval = accessedDatabase.transient.serversConfiguration.pollInterval
         log.debug("Poll interval is \(pollInterval)")
 
         if let lastUpdateDate = lastUpdateDate {
             let elapsed = Int(-lastUpdateDate.timeIntervalSinceNow * 1000.0)
-            guard (elapsed >= pollInterval) else {
+            guard elapsed >= pollInterval else {
                 let leftDelay = pollInterval - elapsed
-                log.debug("Elapsed \(elapsed) milliseconds (< \(pollInterval)) since last update (\(lastUpdateDate)), retrying in \(leftDelay) milliseconds...")
+                log.debug(
+                    "Elapsed \(elapsed) milliseconds (< \(pollInterval)) since last update (\(lastUpdateDate)), retrying in \(leftDelay) milliseconds..."
+                )
 
-                scheduleServersUpdate(withDelay: leftDelay)
-                return
+                return leftDelay
             }
         } else {
             log.debug("Never updated so far, updating now...")
@@ -116,62 +170,130 @@ final class ServersDaemon: Daemon, ConfigurationAccess, DatabaseAccess, Provider
         guard accessedDatabase.transient.isNetworkReachable else {
             let delay = accessedConfiguration.serversUpdateWhenNetworkDownDelay
             log.debug("Not updating when network is down, retrying in \(delay) milliseconds...")
-            scheduleServersUpdate(withDelay: delay)
-            return
+            return delay
         }
 
-        updating = true
-        accessedProviders.serverProvider.download { (servers, error) in
-            self.updating = false
-            self.lastUpdateDate = Date()
-            log.debug("Servers updated on \(self.lastUpdateDate!), will repeat in \(pollInterval) milliseconds")
-            self.scheduleServersUpdate(withDelay: pollInterval)
+        try? await refresh()
 
-            guard let servers = servers else {
-                if let error = error as? ClientError, error == ClientError.noRegions {
-                    self.pingIfOffline(servers: Client.providers.serverProvider.currentServers)
-                }
-                return
+        return accessedDatabase.transient.serversConfiguration.pollInterval
+    }
+
+    private func sleepInterruptibly(milliseconds: Int) async {
+        let nanoseconds = UInt64(max(0, milliseconds)) * NSEC_PER_MSEC
+        let task = Task { [sleep] in
+            await sleep(nanoseconds)
+        }
+        sleepTask = task
+        await task.value
+        sleepTask = nil
+    }
+
+    private func wake() {
+        sleepTask?.cancel()
+    }
+
+    // MARK: - Downloading
+
+    private func refresh() async throws {
+        let result = await runDeduplicatedDownload()
+
+        let updateDate = Date()
+        lastUpdateDate = updateDate
+        let pollInterval = accessedDatabase.transient.serversConfiguration.pollInterval
+        log.debug("Servers updated on \(updateDate), will repeat in \(pollInterval) milliseconds")
+
+        if let servers = result.servers {
+            pingIfOffline(servers: servers)
+        } else if let error = result.error as? ClientError, error == ClientError.noRegions {
+            pingIfOffline(servers: accessedProviders.serverProvider.currentServers)
+        }
+
+        if let error = result.error {
+            throw error
+        }
+    }
+
+    private func runDeduplicatedDownload() async -> DownloadResult {
+        // Join an in-flight download instead of starting a second one.
+        if let inflightUpdate = inflightUpdate {
+            log.debug("Servers download already in flight, joining it")
+            return await inflightUpdate.value
+        }
+
+        inflightGeneration += 1
+        let generation = inflightGeneration
+        let task = Task {
+            await downloadWithWatchdog()
+        }
+        inflightUpdate = task
+
+        let result = await task.value
+
+        // Only the owning call clears the slot; reset() may have installed a newer generation.
+        if inflightGeneration == generation {
+            inflightUpdate = nil
+        }
+
+        return result
+    }
+
+    private func downloadWithWatchdog() async -> DownloadResult {
+        await withTaskGroup(of: DownloadResult?.self) { group in
+            group.addTask { [downloadServers] in
+                await downloadServers()
             }
-            self.pingIfOffline(servers: servers)
+
+            group.addTask {
+                try? await Task.sleep(nanoseconds: Constants.downloadTimeout)
+                return nil
+            }
+
+            let first = await group.next() ?? nil
+            group.cancelAll()
+
+            guard let first else {
+                log.error("Servers download did not call back within the timeout")
+                return (nil, ClientError.libraryError(message: "Servers download timed out"))
+            }
+            return first
         }
     }
 
-    private func scheduleServersUpdate(withDelay delay: Int) {
-        pendingUpdateTimer?.cancel()
-        pendingUpdateTimer = DispatchSource.makeTimerSource(flags: .strict, queue: .main)
-        pendingUpdateTimer?.schedule(
-            deadline: DispatchTime.now() + .milliseconds(delay),
-            repeating: .never
-        )
-        pendingUpdateTimer?.setEventHandler {
-            self.checkOutdatedServers()
+    private static let downloadFromCurrentProvider: DownloadServers = {
+        await withCheckedContinuation { continuation in
+            let once = DownloadContinuation(continuation)
+            Client.providers.serverProvider.download { servers, error in
+                once.resume(with: (servers, error))
+            }
         }
-        pendingUpdateTimer?.resume()
     }
+
+    // MARK: - Pings
 
     private func pingIfOffline(servers: [Server]) {
         guard accessedConfiguration.enablesServerPings else {
             return
         }
 
-        // not before minimum interval
         if let last = lastPingDate {
             let elapsed = Int(-last.timeIntervalSinceNow * 1000.0)
-            guard (elapsed >= accessedConfiguration.minPingInterval) else {
-                log.debug("Not pinging servers before \(accessedConfiguration.minPingInterval) milliseconds (elapsed: \(elapsed))")
+            guard elapsed >= accessedConfiguration.minPingInterval else {
+                log.debug(
+                    "Not pinging servers before \(accessedConfiguration.minPingInterval) milliseconds (elapsed: \(elapsed))"
+                )
                 return
             }
         }
         lastPingDate = Date()
 
         // pings must be issued when VPN is NOT active to avoid biased response times
-        guard (accessedDatabase.transient.vpnStatus == .disconnected) else {
+        guard accessedDatabase.transient.vpnStatus == .disconnected else {
             log.debug("Not pinging servers while on VPN, will try on next update")
             return
         }
         log.debug("Start pinging servers")
 
+        // Deliberately not awaited: the update cadence must not wait on a full ping pass.
         Task {
             await ServersPinger.shared.ping(withDestinations: servers)
         }
@@ -179,24 +301,62 @@ final class ServersDaemon: Daemon, ConfigurationAccess, DatabaseAccess, Provider
 
     // MARK: Notifications
 
-    @objc private func applicationDidBecomeActive(notification: Notification) {
-        if hasEnabledUpdates {
-            let currentServers = accessedProviders.serverProvider.currentServers
-            pingIfOffline(servers: currentServers)
+    private func beginObserving() {
+        guard observationTasks.isEmpty else {
+            return
+        }
+
+        var tasks = [
+            observationTask(for: .ConnectivityDaemonDidGetReachable, signal: .serversMayBeStale),
+            observationTask(for: .PIADaemonsDidUpdateVPNStatus, signal: .serversMayBeStale)
+        ]
+        #if os(iOS)
+            tasks.append(
+                observationTask(for: UIApplication.didBecomeActiveNotification, signal: .pingOnly)
+            )
+        #endif
+        observationTasks = tasks
+    }
+
+    private func observationTask(for name: Notification.Name, signal: WakeSignal) -> Task<Void, Never> {
+        Task { [weak self] in
+            // Mapped to Void: the notification itself is never read, only used as a signal.
+            for await _ in NotificationCenter.default.notifications(named: name).map({ _ in () }) {
+                guard let self = self else {
+                    return
+                }
+                await self.handle(signal)
+            }
         }
     }
 
-    @objc private func vpnStatusDidChange(notification: Notification) {
-        if hasEnabledUpdates {
-            checkOutdatedServers()
-            pingIfOffline(servers: accessedProviders.serverProvider.currentServers)
+    private func handle(_ signal: WakeSignal) {
+        guard hasEnabledUpdates else {
+            return
         }
+
+        switch signal {
+        case .serversMayBeStale:
+            wake()
+        case .pingOnly:
+            break
+        }
+
+        pingIfOffline(servers: accessedProviders.serverProvider.currentServers)
+    }
+}
+
+private final class DownloadContinuation: @unchecked Sendable {
+    private var continuation: Mutex<CheckedContinuation<ServersDaemon.DownloadResult, Never>?>
+
+    init(_ continuation: CheckedContinuation<ServersDaemon.DownloadResult, Never>) {
+        self.continuation = .init(continuation)
     }
 
-    @objc private func handleReachable() {
-        if hasEnabledUpdates {
-            checkOutdatedServers()
-            pingIfOffline(servers: accessedProviders.serverProvider.currentServers)
+    func resume(with result: ServersDaemon.DownloadResult) {
+        continuation.withLock { continuation in
+            continuation?.resume(returning: result)
+            continuation = nil
         }
     }
 }

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Server/DefaultServerProvider.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Server/DefaultServerProvider.swift
@@ -211,6 +211,7 @@ public final class DefaultServerProvider: ServerProvider, ConfigurationAccess, D
                                 log.error("Get DIPs failed with unauthorized error. Logging out...")
                                 Client.providers.accountProvider.logout(nil)
                                 Macros.postNotification(.PIAUnauthorized)
+                                callback?(self.currentServers, clientError)
                             }
                         } else {
                             DispatchQueue.main.async { [self] in

--- a/LocalPackages/PIALibrary/Tests/PIALibraryTests/ServersDaemonTests.swift
+++ b/LocalPackages/PIALibrary/Tests/PIALibraryTests/ServersDaemonTests.swift
@@ -1,0 +1,307 @@
+//
+//  ServersDaemonTests.swift
+//  PIALibraryTests
+//
+//  Copyright © 2026 Private Internet Access, Inc.
+//
+//  This file is part of the Private Internet Access iOS Client.
+//
+//  The Private Internet Access iOS Client is free software: you can redistribute it and/or
+//  modify it under the terms of the GNU General Public License as published by the Free
+//  Software Foundation, either version 3 of the License, or (at your option) any later version.
+//
+//  The Private Internet Access iOS Client is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+//  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+//  details.
+//
+//  You should have received a copy of the GNU General Public License along with the Private
+//  Internet Access iOS Client.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import XCTest
+
+@testable import PIALibrary
+
+final class ServersDaemonTests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+
+        Client.database.transient.isNetworkReachable = true
+        Client.database.transient.vpnStatus = .disconnected
+        // Pings are exercised by ServersPingerTests; keep them out of the cadence assertions.
+        Client.configuration.enablesServerPings = false
+    }
+
+    override func tearDown() {
+        Client.database.transient.isNetworkReachable = true
+        Client.database.transient.vpnStatus = .disconnected
+        super.tearDown()
+    }
+
+    private var pollIntervalNanoseconds: UInt64 {
+        UInt64(Client.database.transient.serversConfiguration.pollInterval) * NSEC_PER_MSEC
+    }
+
+    /// Regression for KM-17628: `scheduleServersUpdate(withDelay:)` used to recreate an
+    /// unsynchronized `DispatchSourceTimer` from every one of these call sites, and racing threads
+    /// released a source that had not been resumed yet — `EXC_BREAKPOINT` inside libdispatch.
+    /// Hammering the daemon from many tasks at once must neither trap nor start a second download.
+    func testConcurrentWakeSignalsDoNotRaceOrDuplicateDownloads() async {
+        let downloads = Counter()
+        let sleeps = SleepRecorder(honorRequestedDelay: false)
+        let daemon = ServersDaemon(
+            downloadServers: {
+                await downloadStub(downloads, delay: 200_000_000)
+            },
+            sleep: { await sleeps.record($0) }
+        )
+
+        daemon.start()
+        daemon.enableUpdates()
+        _ = await waitUntil { await downloads.invocations >= 1 }
+
+        // Five concurrent producers, mirroring the notification paths that used to re-enter the
+        // scheduler concurrently.
+        await withTaskGroup(of: Void.self) { group in
+            for _ in 0..<5 {
+                group.addTask {
+                    for _ in 0..<40 {
+                        Macros.postNotification(.ConnectivityDaemonDidGetReachable)
+                        Macros.postNotification(.PIADaemonsDidUpdateVPNStatus)
+                        await Task.yield()
+                    }
+                }
+            }
+        }
+
+        _ = await waitUntil { await sleeps.delays.count >= 2 }
+        await daemon.reset()
+
+        // The list is not stale again yet, so all that hammering must not have refetched it.
+        let invocations = await downloads.invocations
+        XCTAssertEqual(invocations, 1)
+    }
+
+    func testFirstRunDownloadsImmediatelyThenWaitsAPollInterval() async {
+        let downloads = Counter()
+        let sleeps = SleepRecorder(honorRequestedDelay: false)
+        let daemon = ServersDaemon(
+            downloadServers: { await downloadStub(downloads) },
+            sleep: { await sleeps.record($0) }
+        )
+
+        daemon.enableUpdates()
+        let recorded = await waitUntil { await sleeps.delays.count >= 1 }
+        await daemon.reset()
+
+        XCTAssertTrue(recorded)
+        let invocations = await downloads.invocations
+        XCTAssertEqual(invocations, 1)
+        let delays = await sleeps.delays
+        XCTAssertEqual(delays.first, pollIntervalNanoseconds)
+    }
+
+    func testNotYetStaleWaitsOnlyTheRemainingInterval() async {
+        let downloads = Counter()
+        let sleeps = SleepRecorder(honorRequestedDelay: false)
+        let daemon = ServersDaemon(
+            downloadServers: { await downloadStub(downloads) },
+            sleep: { await sleeps.record($0) }
+        )
+
+        daemon.enableUpdates()
+        _ = await waitUntil { await sleeps.delays.count >= 2 }
+        await daemon.reset()
+
+        // Second pass finds the list fresh, so it waits the remainder rather than a full interval
+        // and does not download again.
+        let delays = await sleeps.delays
+        XCTAssertGreaterThan(delays.count, 1)
+        XCTAssertLessThanOrEqual(delays[1], pollIntervalNanoseconds)
+        let invocations = await downloads.invocations
+        XCTAssertEqual(invocations, 1)
+    }
+
+    func testNetworkDownSkipsDownloadAndUsesConfiguredDelay() async {
+        Client.database.transient.isNetworkReachable = false
+
+        let downloads = Counter()
+        let sleeps = SleepRecorder(honorRequestedDelay: false)
+        let daemon = ServersDaemon(
+            downloadServers: { await downloadStub(downloads) },
+            sleep: { await sleeps.record($0) }
+        )
+
+        daemon.enableUpdates()
+        _ = await waitUntil { await sleeps.delays.count >= 1 }
+        await daemon.reset()
+
+        let delays = await sleeps.delays
+        XCTAssertEqual(
+            delays.first,
+            UInt64(Client.configuration.serversUpdateWhenNetworkDownDelay) * NSEC_PER_MSEC
+        )
+        let invocations = await downloads.invocations
+        XCTAssertEqual(invocations, 0)
+    }
+
+    func testWakeSignalEndsTheCurrentSleepEarly() async {
+        let downloads = Counter()
+        // Honors the requested delay, so without a wake the loop would park for a full
+        // poll interval (ten minutes by default).
+        let sleeps = SleepRecorder(honorRequestedDelay: true)
+        let daemon = ServersDaemon(
+            downloadServers: { await downloadStub(downloads) },
+            sleep: { await sleeps.record($0) }
+        )
+
+        daemon.start()
+        daemon.enableUpdates()
+        let sleeping = await waitUntil { await sleeps.delays.count >= 1 }
+        XCTAssertTrue(sleeping)
+
+        Macros.postNotification(.ConnectivityDaemonDidGetReachable)
+
+        let wokeUp = await waitUntil(timeout: 3) { await sleeps.delays.count >= 2 }
+        await daemon.reset()
+
+        XCTAssertTrue(wokeUp, "wake() should have cancelled the in-progress sleep")
+    }
+
+    func testFailedDownloadStillReschedules() async {
+        let downloads = Counter()
+        let sleeps = SleepRecorder(honorRequestedDelay: false)
+        let daemon = ServersDaemon(
+            downloadServers: {
+                await downloads.increment()
+                return (nil, ClientError.malformedResponseData)
+            },
+            sleep: { await sleeps.record($0) }
+        )
+
+        daemon.enableUpdates()
+        let rescheduled = await waitUntil { await sleeps.delays.count >= 1 }
+        await daemon.reset()
+
+        // A failure must not silently stop the cadence.
+        XCTAssertTrue(rescheduled)
+        let invocations = await downloads.invocations
+        XCTAssertEqual(invocations, 1)
+    }
+
+    func testResetStopsTheLoop() async {
+        let sleeps = SleepRecorder(honorRequestedDelay: false)
+        let daemon = ServersDaemon(
+            downloadServers: { (makeServers(count: 1), nil) },
+            sleep: { await sleeps.record($0) }
+        )
+
+        daemon.enableUpdates()
+        _ = await waitUntil { await sleeps.delays.count >= 1 }
+        await daemon.reset()
+
+        // Let any iteration that was already past its cancellation check finish before sampling.
+        try? await Task.sleep(nanoseconds: 100_000_000)
+        let afterReset = await sleeps.delays.count
+        try? await Task.sleep(nanoseconds: 200_000_000)
+        let settled = await sleeps.delays.count
+
+        XCTAssertEqual(settled, afterReset, "the loop kept running after reset()")
+    }
+
+    func testForceUpdatesThrowsTheDownloadError() async {
+        let daemon = ServersDaemon(
+            downloadServers: { (nil, ClientError.malformedResponseData) },
+            sleep: { _ in }
+        )
+
+        do {
+            try await daemon.forceUpdates()
+            XCTFail("expected forceUpdates() to throw")
+        } catch {
+            XCTAssertEqual(error as? ClientError, .malformedResponseData)
+        }
+        await daemon.reset()
+    }
+
+    func testForceUpdatesSucceedsWhenTheDownloadSucceeds() async {
+        let daemon = ServersDaemon(
+            downloadServers: { (makeServers(count: 2), nil) },
+            sleep: { _ in }
+        )
+
+        do {
+            try await daemon.forceUpdates()
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+        await daemon.reset()
+    }
+}
+
+private func makeServers(count: Int) -> [Server] {
+    return (0..<count).map { index in
+        Server(
+            serial: "serial-\(index)",
+            name: "Server \(index)",
+            country: "us",
+            hostname: "server\(index).example.com",
+            iKEv2AddressesForUDP: [Server.ServerAddressIP(ip: "10.0.0.\(index)", cn: "cn", van: false)],
+            pingAddress: nil,
+            regionIdentifier: "region-\(index)"
+        )
+    }
+}
+
+private func downloadStub(
+    _ counter: Counter,
+    delay: UInt64 = 0
+) async -> ServersDaemon.DownloadResult {
+    await counter.increment()
+    if delay > 0 {
+        try? await Task.sleep(nanoseconds: delay)
+    }
+    return (makeServers(count: 1), nil)
+}
+
+private func waitUntil(
+    timeout: TimeInterval = 2,
+    _ condition: @escaping () async -> Bool
+) async -> Bool {
+    let deadline = Date().addingTimeInterval(timeout)
+    while Date() < deadline {
+        if await condition() {
+            return true
+        }
+        try? await Task.sleep(nanoseconds: 5_000_000)
+    }
+    return await condition()
+}
+
+private actor Counter {
+    private(set) var invocations = 0
+
+    func increment() {
+        invocations += 1
+    }
+}
+
+private actor SleepRecorder {
+    private(set) var delays: [UInt64] = []
+    private let honorRequestedDelay: Bool
+
+    init(honorRequestedDelay: Bool) {
+        self.honorRequestedDelay = honorRequestedDelay
+    }
+
+    func record(_ nanoseconds: UInt64) async {
+        delays.append(nanoseconds)
+        if honorRequestedDelay {
+            try? await Task.sleep(nanoseconds: nanoseconds)
+        } else {
+            await Task.yield()
+        }
+    }
+}

--- a/LocalPackages/PIALibrary/Tests/PIALibraryTests/ServersDaemonTests.swift
+++ b/LocalPackages/PIALibrary/Tests/PIALibraryTests/ServersDaemonTests.swift
@@ -191,6 +191,46 @@ final class ServersDaemonTests: XCTestCase {
         XCTAssertEqual(invocations, 1)
     }
 
+    /// A download that never calls back must not wedge the loop. The watchdog has to abandon it
+    /// rather than wait for it, so the cadence keeps running.
+    func testHungDownloadDoesNotWedgeTheLoop() async {
+        let sleeps = SleepRecorder(honorRequestedDelay: false)
+        let daemon = ServersDaemon(
+            downloadServers: {
+                // Suspends forever and ignores cancellation, like a provider that drops its callback.
+                await withCheckedContinuation { (_: CheckedContinuation<Void, Never>) in }
+                return (nil, nil)
+            },
+            sleep: { await sleeps.record($0) },
+            downloadTimeout: 50_000_000
+        )
+
+        daemon.enableUpdates()
+        let rescheduled = await waitUntil(timeout: 3) { await sleeps.delays.count >= 1 }
+        await daemon.reset()
+
+        XCTAssertTrue(rescheduled, "the watchdog did not release the loop")
+    }
+
+    func testForceUpdatesReportsTheWatchdogTimeout() async {
+        let daemon = ServersDaemon(
+            downloadServers: {
+                await withCheckedContinuation { (_: CheckedContinuation<Void, Never>) in }
+                return (nil, nil)
+            },
+            sleep: { _ in },
+            downloadTimeout: 50_000_000
+        )
+
+        do {
+            try await daemon.forceUpdates()
+            XCTFail("expected forceUpdates() to throw the watchdog error")
+        } catch {
+            XCTAssertNotNil(error as? ClientError)
+        }
+        await daemon.reset()
+    }
+
     func testResetStopsTheLoop() async {
         let sleeps = SleepRecorder(honorRequestedDelay: false)
         let daemon = ServersDaemon(


### PR DESCRIPTION
**The bug**

The server list refresh used a timer that got thrown away and rebuilt from five different places, on two different threads. When two of them ran at the same time, one threw away a timer the other had just built but not started yet — and that crashes the app. Roughly 484 crashes a year, still happening in 3.33.0.

**The fix**

`ServersDaemon` is now an `actor`, so only one thing touches its state at a time. A single background task owns the timing: check if the list is old, refresh it, sleep, repeat. Notifications no longer change anything themselves — they just wake that task up early so it can check again.

Same delays, same pings, same handling of download results as before.

**Also fixed on the way**

- `DefaultServerProvider.download` never called back when a DIP request came back unauthorized, which quietly stopped all future refreshes.
- `reset()` left the old timer running, so every reset added another one.
- `forceUpdates` could return without calling its completion block.

**Worth knowing**

- `start()` and `enableUpdates()` are async now.
- `pollInterval` is read after the download instead of before, so a new value from the server takes effect one cycle sooner.

**Tests**

9 new tests in `ServersDaemonTests`, including one that hammers the daemon from five threads at once while a download is running.

```
ServersDaemonTests                → 9 tests, 0 failures
full PIALibraryTests              → 100 tests, 4 failures
iOS / tvOS / Mac Catalyst builds  → BUILD SUCCEEDED
```

The 4 failures are old `ProductTests` ones, not from this PR — I checked by stashing these changes and running them on clean `master`, where they fail the same way.

TSan and a manual soak still to do, both need a logged-in session.

**Closing issues**

https://polymoon.atlassian.net/browse/KM-17628
