### PR TITLE
KM-17384: background create and update live activities

### DIFF
--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Util/Task+Extensions.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Util/Task+Extensions.swift
@@ -1,0 +1,41 @@
+//
+//  Task+Extensions.swift
+//  PIALibrary
+//
+//  Created by Mario on 18/08/2026.
+//  Copyright © 2020 Private Internet Access, Inc.
+//
+//  This file is part of the Private Internet Access iOS Client.
+//
+//  The Private Internet Access iOS Client is free software: you can redistribute it and/or
+//  modify it under the terms of the GNU General Public License as published by the Free
+//  Software Foundation, either version 3 of the License, or (at your option) any later version.
+//
+//  The Private Internet Access iOS Client is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+//  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+//  details.
+//
+//  You should have received a copy of the GNU General Public License along with the Private
+//  Internet Access iOS Client.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Foundation
+
+public extension Task where Failure == Never, Success == Void {
+    /// Run an async operation in a synchronous context, and wait for it to finish.
+    ///
+    /// Blocks the thread until the operation is finished. The caller is responsible for managing multithreading.
+    static func blockingThreadUnsafe(
+        name: String? = nil,
+        priority: TaskPriority? = nil,
+        operation: sending @escaping @isolated(any) () async -> Void
+    ) {
+        let semaphore = DispatchSemaphore(value: 0)
+        Task(name: name, priority: priority) {
+            await operation()
+            semaphore.signal()
+        }
+        semaphore.wait()
+    }
+}

--- a/PIA VPN/AppDelegate.swift
+++ b/PIA VPN/AppDelegate.swift
@@ -94,7 +94,9 @@ final class AppDelegate: NSObject, UIApplicationDelegate {
         Bootstrapper.shared.dispose()
 
         #if !targetEnvironment(macCatalyst)
-            liveActivityManager?.endLiveActivities()
+            Task {
+                await liveActivityManager?.endLiveActivities()
+            }
         #endif
     }
 

--- a/PIA VPN/AppDelegate.swift
+++ b/PIA VPN/AppDelegate.swift
@@ -94,7 +94,7 @@ final class AppDelegate: NSObject, UIApplicationDelegate {
         Bootstrapper.shared.dispose()
 
         #if !targetEnvironment(macCatalyst)
-            Task {
+            Task.blockingThreadUnsafe { [weak liveActivityManager] in
                 await liveActivityManager?.endLiveActivities()
             }
         #endif

--- a/PIA VPN/UI/Dashboard/DashboardViewController.swift
+++ b/PIA VPN/UI/Dashboard/DashboardViewController.swift
@@ -1540,19 +1540,19 @@ extension DashboardViewController: UICollectionViewDelegate, UICollectionViewDat
 
         @available(iOS 16.2, *)
         private func startConnectionLiveActivityIfNeeded() {
-            guard let appDelegate = UIApplication.shared.delegate as? AppDelegate,
-                let liveActivityManager = appDelegate.liveActivityManager
-            else { return }
+            guard let liveActivityManager = AppDelegate.delegate().liveActivityManager else { return }
             let connState = makeLiveActivityStateForCurrentConnection()
-            liveActivityManager.startLiveActivity(with: connState)
+            Task {
+                await liveActivityManager.startLiveActivity(with: connState)
+            }
         }
 
         @available(iOS 16.2, *)
         private func stopConnectionLiveActivity() {
-            guard let appDelegate = UIApplication.shared.delegate as? AppDelegate,
-                let liveActivityManager = appDelegate.liveActivityManager
-            else { return }
-            liveActivityManager.endLiveActivities()
+            guard let liveActivityManager = AppDelegate.delegate().liveActivityManager else { return }
+            Task {
+                await liveActivityManager.endLiveActivities()
+            }
         }
     }
 #endif

--- a/PIAWidget/Domain/Widget/PIAConnectionLiveActivityManager.swift
+++ b/PIAWidget/Domain/Widget/PIAConnectionLiveActivityManager.swift
@@ -1,86 +1,65 @@
 #if !targetEnvironment(macCatalyst)
     import ActivityKit
     import Foundation
+    import enum PIALibrary.PIALogger
 
-    public protocol PIAConnectionLiveActivityManagerType {
-        func startLiveActivity(with state: PIAConnectionAttributes.ContentState)
-        func endLiveActivities()
+    @available(iOS 16.2, *)
+    private let log = PIALogger.logger(for: PIAConnectionLiveActivityManager.self)
+
+    protocol PIAConnectionLiveActivityManagerType: Sendable {
+        func startLiveActivity(with state: PIAConnectionAttributes.ContentState) async
+        func endLiveActivities() async
     }
 
     @available(iOS 16.2, *)
-    public final class PIAConnectionLiveActivityManager: PIAConnectionLiveActivityManagerType {
-
-        private var activity: Activity<PIAConnectionAttributes>?
-        private var currentActivityPriority = 0
+    final actor PIAConnectionLiveActivityManager: PIAConnectionLiveActivityManagerType {
+        typealias Activity = ActivityKit.Activity<PIAConnectionAttributes>
 
         static let shared = PIAConnectionLiveActivityManager()
-
         private init() {}
 
-        deinit {
-            endLiveActivities()
-        }
-
-        public func startLiveActivity(with state: PIAConnectionAttributes.ContentState) {
-            guard activity == nil else {
-                updateLiveActivity(with: state)
-                return
+        func startLiveActivity(with state: PIAConnectionAttributes.ContentState) async {
+            if let activity = Activity.activities.first(where: { $0.activityState == .active }) {
+                await updateLiveActivity(activity: activity, with: state)
+            } else {
+                await createNewLiveActivity(with: state)
             }
-
-            createNewLiveActivity(with: state)
-
         }
 
-        public func endLiveActivities() {
-            let currentActivities = Activity<PIAConnectionAttributes>.activities
-
+        func endLiveActivities() async {
+            let currentActivities = Activity.activities
             guard !currentActivities.isEmpty else { return }
 
-            let semaphore = DispatchSemaphore(value: 0)
-
-            Task {
+            await withTaskGroup(of: Void.self) { group in
                 for act in currentActivities {
-                    await act.end(dismissalPolicy: .immediate)
-
-                    semaphore.signal()
+                    group.addTask {
+                        await act.end(dismissalPolicy: .immediate)
+                    }
                 }
             }
-            semaphore.wait()
-
         }
 
-        public func endPreviousActivities() {
-            let currentActivities = Activity<PIAConnectionAttributes>.activities
-            for act in currentActivities {
-                Task {
-                    await act.end(dismissalPolicy: .immediate)
-                }
-            }
-            activity = nil
-        }
-
-        private func createNewLiveActivity(with state: PIAConnectionAttributes.ContentState) {
+        private func createNewLiveActivity(with state: PIAConnectionAttributes.ContentState) async {
             // Clear all the Live Activities before starting a new one
-            endPreviousActivities()
+            await endLiveActivities()
 
             let attributes = PIAConnectionAttributes()
-
-            activity = try? Activity<PIAConnectionAttributes>.request(attributes: attributes, contentState: state, pushType: nil)
+            do {
+                _ = try Activity.request(attributes: attributes, contentState: state, pushType: nil)
+            } catch {
+                log.error("Unable to create live activity: \(error.localizedDescription)")
+            }
         }
 
-        private func updateLiveActivity(with state: PIAConnectionAttributes.ContentState) {
-            guard activity?.activityState == .active else {
-                createNewLiveActivity(with: state)
+        private func updateLiveActivity(activity: Activity, with state: PIAConnectionAttributes.ContentState) async {
+            guard activity.activityState == .active else {
+                await createNewLiveActivity(with: state)
                 return
             }
+
             // Only update the live activity if there is new content
-            guard state != activity?.content.state else { return }
-
-            Task {
-                await activity?.update(using: state)
-            }
-
+            guard state != activity.content.state else { return }
+            await activity.update(using: state)
         }
-
     }
 #endif

--- a/PIAWidget/Domain/Widget/PIAConnectionLiveActivityManager.swift
+++ b/PIAWidget/Domain/Widget/PIAConnectionLiveActivityManager.swift
@@ -6,7 +6,7 @@
     @available(iOS 16.2, *)
     private let log = PIALogger.logger(for: PIAConnectionLiveActivityManager.self)
 
-    protocol PIAConnectionLiveActivityManagerType: Sendable {
+    protocol PIAConnectionLiveActivityManagerType: AnyObject, Sendable {
         func startLiveActivity(with state: PIAConnectionAttributes.ContentState) async
         func endLiveActivities() async
     }


### PR DESCRIPTION
- Resurface work from #349 that was lost when we reverted commits for a hotfix.
- `PIAConnectionLiveActivityManager` is now an actor so creating and updating live activities is done in a background thread.