### PR TITLE
KM-17255: Improve error descriptions for login

### DIFF
--- a/LocalPackages/PIAAccount/Sources/PIAAccount/Networking/AccountHTTPClient.swift
+++ b/LocalPackages/PIAAccount/Sources/PIAAccount/Networking/AccountHTTPClient.swift
@@ -68,12 +68,14 @@ actor AccountHTTPClient {
             let (data, response) = try await session.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {
-                throw PIAAccountError.networkFailure(
+                throw PIAAccountError.decodingFailed(
                     NSError(
-                        domain: "PIAAccount", code: 0,
+                        domain: "PIAAccount",
+                        code: 0,
                         userInfo: [
-                            NSLocalizedDescriptionKey: "Invalid response type"
-                        ])
+                            NSLocalizedDescriptionKey: "Invalid response type \(type(of: response))"
+                        ]
+                    )
                 )
             }
 
@@ -111,12 +113,14 @@ actor AccountHTTPClient {
             let (data, response) = try await session.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {
-                throw PIAAccountError.networkFailure(
+                throw PIAAccountError.decodingFailed(
                     NSError(
-                        domain: "PIAAccount", code: 0,
+                        domain: "PIAAccount",
+                        code: 0,
                         userInfo: [
-                            NSLocalizedDescriptionKey: "Invalid response type"
-                        ])
+                            NSLocalizedDescriptionKey: "Invalid response type \(type(of: response))"
+                        ]
+                    )
                 )
             }
 

--- a/LocalPackages/PIAAccount/Sources/PIAAccount/PIAAccountError.swift
+++ b/LocalPackages/PIAAccount/Sources/PIAAccount/PIAAccountError.swift
@@ -1,9 +1,31 @@
 import Foundation
 
+public enum PIAErrorType: Equatable, Sendable {
+    case network
+    case decoding
+    case encoding
+    case configuration
+    case keychain
+    case certificatePinning
+    case http(status: Int)
+
+    public var code: Int {
+        return switch self {
+        case .network: 600
+        case .decoding: 601
+        case .encoding: 602
+        case .configuration: 603
+        case .keychain: 604
+        case .certificatePinning: 605
+        case .http(let status): status
+        }
+    }
+}
+
 /// Base protocol for all PIA SDK errors
 public protocol PIAError: Error, LocalizedError {
     /// HTTP status code or custom error code
-    var code: Int { get }
+    var type: PIAErrorType { get }
 
     /// The underlying error that caused this error, if any
     var underlyingError: Error? { get }
@@ -12,7 +34,7 @@ public protocol PIAError: Error, LocalizedError {
 /// Error type for account-related operations
 public struct PIAAccountError: PIAError, Sendable {
     /// HTTP status code or custom error code (600+ for local errors)
-    public let code: Int
+    public let type: PIAErrorType
 
     /// Human-readable error message from the API or SDK
     public let message: String?
@@ -24,12 +46,12 @@ public struct PIAAccountError: PIAError, Sendable {
     public let underlyingError: Error?
 
     public init(
-        code: Int,
+        type: PIAErrorType,
         message: String?,
         retryAfterSeconds: TimeInterval = 0,
         underlyingError: Error? = nil
     ) {
-        self.code = code
+        self.type = type
         self.message = message
         self.retryAfterSeconds = retryAfterSeconds
         self.underlyingError = underlyingError
@@ -41,7 +63,15 @@ public struct PIAAccountError: PIAError, Sendable {
         if let message = message {
             return message
         }
-        return HTTPURLResponse.localizedString(forStatusCode: code)
+        return switch type {
+        case .network: "Network failure"
+        case .decoding: "Decoding error"
+        case .encoding: "Encoding error"
+        case .configuration: "Configuration error"
+        case .keychain: "Keychain error"
+        case .certificatePinning: "Certificate pinning error"
+        case .http(let status): HTTPURLResponse.localizedString(forStatusCode: status)
+        }
     }
 
     public var failureReason: String? {
@@ -66,7 +96,7 @@ public struct PIAAccountError: PIAError, Sendable {
     ) -> PIAAccountError {
         let message = data.flatMap { parseErrorMessage(from: $0) }
         return PIAAccountError(
-            code: status,
+            type: .http(status: status),
             message: message,
             retryAfterSeconds: retryAfter,
             underlyingError: nil
@@ -76,7 +106,7 @@ public struct PIAAccountError: PIAError, Sendable {
     /// Creates an unauthorized error (401)
     public static func unauthorized() -> PIAAccountError {
         return PIAAccountError(
-            code: 401,
+            type: .http(status: 401),
             message: "Invalid credentials or authentication required",
             retryAfterSeconds: 0,
             underlyingError: nil
@@ -86,7 +116,7 @@ public struct PIAAccountError: PIAError, Sendable {
     /// Creates a network failure error (600)
     public static func networkFailure(_ error: Error) -> PIAAccountError {
         return PIAAccountError(
-            code: networkFailureCode,
+            type: .network,
             message: "Network request failed: \(error.localizedDescription)",
             retryAfterSeconds: 0,
             underlyingError: error
@@ -96,7 +126,7 @@ public struct PIAAccountError: PIAError, Sendable {
     /// Creates a decoding failure error (601)
     public static func decodingFailed(_ error: Error) -> PIAAccountError {
         return PIAAccountError(
-            code: 601,
+            type: .encoding,
             message: "Failed to decode response: \(error.localizedDescription)",
             retryAfterSeconds: 0,
             underlyingError: error
@@ -106,7 +136,7 @@ public struct PIAAccountError: PIAError, Sendable {
     /// Creates an encoding failure error (602)
     public static func encodingFailed(_ error: Error) -> PIAAccountError {
         return PIAAccountError(
-            code: 602,
+            type: .decoding,
             message: "Failed to encode request: \(error.localizedDescription)",
             retryAfterSeconds: 0,
             underlyingError: error
@@ -116,7 +146,7 @@ public struct PIAAccountError: PIAError, Sendable {
     /// Creates a configuration error (603)
     public static func configurationError(_ message: String) -> PIAAccountError {
         return PIAAccountError(
-            code: 603,
+            type: .configuration,
             message: message,
             retryAfterSeconds: 0,
             underlyingError: nil
@@ -126,7 +156,7 @@ public struct PIAAccountError: PIAError, Sendable {
     /// Creates a keychain error (604)
     public static func keychainError(_ message: String, osStatus: OSStatus) -> PIAAccountError {
         return PIAAccountError(
-            code: 604,
+            type: .keychain,
             message: "\(message) (status: \(osStatus))",
             retryAfterSeconds: 0,
             underlyingError: nil
@@ -136,7 +166,7 @@ public struct PIAAccountError: PIAError, Sendable {
     /// Creates a certificate pinning failure error (605)
     public static func certificatePinningFailed(_ reason: String) -> PIAAccountError {
         return PIAAccountError(
-            code: 605,
+            type: .certificatePinning,
             message: "Certificate pinning failed: \(reason)",
             retryAfterSeconds: 0,
             underlyingError: nil
@@ -177,8 +207,8 @@ public struct PIAMultipleErrors: PIAError, Sendable {
 
     // MARK: - PIAError
 
-    public var code: Int {
-        errors.first?.code ?? PIAAccountError.networkFailureCode
+    public var type: PIAErrorType {
+        errors.first?.type ?? .network
     }
 
     public var underlyingError: Error? {
@@ -194,7 +224,7 @@ public struct PIAMultipleErrors: PIAError, Sendable {
         if errors.count == 1, let first = errors.first {
             return first.errorDescription
         }
-        let codes = errors.map { String($0.code) }.joined(separator: ", ")
+        let codes = errors.map { String($0.type.code) }.joined(separator: ", ")
         return "Multiple endpoint failures (codes: \(codes))"
     }
 
@@ -208,30 +238,5 @@ public struct PIAMultipleErrors: PIAError, Sendable {
     /// Returns the primary error (first in the list)
     public var primaryError: PIAAccountError? {
         errors.first
-    }
-}
-
-// MARK: - HTTP Status Code Helpers
-
-extension PIAAccountError {
-    /// Checks if the error is a client error (4xx)
-    public var isClientError: Bool {
-        (400...499).contains(code)
-    }
-
-    /// Checks if the error is a server error (5xx)
-    public var isServerError: Bool {
-        (500...599).contains(code)
-    }
-
-    /// Checks if the error is a network/local error (600+)
-    public var isLocalError: Bool {
-        code >= PIAAccountError.networkFailureCode
-    }
-
-    /// Checks if the error suggests the request can be retried
-    public var isRetryable: Bool {
-        // Retry on server errors, timeout, and certain client errors
-        isServerError || code == 408 || code == 429 || isLocalError
     }
 }

--- a/LocalPackages/PIAAccount/Sources/PIAAccount/PIAAccountError.swift
+++ b/LocalPackages/PIAAccount/Sources/PIAAccount/PIAAccountError.swift
@@ -1,31 +1,9 @@
 import Foundation
 
-public enum PIAErrorType: Equatable, Sendable {
-    case network
-    case decoding
-    case encoding
-    case configuration
-    case keychain
-    case certificatePinning
-    case http(status: Int)
-
-    public var code: Int {
-        return switch self {
-        case .network: 600
-        case .decoding: 601
-        case .encoding: 602
-        case .configuration: 603
-        case .keychain: 604
-        case .certificatePinning: 605
-        case .http(let status): status
-        }
-    }
-}
-
 /// Base protocol for all PIA SDK errors
 public protocol PIAError: Error, LocalizedError {
     /// HTTP status code or custom error code
-    var type: PIAErrorType { get }
+    var type: PIAAccountErrorType { get }
 
     /// The underlying error that caused this error, if any
     var underlyingError: Error? { get }
@@ -34,10 +12,10 @@ public protocol PIAError: Error, LocalizedError {
 /// Error type for account-related operations
 public struct PIAAccountError: PIAError, Sendable {
     /// HTTP status code or custom error code (600+ for local errors)
-    public let type: PIAErrorType
+    public let type: PIAAccountErrorType
 
     /// Human-readable error message from the API or SDK
-    public let message: String?
+    public let message: String
 
     /// Number of seconds to wait before retrying (from Retry-After header)
     public let retryAfterSeconds: TimeInterval
@@ -46,8 +24,8 @@ public struct PIAAccountError: PIAError, Sendable {
     public let underlyingError: Error?
 
     public init(
-        type: PIAErrorType,
-        message: String?,
+        type: PIAAccountErrorType,
+        message: String,
         retryAfterSeconds: TimeInterval = 0,
         underlyingError: Error? = nil
     ) {
@@ -59,20 +37,7 @@ public struct PIAAccountError: PIAError, Sendable {
 
     // MARK: - LocalizedError
 
-    public var errorDescription: String? {
-        if let message = message {
-            return message
-        }
-        return switch type {
-        case .network: "Network failure"
-        case .decoding: "Decoding error"
-        case .encoding: "Encoding error"
-        case .configuration: "Configuration error"
-        case .keychain: "Keychain error"
-        case .certificatePinning: "Certificate pinning error"
-        case .http(let status): HTTPURLResponse.localizedString(forStatusCode: status)
-        }
-    }
+    public var errorDescription: String? { message }
 
     public var failureReason: String? {
         if retryAfterSeconds > 0 {
@@ -80,11 +45,6 @@ public struct PIAAccountError: PIAError, Sendable {
         }
         return nil
     }
-
-    // MARK: - Error Codes
-
-    /// Error code for network-level failures (not an HTTP status code)
-    public static let networkFailureCode = 600
 
     // MARK: - Factory Methods
 
@@ -97,7 +57,7 @@ public struct PIAAccountError: PIAError, Sendable {
         let message = data.flatMap { parseErrorMessage(from: $0) }
         return PIAAccountError(
             type: .http(status: status),
-            message: message,
+            message: message ?? HTTPURLResponse.localizedString(forStatusCode: status),
             retryAfterSeconds: retryAfter,
             underlyingError: nil
         )
@@ -126,7 +86,7 @@ public struct PIAAccountError: PIAError, Sendable {
     /// Creates a decoding failure error (601)
     public static func decodingFailed(_ error: Error) -> PIAAccountError {
         return PIAAccountError(
-            type: .encoding,
+            type: .decoding,
             message: "Failed to decode response: \(error.localizedDescription)",
             retryAfterSeconds: 0,
             underlyingError: error
@@ -136,7 +96,7 @@ public struct PIAAccountError: PIAError, Sendable {
     /// Creates an encoding failure error (602)
     public static func encodingFailed(_ error: Error) -> PIAAccountError {
         return PIAAccountError(
-            type: .decoding,
+            type: .encoding,
             message: "Failed to encode request: \(error.localizedDescription)",
             retryAfterSeconds: 0,
             underlyingError: error
@@ -207,7 +167,7 @@ public struct PIAMultipleErrors: PIAError, Sendable {
 
     // MARK: - PIAError
 
-    public var type: PIAErrorType {
+    public var type: PIAAccountErrorType {
         errors.first?.type ?? .network
     }
 

--- a/LocalPackages/PIAAccount/Sources/PIAAccount/PIAAccountError.swift
+++ b/LocalPackages/PIAAccount/Sources/PIAAccount/PIAAccountError.swift
@@ -162,7 +162,8 @@ public struct PIAMultipleErrors: PIAError, Sendable {
     public let errors: [PIAAccountError]
 
     public init(errors: [PIAAccountError]) {
-        self.errors = errors
+        // sort them by importance, highest first
+        self.errors = errors.sorted(using: KeyPathComparator(\.type.importance, order: .reverse))
     }
 
     // MARK: - PIAError

--- a/LocalPackages/PIAAccount/Sources/PIAAccount/PIAAccountErrorType.swift
+++ b/LocalPackages/PIAAccount/Sources/PIAAccount/PIAAccountErrorType.swift
@@ -22,4 +22,18 @@ public enum PIAAccountErrorType: Equatable, Sendable {
         case .http(let status): status
         }
     }
+
+    /// How imporant the error is, when ranking in ``PIAMultipleErrors``.
+    ///
+    /// HTTP status are more important, since they actually reached the server.
+    internal var importance: Int {
+        return switch self {
+        // rank 4xx higher because that's an actual response.
+        case .http(400..<500): 2000
+        // servers returning 5xx failed, ignoring them in favour of 4xx.
+        case .http(500..<600): 1000
+        // don't know how to rank the rest, but using code so they have a predictable order.
+        default: code
+        }
+    }
 }

--- a/LocalPackages/PIAAccount/Sources/PIAAccount/PIAAccountErrorType.swift
+++ b/LocalPackages/PIAAccount/Sources/PIAAccount/PIAAccountErrorType.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+/// Types of errors in Account SDK, including HTTP status codes.
+public enum PIAAccountErrorType: Equatable, Sendable {
+    case network
+    case decoding
+    case encoding
+    case configuration
+    case keychain
+    case certificatePinning
+    case http(status: Int)
+
+    /// Internal error code or HTTP status.
+    public var code: Int {
+        return switch self {
+        case .network: 600
+        case .decoding: 601
+        case .encoding: 602
+        case .configuration: 603
+        case .keychain: 604
+        case .certificatePinning: 605
+        case .http(let status): status
+        }
+    }
+}

--- a/LocalPackages/PIAAccount/Sources/PIAAccount/Utils/URLBuilder.swift
+++ b/LocalPackages/PIAAccount/Sources/PIAAccount/Utils/URLBuilder.swift
@@ -102,7 +102,7 @@ extension URLBuilder {
         case 500...599:
             // Server error response
             return true
-        case PIAAccountError.networkFailureCode...:
+        case PIAAccountErrorType.network.code...:
             // Unknown/local error response
             return true
         default:

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Account/AccountProvider.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Account/AccountProvider.swift
@@ -75,7 +75,7 @@ public protocol AccountProvider: AnyObject {
      - Parameter request: The login request.
      - Parameter callback: Returns an `UserAccount`.
      */
-    func login(with request: LoginRequest, _ callback: LibraryCallback<UserAccount>?)
+    func login(with request: LoginRequest, _ callback: @escaping ClientCallback<UserAccount>)
 
     /**
      Logs into system using the purchase receipt. The `isLoggedIn` variable becomes `true` on success.
@@ -87,7 +87,7 @@ public protocol AccountProvider: AnyObject {
      - Parameter request: The login receipt request.
      - Parameter callback: Returns an `UserAccount`.
      */
-    func login(with receiptRequest: LoginReceiptRequest, _ callback: LibraryCallback<UserAccount>?)
+    func login(with receiptRequest: LoginReceiptRequest, _ callback: @escaping ClientCallback<UserAccount>)
 
     /**
     Logs into system using the login link token directly. The `isLoggedIn` variable becomes `true` on success.
@@ -99,7 +99,7 @@ public protocol AccountProvider: AnyObject {
     - Parameter linkToken: A valid token.
     - Parameter callback: Returns an `UserAccount`.
     */
-    func login(with linkToken: String, _ callback: ((UserAccount?, Error?) -> Void)?)
+    func login(with linkToken: String, _ callback: @escaping ClientCallback<UserAccount>)
 
     /**
     Validates the QR token and generated a new API Token.
@@ -208,9 +208,9 @@ public protocol AccountProvider: AnyObject {
         Send a login link to the email provided as parameter.
 
         - Parameter email: The associated email to the account where the magic link is sent.
-        - Parameter callback: Returns `nil` on success.
+        - Parameter callback: Returns `.success(())` on success.
         */
-        func loginUsingMagicLink(withEmail email: String, _ callback: SuccessLibraryCallback?)
+        func loginUsingMagicLink(withEmail email: String, _ callback: @escaping SuccessClientCallback)
 
         /**
          Signs up with current purchase history.

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Account/DefaultAccountProvider.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Account/DefaultAccountProvider.swift
@@ -167,13 +167,15 @@ public final class DefaultAccountProvider: AccountProvider, ConfigurationAccess,
         }
     }
 
-    public func login(with receiptRequest: LoginReceiptRequest, _ callback: ((UserAccount?, Error?) -> Void)?) {
-        guard !isLoggedIn else {
-            callback?(currentUser, nil)
+    public func login(with receiptRequest: LoginReceiptRequest, _ callback: @escaping ClientCallback<UserAccount>) {
+        if isLoggedIn, let currentUser {
+            log.debug("User is already logged in, returning current user")
+            callback(.success(currentUser))
             return
         }
 
-        Task { @MainActor in
+        Task { @MainActor [weak self] in
+            guard let self else { return }
             let credentials = Credentials(username: "", password: "")
             ServiceQualityManager.shared.iapProcessingPurchaseEvent(origin: .restore)
 
@@ -181,43 +183,48 @@ public final class DefaultAccountProvider: AccountProvider, ConfigurationAccess,
                 try await webServices.token(receipt: receiptRequest.receipt)
                 ServiceQualityManager.shared.iapProcessingSuccessEvent(origin: .restore)
                 self.handleLoginResult(error: nil, credentials: credentials, callback: callback)
-            } catch {
+            } catch let error as ClientError {
                 ServiceQualityManager.shared.iapProcessingFailureEvent(origin: .restore, error: error)
                 self.handleLoginResult(error: error, credentials: credentials, callback: callback)
             }
         }
     }
 
-    public func login(with linkToken: String, _ callback: ((UserAccount?, Error?) -> Void)?) {
-        guard !isLoggedIn else {
-            callback?(currentUser, nil)
+    public func login(with linkToken: String, _ callback: @escaping ClientCallback<UserAccount>) {
+        if isLoggedIn, let currentUser {
+            log.debug("User is already logged in, returning current user")
+            callback(.success(currentUser))
             return
         }
 
-        Task { @MainActor in
+        Task { @MainActor [weak self] in
+            guard let self else { return }
             let credentials = Credentials(username: "", password: "")
 
             do {
                 try await webServices.migrateToken(token: linkToken)
                 self.handleLoginResult(error: nil, credentials: credentials, callback: callback)
-            } catch {
+            } catch let error as ClientError {
                 self.handleLoginResult(error: error, credentials: credentials, callback: callback)
             }
         }
     }
 
-    public func login(with request: LoginRequest, _ callback: ((UserAccount?, Error?) -> Void)?) {
-        guard !isLoggedIn else {
-            callback?(currentUser, nil)
+    public func login(with request: LoginRequest, _ callback: @escaping ClientCallback<UserAccount>) {
+        if isLoggedIn, let currentUser {
+            log.debug("User is already logged in, returning current user")
+            callback(.success(currentUser))
             return
         }
 
-        Task { @MainActor in
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+
             do {
                 try await webServices.token(credentials: request.credentials)
-                handleLoginResult(error: nil, credentials: request.credentials, callback: callback)
-            } catch {
-                handleLoginResult(error: error, credentials: request.credentials, callback: callback)
+                self.handleLoginResult(error: nil, credentials: request.credentials, callback: callback)
+            } catch let error as ClientError {
+                self.handleLoginResult(error: error, credentials: request.credentials, callback: callback)
             }
         }
     }
@@ -233,43 +240,47 @@ public final class DefaultAccountProvider: AccountProvider, ConfigurationAccess,
         }
     }
 
-    private func handleLoginResult(error: Error?, credentials: Credentials, callback: ((UserAccount?, Error?) -> Void)?) {
-        guard error == nil else {
-            DispatchQueue.main.async { callback?(nil, error) }
+    private func handleLoginResult(
+        error: ClientError?,
+        credentials: Credentials,
+        callback: @escaping ClientCallback<UserAccount>
+    ) {
+        if let error {
+            DispatchQueue.main.async { callback(.failure(error)) }
             return
         }
 
         guard vpnToken != nil else {
-            DispatchQueue.main.async { callback?(nil, ClientError.unauthorized) }
+            DispatchQueue.main.async { callback(.failure(ClientError.unauthorized)) }
             return
         }
 
-        self.updateUser(credentials: credentials) { userAccount, error in
-            if let userAccount = userAccount {
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            let result = await self.updateUser(credentials: credentials)
+            if case let .success(userAccount) = result {
                 Macros.postNotification(.PIAAccountDidLogin, [.user: userAccount])
             }
-            callback?(userAccount, error)
+            DispatchQueue.main.async { callback(result) }
         }
     }
 
-    private func updateUser(credentials: Credentials, callback: ((UserAccount?, Error?) -> Void)?) {
+    private func updateUser(credentials: Credentials) async -> ClientResult<UserAccount> {
         self.updateUsernamePassword()
-        self.updateUserAccount(credentials: credentials, callback: callback)
+        return await updateUserAccount(credentials: credentials)
     }
 
-    private func updateUserAccount(credentials: Credentials, callback: ((UserAccount?, Error?) -> Void)?) {
-        Task { @MainActor in
-            do {
-                let accountInfo = try await self.webServices.info()
-                self.accessedDatabase.plain.accountInfo = accountInfo
-                self.accessedDatabase.secure.setPublicUsername(accountInfo.username)
-                let userAccount = UserAccount(credentials: credentials, info: accountInfo)
-                DispatchQueue.main.async { callback?(userAccount, nil) }
-            } catch {
-                try? await self.webServices.logout()
-                self.cleanDatabase()
-                DispatchQueue.main.async { callback?(nil, ClientError.unauthorized) }
-            }
+    private func updateUserAccount(credentials: Credentials) async -> ClientResult<UserAccount> {
+        do {
+            let accountInfo = try await self.webServices.info()
+            self.accessedDatabase.plain.accountInfo = accountInfo
+            self.accessedDatabase.secure.setPublicUsername(accountInfo.username)
+            let userAccount = UserAccount(credentials: credentials, info: accountInfo)
+            return .success(userAccount)
+        } catch {
+            try? await self.webServices.logout()
+            self.cleanDatabase()
+            return .failure(error)
         }
     }
 
@@ -471,13 +482,13 @@ public final class DefaultAccountProvider: AccountProvider, ConfigurationAccess,
             }
         }
 
-        public func loginUsingMagicLink(withEmail email: String, _ callback: SuccessLibraryCallback?) {
+        public func loginUsingMagicLink(withEmail email: String, _ callback: @escaping SuccessClientCallback) {
             Task { @MainActor in
                 do {
                     try await webServices.loginLink(email: email)
-                    DispatchQueue.main.async { callback?(nil) }
-                } catch {
-                    DispatchQueue.main.async { callback?(error) }
+                    DispatchQueue.main.async { callback(.success(())) }
+                } catch let error as ClientError {
+                    DispatchQueue.main.async { callback(.failure(error)) }
                 }
             }
         }

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Account/EphemeralAccountProvider.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Account/EphemeralAccountProvider.swift
@@ -52,11 +52,11 @@ final class EphemeralAccountProvider: AccountProvider, ProvidersAccess, InAppAcc
         return nil
     }
 
-    func login(with request: LoginRequest, _ callback: ClientCallback<UserAccount>) {
+    func login(with request: LoginRequest, _ callback: @escaping ClientCallback<UserAccount>) {
         log.error("Not implemented")
     }
 
-    func login(with receiptRequest: LoginReceiptRequest, _ callback: ClientCallback<UserAccount>) {
+    func login(with receiptRequest: LoginReceiptRequest, _ callback: @escaping ClientCallback<UserAccount>) {
         log.error("Not implemented")
     }
 
@@ -72,7 +72,7 @@ final class EphemeralAccountProvider: AccountProvider, ProvidersAccess, InAppAcc
         log.error("Not implemented")
     }
 
-    func login(with token: String, _ callback: ClientCallback<UserAccount>) {
+    func login(with token: String, _ callback: @escaping ClientCallback<UserAccount>) {
         log.error("Not implemented")
     }
 

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Account/EphemeralAccountProvider.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Account/EphemeralAccountProvider.swift
@@ -52,11 +52,11 @@ final class EphemeralAccountProvider: AccountProvider, ProvidersAccess, InAppAcc
         return nil
     }
 
-    func login(with request: LoginRequest, _ callback: ((UserAccount?, Error?) -> Void)?) {
+    func login(with request: LoginRequest, _ callback: ClientCallback<UserAccount>) {
         log.error("Not implemented")
     }
 
-    func login(with receiptRequest: LoginReceiptRequest, _ callback: ((UserAccount?, Error?) -> Void)?) {
+    func login(with receiptRequest: LoginReceiptRequest, _ callback: ClientCallback<UserAccount>) {
         log.error("Not implemented")
     }
 
@@ -72,11 +72,11 @@ final class EphemeralAccountProvider: AccountProvider, ProvidersAccess, InAppAcc
         log.error("Not implemented")
     }
 
-    func login(with token: String, _ callback: ((UserAccount?, Error?) -> Void)?) {
+    func login(with token: String, _ callback: ClientCallback<UserAccount>) {
         log.error("Not implemented")
     }
 
-    func loginUsingMagicLink(withEmail email: String, _ callback: SuccessLibraryCallback?) {
+    func loginUsingMagicLink(withEmail email: String, _ callback: @escaping SuccessClientCallback) {
         log.error("Not implemented")
     }
 

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/ClientError.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/ClientError.swift
@@ -28,6 +28,9 @@ public enum ClientError: Error, Equatable {
     /// The Internet is unreachable.
     case internetUnreachable
 
+    /// Our backend is down, or returning 5xx errors.
+    case backendUnavailable
+
     /// The service has been denied authorization.
     case unauthorized
 
@@ -64,48 +67,46 @@ public enum ClientError: Error, Equatable {
     /// Operation was interrupted by the user. Can be ignored most of the time.
     case userCancelled
 
-    /// Internal error in the `mobile-shared-account` library (code 600)
-    case libraryError(message: String?)
+    /// Internal error in the `mobile-shared-account` library (code 6xx)
+    case libraryError(code: Int, message: String)
+
+    /// No in-app history receipt is available.
+    case noReceipt
+
+    /// The in-app history receipt is not eligible for a plan or is corrupt.
+    case badReceipt
+
+    /// The selected in-app product is not available.
+    case productUnavailable
+
+    /// The redeem code is invalid.
+    case redeemInvalid
+
+    /// The redeem code was claimed already.
+    case redeemClaimed
+
+    /// Trial accounts are not renewable.
+    case renewingTrial
+
+    /// The account is not renewable.
+    case renewingNonRenewable
+
+    /// Invalid parameter
+    case invalidParameter
+
+    /// The selected sandbox subscription is not available in production.
+    case sandboxPurchase
+
+    /// The purchase is pending external action (e.g. "Ask to Buy" approval or SCA).
+    /// The transaction will be delivered later through `Transaction.updates`.
+    case purchasePending
+
+    /// Cant retrieve regions
+    case noRegions
+
+    /// No servers available
+    case noServersAvailable
 
     /// Unknown error
-    case unknown(code: Int, message: String?)
-
-    #if os(iOS) || os(tvOS)
-        /// No in-app history receipt is available.
-        case noReceipt
-
-        /// The in-app history receipt is not eligible for a plan or is corrupt.
-        case badReceipt
-
-        /// The selected in-app product is not available.
-        case productUnavailable
-
-        /// The redeem code is invalid.
-        case redeemInvalid
-
-        /// The redeem code was claimed already.
-        case redeemClaimed
-
-        /// Trial accounts are not renewable.
-        case renewingTrial
-
-        /// The account is not renewable.
-        case renewingNonRenewable
-
-        /// Invalid parameter
-        case invalidParameter
-
-        /// The selected sandbox subscription is not available in production.
-        case sandboxPurchase
-
-        /// The purchase is pending external action (e.g. "Ask to Buy" approval or SCA).
-        /// The transaction will be delivered later through `Transaction.updates`.
-        case purchasePending
-
-        /// Cant retrieve regions
-        case noRegions
-
-        /// No servers available
-        case noServersAvailable
-    #endif
+    case unknown(code: Int, message: String)
 }

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/ClientError.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/ClientError.swift
@@ -28,7 +28,7 @@ public enum ClientError: Error, Equatable {
     /// The Internet is unreachable.
     case internetUnreachable
 
-    /// Our backend is down, or returning 5xx errors.
+    /// Our backend is down, timing out, or returning 5xx errors.
     case backendUnavailable
 
     /// The service has been denied authorization.

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Daemons/ServersDaemon.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Daemons/ServersDaemon.swift
@@ -250,7 +250,7 @@ internal actor ServersDaemon: Daemon, ConfigurationAccess, DatabaseAccess, Provi
         let watchdog = Task { [downloadTimeout] in
             try? await Task.sleep(nanoseconds: downloadTimeout)
             log.error("Servers download did not call back within the timeout")
-            outcome.resume(with: (nil, ClientError.libraryError(message: "Servers download timed out")))
+            outcome.resume(with: (nil, ClientError.noServersAvailable))
         }
 
         let result = await outcome.value()

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/LibraryCallback.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/LibraryCallback.swift
@@ -27,3 +27,14 @@ public typealias LibraryCallback<T> = (T?, Error?) -> Void
 
 /// A simple callback returning `nil` on success and `Error` on failure.
 public typealias SuccessLibraryCallback = (Error?) -> Void
+
+// MARK: ClientError
+
+/// Result that contains either value `T` or error ``ClientError``.
+public typealias ClientResult<T> = Result<T, ClientError>
+
+/// Callback that returns either a value or a ``ClientError``.
+public typealias ClientCallback<T> = (ClientResult<T>) -> Void
+
+/// Simple callback that doesn't return a value, but can return a ``ClientError``.
+public typealias SuccessClientCallback = ClientCallback<Void>

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Mock/MockAccountProvider.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Mock/MockAccountProvider.swift
@@ -217,25 +217,25 @@ public final class MockAccountProvider: AccountProvider, WebServicesConsumer {
         }
     #endif
 
-    public func login(with request: LoginRequest, _ callback: ((UserAccount?, Error?) -> Void)?) {
+    public func login(with request: LoginRequest, _ callback: @escaping ClientCallback<UserAccount>) {
         guard !mockIsUnauthorized else {
-            callback?(nil, ClientError.unauthorized)
+            callback(.failure(ClientError.unauthorized))
             return
         }
         delegate.login(with: request, callback)
     }
 
-    public func login(with receiptRequest: LoginReceiptRequest, _ callback: LibraryCallback<UserAccount>?) {
+    public func login(with receiptRequest: LoginReceiptRequest, _ callback: @escaping ClientCallback<UserAccount>) {
         guard !mockIsUnauthorized else {
-            callback?(nil, ClientError.unauthorized)
+            callback(.failure(ClientError.unauthorized))
             return
         }
         delegate.login(with: receiptRequest, callback)
     }
 
-    public func login(with token: String, _ callback: ((UserAccount?, Error?) -> Void)?) {
+    public func login(with token: String, _ callback: @escaping ClientCallback<UserAccount>) {
         guard !mockIsUnauthorized else {
-            callback?(nil, ClientError.unauthorized)
+            callback(.failure(ClientError.unauthorized))
             return
         }
         delegate.login(with: "12345", callback)
@@ -300,7 +300,7 @@ public final class MockAccountProvider: AccountProvider, WebServicesConsumer {
             return await delegate.restorePurchases()
         }
 
-        public func loginUsingMagicLink(withEmail email: String, _ callback: SuccessLibraryCallback?) {
+        public func loginUsingMagicLink(withEmail email: String, _ callback: @escaping SuccessClientCallback) {
             delegate.loginUsingMagicLink(withEmail: email, callback)
         }
 

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Mock/MockWebServices.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Mock/MockWebServices.swift
@@ -43,13 +43,13 @@ final class MockWebServices: WebServices {
 
     var apiToken: String?
 
-    func migrateToken(token: String) async throws {}
+    func migrateToken(token: String) async throws(ClientError) {}
 
-    func token(credentials: Credentials) async throws {}
+    func token(credentials: Credentials) async throws(ClientError) {}
 
-    func token(receipt: JWS) async throws {}
+    func token(receipt: JWS) async throws(ClientError) {}
 
-    func info() async throws -> AccountInfo {
+    func info() async throws(ClientError) -> AccountInfo {
         let result = accountInfo?()
         let error: ClientError? = (result == nil) ? .unsupported : nil
 
@@ -64,7 +64,7 @@ final class MockWebServices: WebServices {
 
     func update(credentials: Credentials, resetPassword reset: Bool, email: String) async throws {}
 
-    func loginLink(email: String) async throws {}
+    func loginLink(email: String) async throws(ClientError) {}
 
     func logout() async throws {}
 

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/ServiceQuality/ServiceQualityManager.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/ServiceQuality/ServiceQualityManager.swift
@@ -299,7 +299,7 @@ public final class ServiceQualityManager: NSObject {
             switch clientError {
             case .unknown(let code, _): return "unknown_\(code)"
             case .throttled(let retryAfter): return "throttled_\(retryAfter)"
-            case .libraryError: return "library_error"
+            case .libraryError(let code, _): return "library_error_\(code)"
             default: return String(describing: clientError)
             }
         default:
@@ -319,10 +319,8 @@ public final class ServiceQualityManager: NSObject {
         ]
         if let clientError = error as? ClientError {
             switch clientError {
-            case .unknown(_, let message), .libraryError(let message):
-                if let message {
-                    details[KPIIapPropertyKey.internalError.rawValue] = message
-                }
+            case .unknown(_, let message), .libraryError(_, let message):
+                details[KPIIapPropertyKey.internalError.rawValue] = message
             default:
                 break
             }

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/WebServices/PIAWebServices.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/WebServices/PIAWebServices.swift
@@ -177,12 +177,12 @@ final class PIAWebServices: WebServices, ConfigurationAccess {
             return .throttled(retryAfter: UInt(retryAfter))
         case .http(500..<600):
             return .backendUnavailable
+        case .http(let status):
+            return .unknown(code: status, message: error.localizedDescription)
         case .network:
             return .internetUnreachable
         case let type:
             return .libraryError(code: type.code, message: error.localizedDescription)
-        default:
-            return .unknown(code: 0, message: error.localizedDescription)
         }
     }
 

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/WebServices/PIAWebServices.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/WebServices/PIAWebServices.swift
@@ -180,7 +180,7 @@ final class PIAWebServices: WebServices, ConfigurationAccess {
         case .http(let status):
             return .unknown(code: status, message: error.localizedDescription)
         case .network:
-            return .internetUnreachable
+            return .backendUnavailable
         case let type:
             return .libraryError(code: type.code, message: error.localizedDescription)
         }

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/WebServices/PIAWebServices.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/WebServices/PIAWebServices.swift
@@ -115,21 +115,17 @@ final class PIAWebServices: WebServices, ConfigurationAccess {
         return self.nativeAccountAPI.syncApiToken
     }
 
-    /***
-     Generates a new auth expiring token based on a previous non-expiry one.
-     */
-    func migrateToken(token: String) async throws {
+    /// Generates a new auth expiring token based on a previous non-expiry one.
+    func migrateToken(token: String) async throws(ClientError) {
         do {
             try await nativeAccountAPI.migrateApiToken(apiToken: token)
         } catch {
-            throw ClientError.unauthorized
+            throw mapNativeLoginError(error)
         }
     }
 
-    /***
-     Generates a new auth token for the specific user
-     */
-    func token(credentials: Credentials) async throws {
+    /// Generates a new auth token for the specific user
+    func token(credentials: Credentials) async throws(ClientError) {
         do {
             try await nativeAccountAPI.loginWithCredentials(
                 username: credentials.username,
@@ -151,69 +147,57 @@ final class PIAWebServices: WebServices, ConfigurationAccess {
         }
     }
 
-    /***
-     Generates a new auth token for the specific user
-     */
-    func token(receipt: JWS) async throws {
+    /// Generates a new auth token for the specific user
+    func token(receipt: JWS) async throws(ClientError) {
         do {
             try await nativeAccountAPI.loginWithReceipt(receipt: receipt)
-            try handleLoginResponse(error: nil, mapError: mapNativeLoginFromReceiptError)
         } catch {
-            try handleLoginResponse(error: error, mapError: mapNativeLoginFromReceiptError)
-        }
-    }
-
-    private func handleLoginResponse(
-        error: Error?,
-        mapError: ((Error) -> (ClientError))
-    ) throws {
-        if let error {
-            throw mapError(error)
+            throw mapNativeLoginFromReceiptError(error)
         }
     }
 
     // MARK: - Error mapping
 
     private func mapNativeLoginError(_ error: Error) -> ClientError {
-        let code = (error as? PIAAccountError)?.code ?? (error as? PIAMultipleErrors)?.code
-        log.debug("\(#function) code: \(code ?? 0) error: \(error)")
-        switch code ?? 0 {
-        case 402:
+        guard let error = error as? PIAError else {
+            return .unknown(code: 0, message: error.localizedDescription)
+        }
+
+        log.debug("\(#function) code: \(error.type) error: \(error)")
+
+        switch error.type {
+        case .http(400):
+            return .invalidParameter
+        case .http(401), .http(403):
+            return .unauthorized
+        case .http(402):
             return .expired
-        case 429:
+        case .http(429):
             let retryAfter = (error as? PIAAccountError)?.retryAfterSeconds ?? 0
             return .throttled(retryAfter: UInt(retryAfter))
-        case 500..<600:
-            return .noServersAvailable
-        case PIAAccountError.networkFailureCode:
+        case .http(500..<600):
+            return .backendUnavailable
+        case .network:
             return .internetUnreachable
+        case let type:
+            return .libraryError(code: type.code, message: error.localizedDescription)
         default:
-            return .unauthorized
+            return .unknown(code: 0, message: error.localizedDescription)
         }
     }
 
     private func mapNativeLoginFromReceiptError(_ error: Error) -> ClientError {
-        let code = (error as? PIAAccountError)?.code ?? (error as? PIAMultipleErrors)?.code
-        switch code {
+        let type = (error as? PIAError)?.type
+        switch type {
         // Errors that indicate the receipt is either invalid or expired
-        case 400, 401:
+        case .http(400), .http(401):
             return .badReceipt
         default:
             return mapNativeLoginError(error)
         }
     }
 
-    private func mapNativeLoginLinkError(_ error: Error) -> ClientError {
-        let code = (error as? PIAAccountError)?.code ?? (error as? PIAMultipleErrors)?.code
-        switch code {
-        case 401, 402, 429:
-            return mapNativeLoginError(error)
-        default:
-            return .invalidParameter
-        }
-    }
-
-    func info() async throws -> AccountInfo {
+    func info() async throws(ClientError) -> AccountInfo {
         do {
             let account = try await nativeAccountAPI.accountDetails()
             return AccountInfo(accountInformation: account)
@@ -233,11 +217,11 @@ final class PIAWebServices: WebServices, ConfigurationAccess {
         }
     }
 
-    func loginLink(email: String) async throws {
+    func loginLink(email: String) async throws(ClientError) {
         do {
             try await nativeAccountAPI.loginLink(email: email)
         } catch {
-            throw mapNativeLoginLinkError(error)
+            throw mapNativeLoginError(error)
         }
     }
 
@@ -282,8 +266,8 @@ final class PIAWebServices: WebServices, ConfigurationAccess {
                 }
             } catch {
                 log.error("Failed to signup: \(error)")
-                let code = (error as? PIAAccountError)?.code ?? (error as? PIAMultipleErrors)?.code
-                throw code == 400 ? ClientError.badReceipt : ClientError.invalidParameter
+                let type = (error as? PIAError)?.type
+                throw type == .http(status: 400) ? ClientError.badReceipt : ClientError.invalidParameter
             }
         }
 
@@ -393,18 +377,7 @@ final class PIAWebServices: WebServices, ConfigurationAccess {
             return info
         } catch {
             log.warning("Failed to fetch subscription information: \(error)")
-            let code = (error as? PIAAccountError)?.code ?? (error as? PIAMultipleErrors)?.code
-            switch code {
-            case 400:
-                throw ClientError.badReceipt
-            case 401:
-                throw ClientError.unauthorized
-            case 600:
-                throw ClientError.libraryError(message: error.localizedDescription)
-            case let code:
-                log.warning("Unhandled error code: \(code ?? 0)")
-                throw ClientError.invalidParameter
-            }
+            throw mapNativeLoginError(error)
         }
     }
 }

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/WebServices/WebServices.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/WebServices/WebServices.swift
@@ -31,19 +31,19 @@ protocol WebServices: AnyObject {
 
     // MARK: Account
 
-    func migrateToken(token: String) async throws
+    func migrateToken(token: String) async throws(ClientError)
 
-    func token(credentials: Credentials) async throws
+    func token(credentials: Credentials) async throws(ClientError)
 
-    func token(receipt: JWS) async throws
+    func token(receipt: JWS) async throws(ClientError)
 
     func validateLoginQR(qrToken: String) async throws -> String
 
-    func info() async throws -> AccountInfo
+    func info() async throws(ClientError) -> AccountInfo
 
     func update(credentials: Credentials, resetPassword reset: Bool, email: String) async throws
 
-    func loginLink(email: String) async throws
+    func loginLink(email: String) async throws(ClientError)
 
     /// The token to use for protocol authentication.
     var vpnToken: String? { get }

--- a/LocalPackages/PIALibrary/Tests/PIALibraryTests/AccountInfoTests.swift
+++ b/LocalPackages/PIALibrary/Tests/PIALibraryTests/AccountInfoTests.swift
@@ -80,17 +80,18 @@ class AccountInfoTests: XCTestCase {
         let expLogin = expectation(description: "login")
         let credentials = Credentials(username: "p0000000", password: "foobarbogus")
 
-        Client.providers.accountProvider.login(with: LoginRequest(credentials: credentials)) { (user, error) in
-            guard let _ = user else {
-                print("Login error: \(error!)")
+        Client.providers.accountProvider.login(with: LoginRequest(credentials: credentials)) { result in
+            switch result {
+            case .failure(let error):
+                print("Login error: \(error)")
                 expLogin.fulfill()
                 XCTAssert(false)
-                return
+            case .success(let user):
+                XCTAssert(factory.accountProvider.isLoggedIn)
+                XCTAssertEqual(user.isRenewable, false)
+                XCTAssertEqual(user.info?.isRecurring, true)
+                expLogin.fulfill()
             }
-            XCTAssert(factory.accountProvider.isLoggedIn)
-            XCTAssertEqual(user?.isRenewable, false)
-            XCTAssertEqual(user?.info?.isRecurring, true)
-            expLogin.fulfill()
         }
         waitForExpectations(timeout: 5.0, handler: nil)
 

--- a/LocalPackages/PIALibrary/Tests/PIALibraryTests/AccountTests.swift
+++ b/LocalPackages/PIALibrary/Tests/PIALibraryTests/AccountTests.swift
@@ -81,29 +81,22 @@ class AccountTests: XCTestCase {
 
     }
 
-    /*func testWeb() {
-        __testLogin(factory: live)
-        sleep(1)
-        __testUpdate(factory: live)
-        sleep(1)
-        __testLogout(factory: live)
-    }*/
-
     private func __testLogin(factory: Client.Providers) {
         let expLogin = expectation(description: "login")
         let credentials = Credentials(username: "p0000000", password: "foobarbogus")
 
-        factory.accountProvider.login(with: LoginRequest(credentials: credentials)) { (user, error) in
-            guard let _ = user else {
-                print("Login error: \(error!)")
+        factory.accountProvider.login(with: LoginRequest(credentials: credentials)) { result in
+            switch result {
+            case .failure(let error):
+                print("Login error: \(error)")
                 expLogin.fulfill()
                 XCTAssert(false)
-                return
+            case .success:
+                XCTAssert(factory.accountProvider.isLoggedIn)
+                XCTAssertNotNil(factory.accountProvider.currentUser)
+                print("Logged in with: \(factory.accountProvider.currentUser)")
+                expLogin.fulfill()
             }
-            XCTAssert(factory.accountProvider.isLoggedIn)
-            XCTAssertNotNil(factory.accountProvider.currentUser)
-            print("Logged in with: \(factory.accountProvider.currentUser)")
-            expLogin.fulfill()
         }
         waitForExpectations(timeout: 5.0, handler: nil)
     }

--- a/LocalPackages/PIALocalizations/Sources/PIALocalizations/Generated/L10n.swift
+++ b/LocalPackages/PIALocalizations/Sources/PIALocalizations/Generated/L10n.swift
@@ -1155,9 +1155,9 @@ public enum L10n {
       public static let submit = L10n.tr("Localizable", "signup.failure.submit", fallback: "GO BACK")
       /// Account creation failed
       public static let title = L10n.tr("Localizable", "signup.failure.title", fallback: "Account creation failed")
-      /// Unknown error: %s (%d)
-      public static func unknown(_ p1: UnsafePointer<CChar>, _ p2: Int) -> String {
-        return L10n.tr("Localizable", "signup.failure.unknown", p1, p2, fallback: "Unknown error: %s (%d)")
+      /// Unknown error: %@ (%d)
+      public static func unknown(_ p1: Any, _ p2: Int) -> String {
+        return L10n.tr("Localizable", "signup.failure.unknown", String(describing: p1), p2, fallback: "Unknown error: %@ (%d)")
       }
       /// Sign-up failed
       public static let vcTitle = L10n.tr("Localizable", "signup.failure.vc_title", fallback: "Sign-up failed")
@@ -1827,6 +1827,8 @@ public enum L10n {
       /// Sign in to your account
       public static let title = L10n.tr("Localizable", "welcome.login.title", fallback: "Sign in to your account")
       public enum Error {
+        /// Our server is unavailable at the moment. Please try again later.
+        public static let backendUnavailable = L10n.tr("Localizable", "welcome.login.error.backendUnavailable", fallback: "Our server is unavailable at the moment. Please try again later.")
         /// Too many failed login attempts with this username. Please try again after %@ second(s).
         public static func throttled(_ p1: Any) -> String {
           return L10n.tr("Localizable", "welcome.login.error.throttled", String(describing: p1), fallback: "Too many failed login attempts with this username. Please try again after %@ second(s).")

--- a/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/ar.lproj/Localizable.strings
+++ b/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/ar.lproj/Localizable.strings
@@ -612,6 +612,7 @@
 "welcome.login.error.validation"= "يجب إدخال اسم المستخدم وكلمة المرور";
 "welcome.login.error.unauthorized"= "اسم المستخدم أو كلمة المرور غير صحيحة.";
 "welcome.login.error.throttled"= "Too many failed login attempts with this username. Please try again after %@ second(s).";
+"welcome.login.error.backendUnavailable"= "خادمنا غير متاح في الوقت الحالي. يرجى المحاولة مرة أخرى لاحقاً.";
 "welcome.login.receipt.button"= "تسجيل الدخول باستخدام إيصال الشراء";
 "welcome.login.magic.link.title"= "تسجيل الدخول باستخدام رابط البريد الإلكتروني السحري";
 "welcome.login.magic.link.response"= "يرجى إلقاء نظرة على بريدك الإلكتروني للحصول على رابط تسجيل الدخول.";

--- a/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/ar.lproj/Localizable.strings
+++ b/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/ar.lproj/Localizable.strings
@@ -546,7 +546,7 @@
 "signup.failure.redeem.claimed.message"= "يبدو أن هذه البطاقة استُخدمت في حساب آخر. حاول إدخال رمز جديد.";
 "signup.failure.submit"= "عودة";
 "signup.failure.internal"= "خطأ داخلي في التطبيق (%d)";
-"signup.failure.unknown"= "خطأ غير معروف: %s (%d)";
+"signup.failure.unknown"= "خطأ غير معروف: %@ (%d)";
 
 "signup.unreachable.vc_title"= "خطأ";
 "signup.unreachable.title"= "أوبس!";

--- a/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/da.lproj/Localizable.strings
+++ b/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/da.lproj/Localizable.strings
@@ -612,6 +612,7 @@ Du har altid kontrollen. Du kan se, hvilke data vi har indsamlet, under Indstill
 "welcome.login.error.validation"= "Du skal indtaste et brugernavn og et kodeord.";
 "welcome.login.error.unauthorized"= "Dit brugernavn eller kodeord er forkert.";
 "welcome.login.error.throttled"= "Too many failed login attempts with this username. Please try again after %@ second(s).";
+"welcome.login.error.backendUnavailable"= "Vores server er i øjeblikket utilgængelig. Prøv igen senere.";
 "welcome.login.receipt.button"= "Log på med købskvittering";
 "welcome.login.magic.link.title"= "Log ind ved hjælp af magisk e-maillink";
 "welcome.login.magic.link.response"= "Se i din e-mail for et login-link.";

--- a/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/da.lproj/Localizable.strings
+++ b/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/da.lproj/Localizable.strings
@@ -546,7 +546,7 @@
 "signup.failure.redeem.claimed.message"= "Det ser ud til, at dette kort allerede er taget af en anden konto. Prøv at indtaste en anden pinkode.";
 "signup.failure.submit"= "GÅ TILBAGE";
 "signup.failure.internal"= "Intern app-fejl (%d)";
-"signup.failure.unknown"= "Ukendt fejl: %s (%d)";
+"signup.failure.unknown"= "Ukendt fejl: %@ (%d)";
 
 "signup.unreachable.vc_title"= "Fejl";
 "signup.unreachable.title"= "Ups!";

--- a/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/de.lproj/Localizable.strings
+++ b/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/de.lproj/Localizable.strings
@@ -546,7 +546,7 @@
 "signup.failure.redeem.claimed.message"= "Anscheinend wurde diese Karte bereits über ein anderes Konto eingelöst. Geben Sie eine andere PIN ein.";
 "signup.failure.submit"= "ZURÜCK";
 "signup.failure.internal"= "Interner App-Fehler (%d)";
-"signup.failure.unknown"= "Unbekannter Fehler: %s (%d)";
+"signup.failure.unknown"= "Unbekannter Fehler: %@ (%d)";
 
 "signup.unreachable.vc_title"= "Fehler";
 "signup.unreachable.title"= "Ups!";

--- a/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/de.lproj/Localizable.strings
+++ b/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/de.lproj/Localizable.strings
@@ -612,6 +612,7 @@ Sie haben immer die Kontrolle. In den Einstellungen können Sie sehen, welche Da
 "welcome.login.error.validation"= "Du musst einen Benutzernamen und ein Passwort angeben.";
 "welcome.login.error.unauthorized"= "Dein Benutzername oder Passwort ist falsch.";
 "welcome.login.error.throttled"= "Too many failed login attempts with this username. Please try again after %@ second(s).";
+"welcome.login.error.backendUnavailable"= "Unser Server ist derzeit nicht verfügbar. Bitte versuche es später erneut.";
 "welcome.login.receipt.button"= "Anmeldung mit Kaufbeleg";
 "welcome.login.magic.link.title"= "Anmeldung mit magischem E-Mail-Link";
 "welcome.login.magic.link.response"= "Bitte überprüfen Sie Ihre E-Mail auf einen Login-Link.";

--- a/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/en.lproj/Localizable.strings
+++ b/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/en.lproj/Localizable.strings
@@ -546,7 +546,7 @@
 "signup.failure.redeem.claimed.message"= "Looks like this card has already been claimed by another account. You can try entering a different PIN.";
 "signup.failure.submit"= "GO BACK";
 "signup.failure.internal"= "Internal app error (%d)";
-"signup.failure.unknown"= "Unknown error: %s (%d)";
+"signup.failure.unknown"= "Unknown error: %@ (%d)";
 
 "signup.unreachable.vc_title"= "Error";
 "signup.unreachable.title"= "Whoops!";
@@ -659,6 +659,7 @@ You will always be in control. You can see what data we’ve collected from Sett
 "welcome.login.error.validation"= "You must enter a username and password.";
 "welcome.login.error.unauthorized"= "Your username or password is incorrect.";
 "welcome.login.error.throttled"= "Too many failed login attempts with this username. Please try again after %@ second(s).";
+"welcome.login.error.backendUnavailable"= "Our server is unavailable at the moment. Please try again later.";
 "welcome.login.receipt.button"= "Login using purchase receipt";
 "welcome.login.magic.link.title"= "Login using magic email link";
 "welcome.login.magic.link.response"= "Please check your e-mail for a login link.";

--- a/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/es-MX.lproj/Localizable.strings
+++ b/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/es-MX.lproj/Localizable.strings
@@ -546,7 +546,7 @@
 "signup.failure.redeem.claimed.message"= "Parece que esta tarjeta ha sido reclamada por otra cuenta. Puedes intentar ingresar un PIN diferente.";
 "signup.failure.submit"= "ATRÁS";
 "signup.failure.internal"= "Error interno de la aplicación (%d)";
-"signup.failure.unknown"= "Error desconocido: %s (%d)";
+"signup.failure.unknown"= "Error desconocido: %@ (%d)";
 
 "signup.unreachable.vc_title"= "Error";
 "signup.unreachable.title"= "¡Ups!";

--- a/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/es-MX.lproj/Localizable.strings
+++ b/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/es-MX.lproj/Localizable.strings
@@ -612,6 +612,7 @@ Siempre tendrás el control. Puedes ver los datos que hemos recopilado desde los
 "welcome.login.error.validation"= "Debe ingresar un nombre de usuario y una contraseña.";
 "welcome.login.error.unauthorized"= "Tu nombre de usuario o contraseña son incorrectos.";
 "welcome.login.error.throttled"= "Too many failed login attempts with this username. Please try again after %@ second(s).";
+"welcome.login.error.backendUnavailable"= "Nuestro servidor no está disponible en este momento. Por favor, inténtalo de nuevo más tarde.";
 "welcome.login.receipt.button"= "Inicia sesión con el recibo de compra";
 "welcome.login.magic.link.title"= "Inicia sesión con el vínculo mágico del correo electrónico.";
 "welcome.login.magic.link.response"= "Busca en tu correo electrónico un enlace de inicio de sesión.";

--- a/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/fr.lproj/Localizable.strings
+++ b/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/fr.lproj/Localizable.strings
@@ -612,6 +612,7 @@ Vous gardez toujours le contrôle. Vous pouvez consulter les données que nous a
 "welcome.login.error.validation"= "Vous devez saisir un nom d'utilisateur et un mot de passe.";
 "welcome.login.error.unauthorized"= "Votre nom d'utilisateur ou mot de passe est incorrect.";
 "welcome.login.error.throttled"= "Too many failed login attempts with this username. Please try again after %@ second(s).";
+"welcome.login.error.backendUnavailable"= "Notre serveur est temporairement indisponible. Veuillez réessayer plus tard.";
 "welcome.login.receipt.button"= "Connectez-vous à l'aide du reçu d'achat";
 "welcome.login.magic.link.title"= "Connectez-vous à l'aide du lien e-mail magique";
 "welcome.login.magic.link.response"= "Veuillez vérifier vos e-mails pour trouver un lien de connexion.";

--- a/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/fr.lproj/Localizable.strings
+++ b/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/fr.lproj/Localizable.strings
@@ -546,7 +546,7 @@
 "signup.failure.redeem.claimed.message"= "Il semblerait que cette carte soit déjà utilisée sur un autre compte. Vous pouvez essayer de saisir un code PIN différent.";
 "signup.failure.submit"= "REVENIR";
 "signup.failure.internal"= "Erreur interne de l'application (%d)";
-"signup.failure.unknown"= "Erreur inconnue: %s (%d)";
+"signup.failure.unknown"= "Erreur inconnue: %@ (%d)";
 
 "signup.unreachable.vc_title"= "Erreur";
 "signup.unreachable.title"= "Oups !";

--- a/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/it.lproj/Localizable.strings
+++ b/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/it.lproj/Localizable.strings
@@ -612,6 +612,7 @@ Avrai sempre il controllo. Puoi vedere quali dati abbiamo raccolto dalle imposta
 "welcome.login.error.validation"= "Devi inserire un nome utente e una password.";
 "welcome.login.error.unauthorized"= "Nome utente o password non valida";
 "welcome.login.error.throttled"= "Too many failed login attempts with this username. Please try again after %@ second(s).";
+"welcome.login.error.backendUnavailable"= "Il nostro server non è disponibile al momento. Riprova più tardi.";
 "welcome.login.receipt.button"= "Accedi mediante ricevuta d'acquisto";
 "welcome.login.magic.link.title"= "Accedi tramite il link magico della mail";
 "welcome.login.magic.link.response"= "Controlla la tua mail per ottenere il link d'accesso.";

--- a/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/it.lproj/Localizable.strings
+++ b/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/it.lproj/Localizable.strings
@@ -546,7 +546,7 @@
 "signup.failure.redeem.claimed.message"= "Questa carta è già stata riscattata da un altro account. Prova a inserire un PIN diverso.";
 "signup.failure.submit"= "INDIETRO";
 "signup.failure.internal"= "Errore interno dell'app (%d)";
-"signup.failure.unknown"= "Errore sconosciuto: %s (%d)";
+"signup.failure.unknown"= "Errore sconosciuto: %@ (%d)";
 
 "signup.unreachable.vc_title"= "Errore";
 "signup.unreachable.title"= "Ops!";

--- a/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/ja.lproj/Localizable.strings
+++ b/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/ja.lproj/Localizable.strings
@@ -547,7 +547,7 @@
 "signup.failure.redeem.claimed.message"= "このカードは、すでに別のアカウントが獲得したようです。別のPINを入力してください。";
 "signup.failure.submit"= "戻る";
 "signup.failure.internal"= "内部アプリエラー (%d)";
-"signup.failure.unknown"= "不明なエラー: %s (%d)";
+"signup.failure.unknown"= "不明なエラー: %@ (%d)";
 
 "signup.unreachable.vc_title"= "エラー";
 "signup.unreachable.title"= "おっと！";

--- a/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/ja.lproj/Localizable.strings
+++ b/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/ja.lproj/Localizable.strings
@@ -613,6 +613,7 @@
 "welcome.login.error.validation"= "ユーザー名とパスワードを入力してください。";
 "welcome.login.error.unauthorized"= "ユーザー名またはパスワードが間違っています。";
 "welcome.login.error.throttled"= "Too many failed login attempts with this username. Please try again after %@ second(s).";
+"welcome.login.error.backendUnavailable"= "現在、サーバーは利用できません。後でもう一度お試しください。";
 "welcome.login.receipt.button"= "購入領収書を使用してログイン";
 "welcome.login.magic.link.title"= "魔法のメールリンクを使用してログイン";
 "welcome.login.magic.link.response"= "ログインリンクについては、メールを確認してください。";

--- a/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/ko.lproj/Localizable.strings
+++ b/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/ko.lproj/Localizable.strings
@@ -546,7 +546,7 @@
 "signup.failure.redeem.claimed.message"= "이 카드는 이미 다른 계정에서 청구한 것 같습니다. 다른 PIN을 입력해 보세요.";
 "signup.failure.submit"= "뒤로";
 "signup.failure.internal"= "내부 앱 오류 (%d)";
-"signup.failure.unknown"= "알 수 없는 오류: %s (%d)";
+"signup.failure.unknown"= "알 수 없는 오류: %@ (%d)";
 
 "signup.unreachable.vc_title"= "오류";
 "signup.unreachable.title"= "앗!";

--- a/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/ko.lproj/Localizable.strings
+++ b/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/ko.lproj/Localizable.strings
@@ -612,6 +612,7 @@
 "welcome.login.error.validation"= "사용자 이름과 비밀번호를 입력하셔야 합니다.";
 "welcome.login.error.unauthorized"= "사용자명 또는 비밀번호가 틀립니다.";
 "welcome.login.error.throttled"= "Too many failed login attempts with this username. Please try again after %@ second(s).";
+"welcome.login.error.backendUnavailable"= "현재 서버를 사용할 수 없습니다. 잠시 후 다시 시도해 주세요.";
 "welcome.login.receipt.button"= "구매 영수증을 사용해 로그인";
 "welcome.login.magic.link.title"= "이메일 링크를 사용해 간편하게 로그인";
 "welcome.login.magic.link.response"= "로그인 링크가 담긴 이메일을 확인하세요.";

--- a/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/nb.lproj/Localizable.strings
+++ b/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/nb.lproj/Localizable.strings
@@ -612,6 +612,7 @@ Du har alltid kontrollen. Du kan se hvilke data vi har samlet inn, i innstilling
 "welcome.login.error.validation"= "Du må oppgi et brukernavn og passord.";
 "welcome.login.error.unauthorized"= "Brukernavnet eller passordet ditt er feil.";
 "welcome.login.error.throttled"= "Too many failed login attempts with this username. Please try again after %@ second(s).";
+"welcome.login.error.backendUnavailable"= "Serveren vår er for øyeblikket utilgjengelig. Prøv igjen senere.";
 "welcome.login.receipt.button"= "Logg på med kjøpsbevis";
 "welcome.login.magic.link.title"= "Pålogging med magisk e-postkobling";
 "welcome.login.magic.link.response"= "Sjekk e-posten din for å finne påloggingskoblingen.";

--- a/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/nb.lproj/Localizable.strings
+++ b/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/nb.lproj/Localizable.strings
@@ -546,7 +546,7 @@
 "signup.failure.redeem.claimed.message"= "Ser ut til at kortet allerede er brukt av en annen konto. Du kan prøve med en annen PIN.";
 "signup.failure.submit"= "GÅ TILBAKE";
 "signup.failure.internal"= "Intern app-feil (%d)";
-"signup.failure.unknown"= "Ukjent feil: %s (%d)";
+"signup.failure.unknown"= "Ukjent feil: %@ (%d)";
 
 "signup.unreachable.vc_title"= "Feil";
 "signup.unreachable.title"= "Ups!";

--- a/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/nl.lproj/Localizable.strings
+++ b/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/nl.lproj/Localizable.strings
@@ -546,7 +546,7 @@
 "signup.failure.redeem.claimed.message"= "Deze kaart is door een ander account geclaimd. Probeer een andere pincode.";
 "signup.failure.submit"= "GA TERUG";
 "signup.failure.internal"= "Interne app-fout (%d)";
-"signup.failure.unknown"= "Onbekende fout: %s (%d)";
+"signup.failure.unknown"= "Onbekende fout: %@ (%d)";
 
 "signup.unreachable.vc_title"= "Fout";
 "signup.unreachable.title"= "Oeps!";

--- a/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/nl.lproj/Localizable.strings
+++ b/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/nl.lproj/Localizable.strings
@@ -612,6 +612,7 @@ U houdt altijd de controle. U kunt in de Instellingen zien welke gegevens we heb
 "welcome.login.error.validation"= "U moet een gebruikersnaam en wachtwoord invoeren.";
 "welcome.login.error.unauthorized"= "Uw gebruikersnaam of wachtwoord is onjuist.";
 "welcome.login.error.throttled"= "Too many failed login attempts with this username. Please try again after %@ second(s).";
+"welcome.login.error.backendUnavailable"= "Onze server is momenteel niet beschikbaar. Probeer het later opnieuw.";
 "welcome.login.receipt.button"= "Inloggen met aankoopbewijs";
 "welcome.login.magic.link.title"= "Log in met de magische link in uw e-mail";
 "welcome.login.magic.link.response"= "Controleer uw e-mail voor een inloglink.";

--- a/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/pl.lproj/Localizable.strings
+++ b/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/pl.lproj/Localizable.strings
@@ -612,6 +612,7 @@ Zawsze masz kontrolę. W ustawieniach możesz sprawdzić, jakie dane zebraliśmy
 "welcome.login.error.validation"= "Musisz podać nazwę użytkownika i hasło.";
 "welcome.login.error.unauthorized"= "Twoja nazwa użytkownika i hasło są nieprawidłowe.";
 "welcome.login.error.throttled"= "Too many failed login attempts with this username. Please try again after %@ second(s).";
+"welcome.login.error.backendUnavailable"= "Nasz serwer jest obecnie niedostępny. Spróbuj ponownie później.";
 "welcome.login.receipt.button"= "Zaloguj się, używając pokwitowania zakupu";
 "welcome.login.magic.link.title"= "Zaloguj się, używając sekretnego linku z e-maila";
 "welcome.login.magic.link.response"= "Link do logowania wysłaliśmy e-mailem,";

--- a/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/pl.lproj/Localizable.strings
+++ b/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/pl.lproj/Localizable.strings
@@ -546,7 +546,7 @@
 "signup.failure.redeem.claimed.message"= "Wygląda na to, że ta karta została użyta na innym koncie. Możesz spróbować wpisać inny PIN.";
 "signup.failure.submit"= "WSTECZ";
 "signup.failure.internal"= "Wewnętrzny błąd aplikacji (%d)";
-"signup.failure.unknown"= "Nieznany błąd: %s (%d)";
+"signup.failure.unknown"= "Nieznany błąd: %@ (%d)";
 
 "signup.unreachable.vc_title"= "Błąd";
 "signup.unreachable.title"= "Ups!";

--- a/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/pt-BR.lproj/Localizable.strings
+++ b/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/pt-BR.lproj/Localizable.strings
@@ -548,7 +548,7 @@
 "signup.failure.redeem.claimed.message"= "Parece que este cartão já foi resgatado por outra conta. Você pode tentar usar um PIN diferente.";
 "signup.failure.submit"= "VOLTAR";
 "signup.failure.internal"= "Erro interno do aplicativo (%d)";
-"signup.failure.unknown"= "Erro desconhecido: %s (%d)";
+"signup.failure.unknown"= "Erro desconhecido: %@ (%d)";
 
 "signup.unreachable.vc_title"= "Erro";
 "signup.unreachable.title"= "Ops!";

--- a/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/pt-BR.lproj/Localizable.strings
+++ b/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/pt-BR.lproj/Localizable.strings
@@ -614,6 +614,7 @@ Você sempre terá o controle. Você pode ver quais dados coletamos nas configur
 "welcome.login.error.validation"= "Você deve inserir um nome de usuário e senha.";
 "welcome.login.error.unauthorized"= "Seu nome de usuário ou senha está incorreto.";
 "welcome.login.error.throttled"= "Too many failed login attempts with this username. Please try again after %@ second(s).";
+"welcome.login.error.backendUnavailable"= "Nosso servidor está temporariamente indisponível. Tente novamente mais tarde.";
 "welcome.login.receipt.button"= "Faça login usando o recibo de compra";
 "welcome.login.magic.link.title"= "Faça login usando o link mágico enviado por e-mail";
 "welcome.login.magic.link.response"= "Veja se você recebeu por e-mail um link para fazer login.";

--- a/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/ru.lproj/Localizable.strings
+++ b/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/ru.lproj/Localizable.strings
@@ -546,7 +546,7 @@
 "signup.failure.redeem.claimed.message"= "Похоже, эту карту уже использовали с другой учетной записи. Попробуйте ввести другой PIN.";
 "signup.failure.submit"= "ВОЗВРАТ";
 "signup.failure.internal"= "Внутренняя ошибка приложения (%d)";
-"signup.failure.unknown"= "Неизвестная ошибка: %s (%d)";
+"signup.failure.unknown"= "Неизвестная ошибка: %@ (%d)";
 
 "signup.unreachable.vc_title"= "Ошибка";
 "signup.unreachable.title"= "Ой!";

--- a/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/ru.lproj/Localizable.strings
+++ b/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/ru.lproj/Localizable.strings
@@ -612,6 +612,7 @@
 "welcome.login.error.validation"= "Нужно ввести имя пользователя и пароль.";
 "welcome.login.error.unauthorized"= "Неправильное имя пользователя или пароль.";
 "welcome.login.error.throttled"= "Too many failed login attempts with this username. Please try again after %@ second(s).";
+"welcome.login.error.backendUnavailable"= "Наш сервер в настоящее время недоступен. Пожалуйста, повторите попытку позже.";
 "welcome.login.receipt.button"= "Выполните вход по квитанции о покупке";
 "welcome.login.magic.link.title"= "Войти через волшебную ссылку из письма";
 "welcome.login.magic.link.response"= "Поищите ссылку для входа в письме.";

--- a/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/th.lproj/Localizable.strings
+++ b/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/th.lproj/Localizable.strings
@@ -612,6 +612,7 @@
 "welcome.login.error.validation"= "คุณต้องกรอกชื่อผู้ใช้และรหัสผ่าน";
 "welcome.login.error.unauthorized"= "ชื่อผู้ใช้หรือรหัสผ่านไม่ถูกต้อง";
 "welcome.login.error.throttled"= "Too many failed login attempts with this username. Please try again after %@ second(s).";
+"welcome.login.error.backendUnavailable"= "เซิร์ฟเวอร์ของเราไม่พร้อมใช้งานในขณะนี้ กรุณาลองอีกครั้งในภายหลัง";
 "welcome.login.receipt.button"= "เข้าสู่ระบบโดยใช้ใบเสร็จรับเงิน";
 "welcome.login.magic.link.title"= "เข้าสู่ระบบโดยใช้ลิงก์อีเมลวิเศษ";
 "welcome.login.magic.link.response"= "โปรดตรวจสอบอีเมลของคุณเพื่อดูลิงค์สำหรับเข้าสู่ระบบ";

--- a/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/th.lproj/Localizable.strings
+++ b/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/th.lproj/Localizable.strings
@@ -546,7 +546,7 @@
 "signup.failure.redeem.claimed.message"= "ดูเหมือนว่าบัตรนี้มีการใช้สิทธิ์แล้วโดยบัญชีอื่น กรุณาลองใส่ PIN อื่น";
 "signup.failure.submit"= "ย้อนกลับ";
 "signup.failure.internal"= "ข้อผิดพลาดภายในแอป (%d)";
-"signup.failure.unknown"= "ข้อผิดพลาดที่ไม่ทราบสาเหตุ: %s (%d)";
+"signup.failure.unknown"= "ข้อผิดพลาดที่ไม่ทราบสาเหตุ: %@ (%d)";
 
 "signup.unreachable.vc_title"= "ข้อผิดพลาด";
 "signup.unreachable.title"= "อุ๊ปส์!";

--- a/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/tr.lproj/Localizable.strings
+++ b/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/tr.lproj/Localizable.strings
@@ -541,7 +541,7 @@
 
 "signup.failure.internal"= "Dahili uygulama hatası (%d)";
 
-"signup.failure.unknown"= "Bilinmeyen hata: %s (%d)";
+"signup.failure.unknown"= "Bilinmeyen hata: %@ (%d)";
 
 "signup.failure.title"= "Hesap Oluşturma Hatası";
 

--- a/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/tr.lproj/Localizable.strings
+++ b/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/tr.lproj/Localizable.strings
@@ -630,6 +630,7 @@
 "welcome.iap.error.title"= "Hata";
 
 "welcome.login.error.throttled"= "Bu kullanıcı adı ile çok fazla kez yanlış giriş yapıldı. Lütfen daha sonra tekrar deneyin.";
+"welcome.login.error.backendUnavailable"= "Sunucumuz şu anda kullanılamıyor. Lütfen daha sonra tekrar deneyin.";
 
 "welcome.login.error.title"= "Giriş yap";
 

--- a/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/zh-Hans.lproj/Localizable.strings
+++ b/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/zh-Hans.lproj/Localizable.strings
@@ -546,7 +546,7 @@
 "signup.failure.redeem.claimed.message"= "此卡片似乎已被另一个账号使用。您可尝试输入另一个PIN。";
 "signup.failure.submit"= "返回";
 "signup.failure.internal"= "内部应用错误 (%d)";
-"signup.failure.unknown"= "未知错误：%s (%d)";
+"signup.failure.unknown"= "未知错误：%@ (%d)";
 
 "signup.unreachable.vc_title"= "错误";
 "signup.unreachable.title"= "糟糕！";

--- a/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/zh-Hans.lproj/Localizable.strings
+++ b/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/zh-Hans.lproj/Localizable.strings
@@ -612,6 +612,7 @@
 "welcome.login.error.validation"= "您必须输入用户名和密码。";
 "welcome.login.error.unauthorized"= "您的用户名或密码不正确。";
 "welcome.login.error.throttled"= "Too many failed login attempts with this username. Please try again after %@ second(s).";
+"welcome.login.error.backendUnavailable"= "我们的服务器目前不可用。请稍后再试。";
 "welcome.login.receipt.button"= "使用购买收据登录";
 "welcome.login.magic.link.title"= "使用魔法电子邮件链接登录";
 "welcome.login.magic.link.response"= "请检查您的电子邮件，以查找登录链接。";

--- a/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/zh-Hant.lproj/Localizable.strings
+++ b/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/zh-Hant.lproj/Localizable.strings
@@ -612,6 +612,7 @@
 "welcome.login.error.validation"= "您必須輸入使用者名稱及密碼。";
 "welcome.login.error.unauthorized"= "您的使用者名稱或密碼不正確。";
 "welcome.login.error.throttled"= "Too many failed login attempts with this username. Please try again after %@ second(s).";
+"welcome.login.error.backendUnavailable"= "我們的伺服器目前無法使用。請稍後再試。";
 "welcome.login.receipt.button"= "使用購買收據登入";
 "welcome.login.magic.link.title"= "使用神奇的電子郵件連結登入";
 "welcome.login.magic.link.response"= "請確認電子信箱是否已收到登入連結。";

--- a/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/zh-Hant.lproj/Localizable.strings
+++ b/LocalPackages/PIALocalizations/Sources/PIALocalizations/Resources/zh-Hant.lproj/Localizable.strings
@@ -546,7 +546,7 @@
 "signup.failure.redeem.claimed.message"= "這張卡似乎已經被另一個帳戶使用。您可以嘗試輸入不同的 PIN 碼。";
 "signup.failure.submit"= "返回";
 "signup.failure.internal"= "內部應用程式錯誤 (%d)";
-"signup.failure.unknown"= "未知錯誤：%s (%d)";
+"signup.failure.unknown"= "未知錯誤：%@ (%d)";
 
 "signup.unreachable.vc_title"= "錯誤";
 "signup.unreachable.title"= "噢！";

--- a/LocalPackages/PIAPaywall/Sources/PIAPaywall/Domain/PaywallError.swift
+++ b/LocalPackages/PIAPaywall/Sources/PIAPaywall/Domain/PaywallError.swift
@@ -19,6 +19,7 @@
 //  Internet Access iOS Client.  If not, see <https://www.gnu.org/licenses/>.
 //
 
+import PIALibrary
 import PIALocalizations
 
 /// Everything that can go wrong on the paywall, reduced to the cases the UI treats differently.
@@ -49,6 +50,23 @@ public enum PaywallError: Error, Equatable, Sendable {
 }
 
 extension PaywallError {
+    init(client: ClientError) {
+        switch client {
+        case .userCancelled:
+            self = .userCancelled
+        case .purchasePending:
+            self = .purchasePending
+        case .productUnavailable:
+            self = .productsUnavailable
+        case .noReceipt:
+            self = .nothingToRestore
+        case .badReceipt:
+            self = .restoreLoginFailed
+        default:
+            self = .failed(message: client.localizedDescription)
+        }
+    }
+
     /// The message to surface, or `nil` when the failure should be silent.
     var userFacingMessage: String? {
         switch self {

--- a/LocalPackages/PIAPaywall/Sources/PIAPaywall/Presentation/PaywallDependencies+Live.swift
+++ b/LocalPackages/PIAPaywall/Sources/PIAPaywall/Presentation/PaywallDependencies+Live.swift
@@ -130,12 +130,8 @@ public extension PaywallDependencies {
         accountProvider: AccountProvider
     ) async -> Result<UserAccount, PaywallError> {
         await withCheckedContinuation { continuation in
-            accountProvider.login(with: LoginReceiptRequest(receipt: jws)) { user, error in
-                if let user, error == nil {
-                    continuation.resume(returning: .success(user))
-                } else {
-                    continuation.resume(returning: .failure(.restoreLoginFailed))
-                }
+            accountProvider.login(with: LoginReceiptRequest(receipt: jws)) { result in
+                continuation.resume(returning: result.mapError(PaywallError.init(client:)))
             }
         }
     }

--- a/PIA VPN-tvOS/Login/Data/LoginProvider.swift
+++ b/PIA VPN-tvOS/Login/Data/LoginProvider.swift
@@ -20,26 +20,29 @@ final class LoginProvider: LoginProviderType {
     func login(with credentials: Credentials, completion: @escaping (Result<UserAccount, Error>) -> Void) {
         let request = LoginRequest(credentials: credentials)
 
-        accountProvider.login(with: request) { [weak self] userAccount, error in
-            self?.handleLoginResult(userAccount: userAccount, error: error, completion: completion)
+        accountProvider.login(with: request) { [weak self] result in
+            self?.handleLoginResult(result: result, completion: completion)
         }
     }
 
     func login(with receipt: JWS, completion: @escaping (Result<UserAccount, Error>) -> Void) {
         let request = LoginReceiptRequest(receipt: receipt)
 
-        accountProvider.login(with: request) { [weak self] userAccount, error in
-            self?.handleLoginResult(userAccount: userAccount, error: error, completion: completion)
+        accountProvider.login(with: request) { [weak self] result in
+            self?.handleLoginResult(result: result, completion: completion)
         }
     }
 
-    private func handleLoginResult(userAccount: UserAccount?, error: Error?, completion: @escaping (Result<UserAccount, Error>) -> Void) {
-        if let error = error {
+    private func handleLoginResult(
+        result: ClientResult<UserAccount>,
+        completion: @escaping (Result<UserAccount, Error>) -> Void
+    ) {
+        if case let .failure(error) = result {
             completion(.failure(error))
             return
         }
 
-        guard let userAccount = userAccount else {
+        guard case let .success(userAccount) = result else {
             completion(.failure(ClientError.unexpectedReply))
             return
         }

--- a/PIA VPN-tvOS/Login/Data/LoginProvider.swift
+++ b/PIA VPN-tvOS/Login/Data/LoginProvider.swift
@@ -17,7 +17,7 @@ final class LoginProvider: LoginProviderType {
         self.accountProvider = accountProvider
     }
 
-    func login(with credentials: Credentials, completion: @escaping (Result<UserAccount, Error>) -> Void) {
+    func login(with credentials: Credentials, completion: @escaping ClientCallback<UserAccount>) {
         let request = LoginRequest(credentials: credentials)
 
         accountProvider.login(with: request) { [weak self] result in
@@ -25,7 +25,7 @@ final class LoginProvider: LoginProviderType {
         }
     }
 
-    func login(with receipt: JWS, completion: @escaping (Result<UserAccount, Error>) -> Void) {
+    func login(with receipt: JWS, completion: @escaping ClientCallback<UserAccount>) {
         let request = LoginReceiptRequest(receipt: receipt)
 
         accountProvider.login(with: request) { [weak self] result in
@@ -35,23 +35,18 @@ final class LoginProvider: LoginProviderType {
 
     private func handleLoginResult(
         result: ClientResult<UserAccount>,
-        completion: @escaping (Result<UserAccount, Error>) -> Void
+        completion: @escaping ClientCallback<UserAccount>
     ) {
-        if case let .failure(error) = result {
+        switch result {
+        case .failure(let error):
             completion(.failure(error))
-            return
-        }
 
-        guard case let .success(userAccount) = result else {
-            completion(.failure(ClientError.unexpectedReply))
-            return
+        case .success(let userAccount):
+            if let info = userAccount.info, info.isExpired {
+                completion(.failure(.expired))
+            } else {
+                completion(.success(userAccount))
+            }
         }
-
-        guard userAccount.info?.isExpired == true else {
-            completion(.success(userAccount))
-            return
-        }
-
-        completion(.failure(ClientError.expired))
     }
 }

--- a/PIA VPN-tvOS/Login/Domain/Interfaces/LoginProviderType.swift
+++ b/PIA VPN-tvOS/Login/Domain/Interfaces/LoginProviderType.swift
@@ -11,6 +11,6 @@ import PIABase
 import PIALibrary
 
 protocol LoginProviderType {
-    func login(with credentials: Credentials, completion: @escaping (Result<UserAccount, Error>) -> Void)
-    func login(with receipt: JWS, completion: @escaping (Result<UserAccount, Error>) -> Void)
+    func login(with credentials: Credentials, completion: @escaping ClientCallback<UserAccount>)
+    func login(with receipt: JWS, completion: @escaping ClientCallback<UserAccount>)
 }

--- a/PIA VPN-tvOS/LoginQR/Domain/Use cases/ValidateLoginQRCodeUseCase.swift
+++ b/PIA VPN-tvOS/LoginQR/Domain/Use cases/ValidateLoginQRCodeUseCase.swift
@@ -26,8 +26,8 @@ class ValidateLoginQRCodeUseCase: ValidateLoginQRCodeUseCaseType {
         let apiToken = try await validateLoginQRCodeProvider.validateLoginQRCodeToken(qrCodeToken)
 
         return try await withCheckedThrowingContinuation { continuation in
-            accountProviderType.login(with: apiToken) { _, error in
-                if let error = error {
+            accountProviderType.login(with: apiToken) { result in
+                if case let .failure(error) = result {
                     continuation.resume(throwing: error)
                     return
                 }

--- a/PIA VPN-tvOSTests/Login/Helpers/AccountProviderMock.swift
+++ b/PIA VPN-tvOSTests/Login/Helpers/AccountProviderMock.swift
@@ -56,7 +56,7 @@ final class AccountProviderMock: AccountProvider {
         self.appStoreInformationResult = appStoreInformationResult
     }
 
-    func login(with request: LoginRequest, _ callback: @escaping ClientCallback<UserAccount>) {
+    private func handleCallback(_ callback: ClientCallback<UserAccount>) {
         if let clientError = errorResult as? ClientError {
             callback(.failure(clientError))
         } else if let userResult {
@@ -66,15 +66,13 @@ final class AccountProviderMock: AccountProvider {
         }
     }
 
+    func login(with request: LoginRequest, _ callback: @escaping ClientCallback<UserAccount>) {
+        handleCallback(callback)
+    }
+
     func login(with linkToken: String, _ callback: @escaping ClientCallback<UserAccount>) {
         loginWithTokenCalledAttempt += 1
-        if let clientError = errorResult as? ClientError {
-            callback(.failure(clientError))
-        } else if let userResult {
-            callback(.success(userResult))
-        } else {
-            callback(.failure(.unexpectedReply))
-        }
+        handleCallback(callback)
     }
 
     func signup(with request: SignupRequest, _ callback: LibraryCallback<UserAccount>?) {
@@ -86,13 +84,7 @@ final class AccountProviderMock: AccountProvider {
     }
 
     func login(with receiptRequest: LoginReceiptRequest, _ callback: @escaping ClientCallback<UserAccount>) {
-        if let clientError = errorResult as? ClientError {
-            callback(.failure(clientError))
-        } else if let userResult {
-            callback(.success(userResult))
-        } else {
-            callback(.failure(.unexpectedReply))
-        }
+        handleCallback(callback)
     }
 
     func refreshAccountInfo(_ callback: LibraryCallback<AccountInfo>?) {}

--- a/PIA VPN-tvOSTests/Login/Helpers/AccountProviderMock.swift
+++ b/PIA VPN-tvOSTests/Login/Helpers/AccountProviderMock.swift
@@ -56,13 +56,25 @@ final class AccountProviderMock: AccountProvider {
         self.appStoreInformationResult = appStoreInformationResult
     }
 
-    func login(with request: LoginRequest, _ callback: LibraryCallback<UserAccount>?) {
-        callback?(userResult, errorResult)
+    func login(with request: LoginRequest, _ callback: @escaping ClientCallback<UserAccount>) {
+        if let clientError = errorResult as? ClientError {
+            callback(.failure(clientError))
+        } else if let userResult {
+            callback(.success(userResult))
+        } else {
+            callback(.failure(.unexpectedReply))
+        }
     }
 
-    func login(with linkToken: String, _ callback: ((UserAccount?, Error?) -> Void)?) {
+    func login(with linkToken: String, _ callback: @escaping ClientCallback<UserAccount>) {
         loginWithTokenCalledAttempt += 1
-        callback?(userResult, errorResult)
+        if let clientError = errorResult as? ClientError {
+            callback(.failure(clientError))
+        } else if let userResult {
+            callback(.success(userResult))
+        } else {
+            callback(.failure(.unexpectedReply))
+        }
     }
 
     func signup(with request: SignupRequest, _ callback: LibraryCallback<UserAccount>?) {
@@ -73,8 +85,14 @@ final class AccountProviderMock: AccountProvider {
         callback?(appStoreInformationResult, errorResult)
     }
 
-    func login(with receiptRequest: LoginReceiptRequest, _ callback: LibraryCallback<UserAccount>?) {
-        callback?(userResult, errorResult)
+    func login(with receiptRequest: LoginReceiptRequest, _ callback: @escaping ClientCallback<UserAccount>) {
+        if let clientError = errorResult as? ClientError {
+            callback(.failure(clientError))
+        } else if let userResult {
+            callback(.success(userResult))
+        } else {
+            callback(.failure(.unexpectedReply))
+        }
     }
 
     func refreshAccountInfo(_ callback: LibraryCallback<AccountInfo>?) {}
@@ -100,7 +118,7 @@ final class AccountProviderMock: AccountProvider {
     }
     func isAPIEndpointAvailable(_ callback: LibraryCallback<Bool>?) {}
     func restorePurchases() async -> Result<JWS, ClientError> { .success(JWS("jws")!) }
-    func loginUsingMagicLink(withEmail email: String, _ callback: SuccessLibraryCallback?) {}
+    func loginUsingMagicLink(withEmail email: String, _ callback: @escaping SuccessClientCallback) {}
     func listRenewablePlans(_ callback: LibraryCallback<[Plan]>?) {}
     func renew(with request: RenewRequest, _ callback: LibraryCallback<UserAccount>?) {}
 

--- a/PIA VPN-tvOSTests/Login/Helpers/LoginProviderMock.swift
+++ b/PIA VPN-tvOSTests/Login/Helpers/LoginProviderMock.swift
@@ -13,17 +13,17 @@ import PIABase
 @testable import PIA_VPN_tvOS
 
 final class LoginProviderMock: LoginProviderType {
-    private let result: Result<UserAccount, Error>
+    private let result: ClientResult<UserAccount>
 
-    init(result: Result<UserAccount, Error>) {
+    init(result: ClientResult<UserAccount>) {
         self.result = result
     }
 
-    func login(with credentials: Credentials, completion: @escaping (Result<UserAccount, Error>) -> Void) {
+    func login(with credentials: Credentials, completion: @escaping ClientCallback<UserAccount>) {
         completion(result)
     }
 
-    func login(with receipt: JWS, completion: @escaping (Result<UserAccount, any Error>) -> Void) {
+    func login(with receipt: JWS, completion: @escaping ClientCallback<UserAccount>) {
         completion(result)
     }
 }

--- a/PIA VPN-tvOSTests/Login/LoginProviderTests.swift
+++ b/PIA VPN-tvOSTests/Login/LoginProviderTests.swift
@@ -18,7 +18,7 @@ final class LoginProviderTests: XCTestCase {
 
     var fixture: Fixture!
     var sut: LoginProvider!
-    var capturedResult: Result<UserAccount, Error>?
+    var capturedResult: ClientResult<UserAccount>?
 
     func instantiateSut(accountProviderResult: (UserAccount?, Error?)) {
         fixture.accountProviderMock = AccountProviderMock(userResult: accountProviderResult.0, errorResult: accountProviderResult.1)

--- a/PIA VPN-tvOSTests/LoginQR/LoginWithReceiptUseCaseTests.swift
+++ b/PIA VPN-tvOSTests/LoginQR/LoginWithReceiptUseCaseTests.swift
@@ -22,7 +22,7 @@ final class LoginWithReceiptUseCaseTests: XCTestCase {
     var fixture: Fixture!
     var sut: LoginWithReceiptUseCase!
 
-    func instantiateSut(paymentProviderResult: Result<JWS, Error>, loginProviderResult: Result<UserAccount, Error>) {
+    func instantiateSut(paymentProviderResult: Result<JWS, Error>, loginProviderResult: ClientResult<UserAccount>) {
         fixture.paymentProviderMock = PaymentProviderMock(result: paymentProviderResult)
         fixture.loginProviderMock = LoginProviderMock(result: loginProviderResult)
 

--- a/PIA VPN-tvOSTests/LoginQR/ValidateLoginQRCodeUseCaseTests.swift
+++ b/PIA VPN-tvOSTests/LoginQR/ValidateLoginQRCodeUseCaseTests.swift
@@ -89,7 +89,7 @@ final class ValidateLoginQRCodeUseCaseTests: XCTestCase {
 
         instantiateSut(
             userResult: nil,
-            errorResult: LoginQRCodeError.generic,
+            errorResult: ClientError.unexpectedReply,
             validateLoginQRCodeResult: .success(apiToken))
 
         var capturedError: Error?
@@ -103,7 +103,7 @@ final class ValidateLoginQRCodeUseCaseTests: XCTestCase {
         }
 
         // THEN
-        let error = try XCTUnwrap(capturedError as? LoginQRCodeError)
-        XCTAssertEqual(error, .generic)
+        let error = try XCTUnwrap(capturedError as? ClientError)
+        XCTAssertEqual(error, .unexpectedReply)
     }
 }

--- a/PIA VPN/Signup/SignupCoordinator.swift
+++ b/PIA VPN/Signup/SignupCoordinator.swift
@@ -110,10 +110,10 @@ final class SignupCoordinator: NSObject, Coordinator {
     func handleMagicLink(token: String) {
         showLogin { controller in
             controller.showLoadingAnimation()
-            Client.providers.accountProvider.login(with: token) { _, error in
+            Client.providers.accountProvider.login(with: token) { result in
                 controller.hideLoadingAnimation()
                 var userInfo: [NotificationKey: Any]?
-                if let error {
+                if case let .failure(error) = result {
                     userInfo = [.error: error]
                 }
                 Macros.postNotification(.PIAFinishLoginWithMagicLink, userInfo)

--- a/PIA VPN/UI/LoginViewController.swift
+++ b/PIA VPN/UI/LoginViewController.swift
@@ -345,20 +345,16 @@ final class LoginViewController: AutolayoutViewController, PIAWelcomeViewControl
     private func handleLoginFailed(_ error: ClientError, loginOption: LoginOption) {
         log.error("Failed to log in: \(error)")
 
-        var displayDuration: Double?
         let errorMessage: String
 
         switch error {
         case .unauthorized:
             errorMessage = L10n.Welcome.Login.Error.unauthorized
 
-        case .throttled(retryAfter: let retryAfter):
-            let localisedThrottlingString = L10n.Welcome.Login.Error.throttled("\(retryAfter)")
-            errorMessage = NSLocalizedString(localisedThrottlingString, comment: localisedThrottlingString)
+        case .throttled(let retryAfter):
+            errorMessage = L10n.Welcome.Login.Error.throttled("\(retryAfter)")
 
             let retryAfterSeconds = Double(retryAfter)
-            displayDuration = retryAfterSeconds
-
             updateTimeToRetry(loginOption: loginOption, retryAfterSeconds: retryAfterSeconds)
 
         case .expired:
@@ -387,7 +383,7 @@ final class LoginViewController: AutolayoutViewController, PIAWelcomeViewControl
             errorMessage = L10n.Signup.Failure.unknown(error.localizedDescription, 0)
         }
 
-        displayErrorMessage(errorMessage: errorMessage, displayDuration: displayDuration)
+        displayErrorMessage(errorMessage: errorMessage)
     }
 
     private func displayErrorMessage(errorMessage: String, displayDuration: Double? = nil) {

--- a/PIA VPN/UI/LoginViewController.swift
+++ b/PIA VPN/UI/LoginViewController.swift
@@ -180,21 +180,18 @@ final class LoginViewController: AutolayoutViewController, PIAWelcomeViewControl
         }
 
         self.showLoadingAnimation()
-        self.config.accountProvider.loginUsingMagicLink(
-            withEmail: email,
-            { error in
-
-                self.hideLoadingAnimation()
-                guard error == nil else {
-                    self.handleLoginFailed(error, loginOption: .magicLink)
-                    return
-                }
-
+        self.config.accountProvider.loginUsingMagicLink(withEmail: email) { [weak self] result in
+            self?.hideLoadingAnimation()
+            switch result {
+            case .failure(let error):
+                self?.handleLoginFailed(error, loginOption: .magicLink)
+            case .success:
                 Macros.displaySuccessImageNote(
                     withImage: Asset.iconWarning.image,
                     message: L10n.Welcome.Login.Magic.Link.response
                 )
-            })
+            }
+        }
     }
 
     @objc private func finishLoginWithMagicLink(notification: Notification) {
@@ -234,14 +231,14 @@ final class LoginViewController: AutolayoutViewController, PIAWelcomeViewControl
                 guard let self else { return }
                 guard let jws else {
                     log.debug("No entitlement found to restore")
-                    self.handleLoginResult(user: nil, error: ClientError.badReceipt, loginOption: .receipt)
+                    self.handleLoginResult(result: .failure(.noReceipt), loginOption: .receipt)
                     return
                 }
 
                 let request = LoginReceiptRequest(receipt: jws)
 
-                self.config.accountProvider.login(with: request) { userAccount, error in
-                    self.handleLoginResult(user: userAccount, error: error, loginOption: .receipt)
+                self.config.accountProvider.login(with: request) { result in
+                    self.handleLoginResult(result: result, loginOption: .receipt)
                 }
             }
         }
@@ -264,8 +261,8 @@ final class LoginViewController: AutolayoutViewController, PIAWelcomeViewControl
         let request = LoginRequest(credentials: credentials)
 
         prepareLogin()
-        config.accountProvider.login(with: request) { [weak self] userAccount, error in
-            self?.handleLoginResult(user: userAccount, error: error, loginOption: .credentials)
+        config.accountProvider.login(with: request) { [weak self] result in
+            self?.handleLoginResult(result: result, loginOption: .credentials)
         }
     }
 
@@ -318,19 +315,19 @@ final class LoginViewController: AutolayoutViewController, PIAWelcomeViewControl
         showLoadingAnimation()
     }
 
-    private func handleLoginResult(user: UserAccount?, error: Error?, loginOption: LoginOption) {
+    private func handleLoginResult(result: ClientResult<UserAccount>, loginOption: LoginOption) {
         enableInteractions(true)
 
         hideLoadingAnimation()
 
-        guard let user = user else {
+        switch result {
+        case .failure(let error):
             handleLoginFailed(error, loginOption: loginOption)
-            return
+
+        case .success(let user):
+            log.debug("Login succeeded!")
+            config.completionDelegate?.welcomeDidLogin(withUser: user, topViewController: self)
         }
-
-        log.debug("Login succeeded!")
-
-        config.completionDelegate?.welcomeDidLogin(withUser: user, topViewController: self)
     }
 
     private func updateTimeToRetry(loginOption: LoginOption, retryAfterSeconds: Double) {
@@ -345,57 +342,58 @@ final class LoginViewController: AutolayoutViewController, PIAWelcomeViewControl
         }
     }
 
-    private func handleLoginFailed(_ error: Error?, loginOption: LoginOption) {
+    private func handleLoginFailed(_ error: ClientError, loginOption: LoginOption) {
+        log.error("Failed to log in: \(error)")
+
         var displayDuration: Double?
-        var errorMessage: String?
-        if let error {
-            log.error("Failed to log in: \(error)")
-            switch error as? ClientError {
-            case .unauthorized:
-                errorMessage = L10n.Welcome.Login.Error.unauthorized
+        let errorMessage: String
 
-            case .throttled(retryAfter: let retryAfter):
-                let localisedThrottlingString = L10n.Welcome.Login.Error.throttled("\(retryAfter)")
-                errorMessage = NSLocalizedString(localisedThrottlingString, comment: localisedThrottlingString)
+        switch error {
+        case .unauthorized:
+            errorMessage = L10n.Welcome.Login.Error.unauthorized
 
-                let retryAfterSeconds = Double(retryAfter)
-                displayDuration = retryAfterSeconds
+        case .throttled(retryAfter: let retryAfter):
+            let localisedThrottlingString = L10n.Welcome.Login.Error.throttled("\(retryAfter)")
+            errorMessage = NSLocalizedString(localisedThrottlingString, comment: localisedThrottlingString)
 
-                updateTimeToRetry(loginOption: loginOption, retryAfterSeconds: retryAfterSeconds)
+            let retryAfterSeconds = Double(retryAfter)
+            displayDuration = retryAfterSeconds
 
-            case .expired:
-                handleExpiredAccount()
-                return
+            updateTimeToRetry(loginOption: loginOption, retryAfterSeconds: retryAfterSeconds)
 
-            case .badReceipt:
-                handleBadReceipt()
-                return
+        case .expired:
+            handleExpiredAccount()
+            return
 
-            case .internetUnreachable:
-                errorMessage = L10n.Global.unreachable
+        case .badReceipt:
+            handleBadReceipt()
+            return
 
-            case let .libraryError(message):
-                let message = message ?? error.localizedDescription
-                log.error("Account library error: \(message)")
-                // we shouldn't show this message to the user since this is an internal error
-                errorMessage = L10n.Signup.Failure.internal(PIAAccountError.networkFailureCode)
+        case .internetUnreachable:
+            errorMessage = L10n.Global.unreachable
 
-            case let .unknown(code, message):
-                let message = message ?? error.localizedDescription
-                errorMessage = L10n.Signup.Failure.unknown(message, code)
+        case .backendUnavailable:
+            errorMessage = L10n.Welcome.Login.Error.backendUnavailable
 
-            default:
-                errorMessage = error.localizedDescription
-            }
+        case let .libraryError(code, message):
+            log.error("Account library error: \(message)")
+            // we shouldn't show this message to the user since this is an internal error
+            errorMessage = L10n.Signup.Failure.internal(code)
+
+        case let .unknown(code, message):
+            errorMessage = L10n.Signup.Failure.unknown(message, code)
+
+        default:
+            errorMessage = L10n.Signup.Failure.unknown(error.localizedDescription, 0)
         }
+
         displayErrorMessage(errorMessage: errorMessage, displayDuration: displayDuration)
     }
 
-    private func displayErrorMessage(errorMessage: String?, displayDuration: Double? = nil) {
-
+    private func displayErrorMessage(errorMessage: String, displayDuration: Double? = nil) {
         Macros.displayImageNote(
             withImage: Asset.iconWarning.image,
-            message: errorMessage ?? L10n.Welcome.Login.Error.title, andDuration: displayDuration,
+            message: errorMessage, andDuration: displayDuration,
             accessbilityIdentifier: Accessibility.Id.Login.Error.banner)
     }
 

--- a/PIA VPN/UI/LoginViewController.swift
+++ b/PIA VPN/UI/LoginViewController.swift
@@ -365,7 +365,7 @@ final class LoginViewController: AutolayoutViewController, PIAWelcomeViewControl
             handleExpiredAccount()
             return
 
-        case .badReceipt:
+        case .noReceipt, .badReceipt:
             handleBadReceipt()
             return
 

--- a/PIA VPNTests/Mocks/AccountProviderMock.swift
+++ b/PIA VPNTests/Mocks/AccountProviderMock.swift
@@ -41,7 +41,7 @@ import XCTest
             logoutCalledAttempt += 1
         }
 
-        func login(with linkToken: String, _ callback: ((UserAccount?, Error?) -> Void)?) {
+        func login(with linkToken: String, _ callback: @escaping ClientCallback<UserAccount>) {
             loginWithTokenCalledAttempt += 1
         }
 
@@ -63,10 +63,10 @@ import XCTest
         var currentPasswordReference: Data?
         var lastSignupRequest: SignupRequest?
 
-        func login(with request: LoginRequest, _ callback: LibraryCallback<UserAccount>?) {}
+        func login(with request: LoginRequest, _ callback: @escaping ClientCallback<UserAccount>) {}
         func signup(with request: SignupRequest, _ callback: LibraryCallback<UserAccount>?) {}
         func subscriptionInformation(_ callback: LibraryCallback<AppStoreInformation>?) {}
-        func login(with receiptRequest: LoginReceiptRequest, _ callback: LibraryCallback<UserAccount>?) {}
+        func login(with receiptRequest: LoginReceiptRequest, _ callback: @escaping ClientCallback<UserAccount>) {}
         func refreshAccountInfo(_ callback: LibraryCallback<AccountInfo>?) {}
         func update(with request: UpdateAccountRequest, resetPassword reset: Bool, andPassword password: String, _ callback: LibraryCallback<AccountInfo>?) {}
         func deleteAccount(_ callback: SuccessLibraryCallback?) {}
@@ -79,7 +79,7 @@ import XCTest
         }
         func isAPIEndpointAvailable(_ callback: LibraryCallback<Bool>?) {}
         func restorePurchases() async -> Result<JWS, ClientError> { .success(JWS("jws")!) }
-        func loginUsingMagicLink(withEmail email: String, _ callback: SuccessLibraryCallback?) {}
+        func loginUsingMagicLink(withEmail email: String, _ callback: @escaping SuccessClientCallback) {}
         func listRenewablePlans(_ callback: LibraryCallback<[Plan]>?) {}
         func renew(with request: RenewRequest, _ callback: LibraryCallback<UserAccount>?) {}
         func validateLoginQR(with qrToken: String, _ callback: ((String?, (any Error)?) -> Void)?) {}


### PR DESCRIPTION
- Add `ClientError.backendUnavailable` and cleanup other cases.
- Create enum `PIAAccountErrorType` to use instead of Int error codes. Use it in `PIAError` for improved type safety.
- Login methods in `AccountProvider` return a `Result<T, ClientError>` instead of `(T?, Error?)?` for improved type safety.
- Rank errors inside `PIAMultipleErrors`. HTTP errors are more important since they reached the server.
