### PR TITLE
Mark many types as Sendable

### DIFF
--- a/LocalPackages/PIAAccount/Package.swift
+++ b/LocalPackages/PIAAccount/Package.swift
@@ -35,5 +35,6 @@ let package = Package(
             name: "PIAAccountTests",
             dependencies: ["PIAAccount"]
         )
-    ]
+    ],
+    swiftLanguageModes: [.v6]
 )

--- a/LocalPackages/PIAAccount/Sources/PIAAccount/PIAAccountAPI.swift
+++ b/LocalPackages/PIAAccount/Sources/PIAAccount/PIAAccountAPI.swift
@@ -29,7 +29,7 @@ import PIABase
 ///
 /// For operations that try multiple endpoints, `PIAMultipleErrors` aggregates
 /// all failures if none succeed.
-public protocol PIAAccountAPI {
+public protocol PIAAccountAPI: Sendable {
     // MARK: - Token Access
 
     /// Returns the cached API token, if available.

--- a/LocalPackages/PIACSI/Package.swift
+++ b/LocalPackages/PIACSI/Package.swift
@@ -18,5 +18,6 @@ let package = Package(
         .target(
             name: "PIACSI"
         )
-    ]
+    ],
+    swiftLanguageModes: [.v6]
 )

--- a/LocalPackages/PIACSI/Sources/PIACSI/CSIClient.swift
+++ b/LocalPackages/PIACSI/Sources/PIACSI/CSIClient.swift
@@ -28,7 +28,7 @@ public enum CSIError: Error {
     case unexpectedResponse
 }
 
-public struct CSIClient {
+public struct CSIClient: Sendable {
     private let baseURL = "https://csi.supreme.tools/api/v2/report"
     private let userAgent: String
 

--- a/LocalPackages/PIADebugMenu/README.md
+++ b/LocalPackages/PIADebugMenu/README.md
@@ -71,7 +71,7 @@ observer and the Catalyst menu bar item; tvOS keeps an equivalent check in `View
 #if DEVELOPMENT || STAGING
     return true
 #else
-    return TestFlightDetector.shared.isTestFlight
+    return TestFlightDetector.isTestFlight
 #endif
 ```
 

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Account/CompositionRoot/AccountFactory.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Account/CompositionRoot/AccountFactory.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public class AccountFactory {
+public enum AccountFactory {
     public static func makeLoginUseCase() -> LoginUseCaseType {
         LoginUseCase(networkClient: NetworkRequestFactory.maketNetworkRequestClient(), apiTokenProvider: makeAPITokenProvider(), refreshVpnTokenUseCase: makeRefreshVpnTokenUseCase())
     }
@@ -76,19 +76,19 @@ public class AccountFactory {
 
 private extension AccountFactory {
 
-    static var apitokenProviderShared: APITokenProviderType = {
+    static let apitokenProviderShared: APITokenProviderType = {
         APITokenProvider(keychainStore: makeSecureStore(), tokenSerializer: makeAuthTokenSerializer())
     }()
 
-    static var vpnTokenProviderShared: VpnTokenProviderType = {
+    static let vpnTokenProviderShared: VpnTokenProviderType = {
         VpnTokenProvider(keychainStore: makeSecureStore(), tokenSerializer: makeAuthTokenSerializer())
     }()
 
-    static var secureStoreShared: SecureStore = {
+    static let secureStoreShared: SecureStore = {
         KeychainStore(team: Client.Configuration.teamId, group: Client.Configuration.appGroup)
     }()
 
-    static var refreshAuthTokensCheckerShared: RefreshAuthTokensCheckerType = {
+    static let refreshAuthTokensCheckerShared: RefreshAuthTokensCheckerType = {
         RefreshAuthTokensChecker(apiTokenProvider: makeAPITokenProvider(), vpnTokenProvier: makeVpnTokenProvider(), refreshAPITokenUseCase: makeRefreshAPITokenUseCase(), refreshVpnTokenUseCase: makeRefreshVpnTokenUseCase())
     }()
 

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Account/Data/APITokenProvider.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Account/Data/APITokenProvider.swift
@@ -1,15 +1,15 @@
 import Foundation
 
-protocol APITokenProviderType {
+protocol APITokenProviderType: Sendable {
     func getAPIToken() -> APIToken?
     func save(apiToken: APIToken)
     func saveAPIToken(from data: Data) throws
     func clearAPIToken()
 }
 
-class APITokenProvider: APITokenProviderType {
+final class APITokenProvider: APITokenProviderType {
     private let keychainStore: SecureStore
-    let tokenSerializer: AuthTokenSerializerType
+    private let tokenSerializer: AuthTokenSerializerType
     private let apiTokenKey = "API_TOKEN_KEY"
 
     init(keychainStore: SecureStore, tokenSerializer: AuthTokenSerializerType) {

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Account/Data/AuthTokenSerializer.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Account/Data/AuthTokenSerializer.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-protocol AuthTokenSerializerType {
+protocol AuthTokenSerializerType: Sendable {
     func decodeAPIToken(from data: Data) -> APIToken?
     func decodeVpnToken(from data: Data) -> VpnToken?
     func encode(apiToken: APIToken) -> String?
@@ -8,7 +8,7 @@ protocol AuthTokenSerializerType {
 
 }
 
-class AuthTokenSerializer: AuthTokenSerializerType {
+final class AuthTokenSerializer: AuthTokenSerializerType {
     private let jsonDecoder = JSONDecoder()
     private let jsonEncoder = JSONEncoder()
 

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Account/Data/DedicatedIPServerMapper.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Account/Data/DedicatedIPServerMapper.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-class DedicatedIPServerMapper: DedicatedIPServerMapperType {
+final class DedicatedIPServerMapper: DedicatedIPServerMapperType {
     private let dedicatedIPTokenHandler: DedicatedIPTokenHandlerType
 
     init(dedicatedIPTokenHandler: DedicatedIPTokenHandlerType) {

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Account/Data/DedicatedIPTokenHandler.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Account/Data/DedicatedIPTokenHandler.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-class DedicatedIPTokenHandler: DedicatedIPTokenHandlerType {
+final class DedicatedIPTokenHandler: DedicatedIPTokenHandlerType {
     private let secureStore: SecureStore
 
     init(secureStore: SecureStore) {

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Account/Data/JSONToStringConverter.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Account/Data/JSONToStringConverter.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-protocol JSONToStringCoverterType {
+protocol JSONToStringCoverterType: Sendable {
     func stringify(json: [String: Any]?, prettyPrinted: Bool) -> String?
 }
 

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Account/Data/PaymentInformationDataConverter.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Account/Data/PaymentInformationDataConverter.swift
@@ -1,10 +1,10 @@
 import Foundation
 
-protocol PaymentInformationDataConverterType {
+protocol PaymentInformationDataConverterType: Sendable {
     func callAsFunction(payment: Payment) -> Data?
 }
 
-class PaymentInformationDataConverter: PaymentInformationDataConverterType, JSONToStringCoverterType {
+final class PaymentInformationDataConverter: PaymentInformationDataConverterType, JSONToStringCoverterType {
 
     func callAsFunction(payment: Payment) -> Data? {
         let paymentInformation = PaymentInformation(

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Account/Data/RefreshAuthTokensChecker.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Account/Data/RefreshAuthTokensChecker.swift
@@ -2,12 +2,12 @@ import Foundation
 
 private let log = PIALogger.logger(for: RefreshAuthTokensChecker.self)
 
-protocol RefreshAuthTokensCheckerType {
+protocol RefreshAuthTokensCheckerType: Sendable {
     typealias Completion = ((NetworkRequestError?) -> Void)
     func refreshIfNeeded(completion: @escaping Completion)
 }
 
-class RefreshAuthTokensChecker: RefreshAuthTokensCheckerType {
+final class RefreshAuthTokensChecker: RefreshAuthTokensCheckerType {
 
     let apiTokenProvider: APITokenProviderType
     let vpnTokenProvier: VpnTokenProviderType

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Account/Data/VpnTokenProvider.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Account/Data/VpnTokenProvider.swift
@@ -1,15 +1,15 @@
 import Foundation
 
-protocol VpnTokenProviderType {
+protocol VpnTokenProviderType: Sendable {
     func getVpnToken() -> VpnToken?
     func save(vpnToken: VpnToken)
     func saveVpnToken(from data: Data) throws
     func clearVpnToken()
 }
 
-class VpnTokenProvider: VpnTokenProviderType {
+final class VpnTokenProvider: VpnTokenProviderType, Sendable {
     private let keychainStore: SecureStore
-    let tokenSerializer: AuthTokenSerializerType
+    private let tokenSerializer: AuthTokenSerializerType
     private let vpnTokenKey = "VPN_TOKEN_KEY"
 
     init(keychainStore: SecureStore, tokenSerializer: AuthTokenSerializerType) {

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Account/Domain/Interfaces/DedicatedIPServerMapperType.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Account/Domain/Interfaces/DedicatedIPServerMapperType.swift
@@ -1,5 +1,5 @@
 import Foundation
 
-protocol DedicatedIPServerMapperType {
+protocol DedicatedIPServerMapperType: Sendable {
     func map(dedicatedIps: [DedicatedIPInformation]) -> Result<[Server], ClientError>
 }

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Account/Domain/Interfaces/DedicatedIPTokenHandlerType.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Account/Domain/Interfaces/DedicatedIPTokenHandlerType.swift
@@ -1,5 +1,5 @@
 import Foundation
 
-protocol DedicatedIPTokenHandlerType {
+protocol DedicatedIPTokenHandlerType: Sendable {
     func callAsFunction(dedicatedIp: DedicatedIPInformation, dipUsername: String)
 }

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Account/Domain/Interfaces/EndpointManagerType.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Account/Domain/Interfaces/EndpointManagerType.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-protocol EndpointManagerType {
+protocol EndpointManagerType: Sendable {
     func availableEndpoints() -> [PinningEndpoint]
 }
 

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Account/Domain/Interfaces/SignupInformationDataCoverterType.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Account/Domain/Interfaces/SignupInformationDataCoverterType.swift
@@ -1,5 +1,5 @@
 import Foundation
 
-protocol SignupInformationDataCoverterType {
+protocol SignupInformationDataCoverterType: Sendable {
     func callAsFunction(signup: Signup) -> Data?
 }

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Account/Domain/UseCases/GetDedicatedIPsUseCase.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Account/Domain/UseCases/GetDedicatedIPsUseCase.swift
@@ -2,12 +2,12 @@ import Foundation
 
 fileprivate let log = PIALogger.logger(for: GetDedicatedIPsUseCase.self)
 
-public protocol GetDedicatedIPsUseCaseType {
+public protocol GetDedicatedIPsUseCaseType: Sendable {
     typealias Completion = ((Result<[DedicatedIPInformation], NetworkRequestError>) -> Void)
     func callAsFunction(dipTokens: [String], completion: @escaping Completion)
 }
 
-class GetDedicatedIPsUseCase: GetDedicatedIPsUseCaseType {
+final class GetDedicatedIPsUseCase: GetDedicatedIPsUseCaseType {
     private let networkClient: NetworkRequestClientType
     private let refreshAuthTokensChecker: RefreshAuthTokensCheckerType
 

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Account/Domain/UseCases/RefreshAPITokenUseCase.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Account/Domain/UseCases/RefreshAPITokenUseCase.swift
@@ -3,13 +3,12 @@ import NWHttpConnection
 
 private let log = PIALogger.logger(for: RefreshAPITokenUseCase.self)
 
-protocol RefreshAPITokenUseCaseType {
+protocol RefreshAPITokenUseCaseType: Sendable {
     typealias Completion = ((NetworkRequestError?) -> Void)
     func callAsFunction(completion: @escaping RefreshAPITokenUseCaseType.Completion)
 }
 
-class RefreshAPITokenUseCase: RefreshAPITokenUseCaseType {
-
+final class RefreshAPITokenUseCase: RefreshAPITokenUseCaseType {
     private let apiTokenProvider: APITokenProviderType
     private let networkClient: NetworkRequestClientType
 

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Account/Domain/UseCases/RefreshVpnTokenUseCase.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Account/Domain/UseCases/RefreshVpnTokenUseCase.swift
@@ -2,13 +2,12 @@ import Foundation
 
 private let log = PIALogger.logger(for: RefreshVpnTokenUseCase.self)
 
-protocol RefreshVpnTokenUseCaseType {
+protocol RefreshVpnTokenUseCaseType: Sendable {
     typealias Completion = ((NetworkRequestError?) -> Void)
     func callAsFunction(completion: @escaping RefreshVpnTokenUseCaseType.Completion)
 }
 
-class RefreshVpnTokenUseCase: RefreshVpnTokenUseCaseType {
-
+final class RefreshVpnTokenUseCase: RefreshVpnTokenUseCaseType {
     private let vpnTokenProvider: VpnTokenProviderType
     private let networkClient: NetworkRequestClientType
 

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Account/Domain/UseCases/RenewDedicatedIPUseCase.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Account/Domain/UseCases/RenewDedicatedIPUseCase.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public protocol RenewDedicatedIPUseCaseType {
+public protocol RenewDedicatedIPUseCaseType: Sendable {
     typealias Completion = ((Result<Void, NetworkRequestError>) -> Void)
     func callAsFunction(dipToken: String, completion: @escaping Completion)
 }
 
-class RenewDedicatedIPUseCase: RenewDedicatedIPUseCaseType {
+final class RenewDedicatedIPUseCase: RenewDedicatedIPUseCaseType {
     private let networkClient: NetworkRequestClientType
     private let refreshAuthTokensChecker: RefreshAuthTokensCheckerType
 

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Account/Domain/UseCases/SignupUseCase.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Account/Domain/UseCases/SignupUseCase.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public protocol SignupUseCaseType {
+public protocol SignupUseCaseType: Sendable {
     typealias Completion = ((Result<Credentials, NetworkRequestError>) -> Void)
     func callAsFunction(signup: Signup, completion: @escaping SignupUseCaseType.Completion)
 }
 
-class SignupUseCase: SignupUseCaseType {
+final class SignupUseCase: SignupUseCaseType {
     private let networkClient: NetworkRequestClientType
     private let signupInformationDataCoverter: SignupInformationDataCoverterType
 

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Account/Domain/UseCases/SubscriptionsUseCase.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Account/Domain/UseCases/SubscriptionsUseCase.swift
@@ -1,12 +1,13 @@
 import Foundation
 
-protocol SubscriptionsUseCaseType {
+protocol SubscriptionsUseCaseType: Sendable {
     typealias Completion = ((Result<AppStoreInformation?, NetworkRequestError>) -> Void)
     func callAsFunction(receiptBase64: String?, completion: @escaping Completion)
 }
-class SubscriptionsUseCase: SubscriptionsUseCaseType {
-    let networkClient: NetworkRequestClientType
-    let refreshAuthTokensChecker: RefreshAuthTokensCheckerType
+
+final class SubscriptionsUseCase: SubscriptionsUseCaseType {
+    private let networkClient: NetworkRequestClientType
+    private let refreshAuthTokensChecker: RefreshAuthTokensCheckerType
 
     init(networkClient: NetworkRequestClientType, refreshAuthTokensChecker: RefreshAuthTokensCheckerType) {
         self.networkClient = networkClient

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Account/Domain/UseCases/UpdateAccountUseCase.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Account/Domain/UseCases/UpdateAccountUseCase.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public protocol UpdateAccountUseCaseType {
+public protocol UpdateAccountUseCaseType: Sendable {
     typealias Completion = ((Result<String?, NetworkRequestError>) -> Void)
 
     func setEmail(email: String, resetPassword: Bool, completion: @escaping Completion)
@@ -8,7 +8,7 @@ public protocol UpdateAccountUseCaseType {
     func setEmail(username: String, password: String, email: String, resetPassword: Bool, completion: @escaping Completion)
 }
 
-class UpdateAccountUseCase: UpdateAccountUseCaseType {
+final class UpdateAccountUseCase: UpdateAccountUseCaseType {
 
     private let networkClient: NetworkRequestClientType
     private let refreshAuthTokensChecker: RefreshAuthTokensCheckerType

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/AppConstants.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/AppConstants.swift
@@ -22,23 +22,23 @@
 
 import Foundation
 
-public struct AppConstants {
+public enum AppConstants: Sendable {
 
     public static let appId = "955626407"
     public static let teamId = "5357M5NW9W"
     public static let appGroup = "group.com.privateinternetaccess"
 
-    public struct Reviews {
-        public static var appReviewUrl = "https://itunes.apple.com/app/id\(appId)?action=write-review"
-        public static var feedbackUrl = "https://www.privateinternetaccess.com/helpdesk/new-ticket"
+    public enum Reviews {
+        public static let appReviewUrl = "https://itunes.apple.com/app/id\(appId)?action=write-review"
+        public static let feedbackUrl = "https://www.privateinternetaccess.com/helpdesk/new-ticket"
     }
 
-    public struct About {
-        public static var componentsPath = Bundle.main.path(forResource: "Components", ofType: "plist")
+    public enum About {
+        public static let componentsPath = Bundle.main.path(forResource: "Components", ofType: "plist")
     }
 
-    public struct RegionsGEN4 {
-        public static var bundleURL = Bundle.main.url(forResource: "Regions", withExtension: "json")
+    public enum RegionsGEN4 {
+        public static let bundleURL = Bundle.main.url(forResource: "Regions", withExtension: "json")
     }
 
     public enum InApp {
@@ -59,11 +59,11 @@ public struct AppConstants {
         public static let oldMonthlyProductIdentifier = "com.privateinternetaccess.ios.iap.1month"
     }
 
-    public struct AppURL {
+    public enum AppURL {
         public static let hostRegion = "region"
     }
 
-    public struct Extensions {
+    public enum Extensions {
         // Legacy per-protocol extensions (pre-PlatformSDK); live only while `usePlatformSDKVPN` is off.
         public static let tunnelBundleIdentifier = Bundle.main.bundleIdentifier! + ".Tunnel"
         public static let tunnelWireguardBundleIdentifier = Bundle.main.bundleIdentifier! + ".WG-Tunnel"
@@ -75,12 +75,12 @@ public struct AppConstants {
         public static let adBlockerBundleIdentifier = "com.privateinternetaccess.ios.PIA-VPN.AdBlocker"
     }
 
-    public struct SiriShortcuts {
+    public enum SiriShortcuts {
         public static let shortcutConnect = "com.privateinternetaccess.ios.PIA-VPN.connect"
         public static let shortcutDisconnect = "com.privateinternetaccess.ios.PIA-VPN.disconnect"
     }
 
-    public struct Web {
+    public enum Web {
         public static let homeURL = URL(string: "https://www.privateinternetaccess.com/")!
         public static let supportURL = URL(string: "https://www.privateinternetaccess.com/helpdesk")!
         public static let privacyURL = URL(string: "https://www.privateinternetaccess.com/pages/privacy-policy/")!
@@ -89,13 +89,13 @@ public struct AppConstants {
         public static let leakProtectionURL = URL(string: "\(Self.supportURL.absoluteString)/kb/articles/what-is-pia-s-leak-protection-feature-on-ios")!
     }
 
-    public struct Browser {
+    public enum Browser {
         public static let scheme = "inbrowser://?www.privateinternetaccess.com"
         public static let appStoreUrl = "itms-apps://itunes.apple.com/app/id598907571"
         public static let safariUrl = "https://apps.apple.com/us/app/inbrowser-private-browsing/id598907571?ls=1"
     }
 
-    public struct OpenVPNPacketSize {
+    public enum OpenVPNPacketSize {
         public static let defaultPacketSize = 1420
         public static let smallPacketSize = 1350
     }
@@ -132,7 +132,7 @@ public struct AppConstants {
         public static let highPacketSize = 1420
     }
 
-    public struct WireGuardPacketSize {
+    public enum WireGuardPacketSize {
         public static let defaultPacketSize = 1280
         public static let highPacketSize = 1420
     }
@@ -158,22 +158,22 @@ public struct AppConstants {
         }
     }
 
-    public struct MagicLink {
+    public enum MagicLink {
         public static let url = "piavpn:login?token="
     }
 
-    public struct Widget {
+    public enum Widget {
         // On iOS 15 and 16 we will keep using URL for the connect/disconnect widget action.
         // Starting on 17 and up, we use AppIntents instead, as a more modern API.
         @available(iOS, deprecated: 17, message: "Drop URL for connect/disconnect. Use AppIntent instead.")
         public static let connect = "piavpn:connect"
     }
 
-    public struct QRSignin {
+    public enum QRSignin {
         public static let url = "piavpn:loginqr?token="
     }
 
-    public struct HotspotHelper {
+    public enum HotspotHelper {
         public static let queueLabel = "com.privateinternetaccess.hotspothelper"
     }
 }

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Client+Configuration.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Client+Configuration.swift
@@ -282,7 +282,7 @@ extension Client {
             if Client.environment == .staging {
                 return true
             } else {
-                guard !TestFlightDetector.shared.isTestFlight else {
+                guard !TestFlightDetector.isTestFlight else {
                     return false
                 }
 

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Client+Daemons.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Client+Daemons.swift
@@ -26,7 +26,7 @@ import Foundation
 extension Client {
 
     /// Provides access to passive library updates.
-    public final class Daemons: DatabaseAccess {
+    public final class Daemons: DatabaseAccess, Sendable {
 
         /// It's `true` when the network is reachable.
         public var isNetworkReachable: Bool {

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Client+Environment.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Client+Environment.swift
@@ -25,7 +25,7 @@ import Foundation
 extension Client {
 
     /// The available client environments.
-    public enum Environment: String {
+    public enum Environment: String, Sendable {
 
         /// Use staging endpoints.
         case staging

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Client.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Client.swift
@@ -21,12 +21,11 @@
 //
 
 import Foundation
-import UIKit
 
 private let log = PIALogger.logger(for: Client.self)
 
 /// The entry point for client initialization and usage.
-public final class Client {
+public enum Client {
 
     // MARK: Strategies
 
@@ -46,9 +45,9 @@ public final class Client {
     public static let preferences = Client.Preferences()
 
     /// The business providers (customizable).
-    public static var providers = Client.Providers()
+    public static let providers = Client.Providers()
 
-    static var webServices: WebServices = PIAWebServices()
+    private(set) static var webServices: WebServices = PIAWebServices()
 
     public static var store: any InAppProvider = AppStoreProvider()
 

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Common/CompositionRoot/NetworkRequestFactory.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Common/CompositionRoot/NetworkRequestFactory.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public class NetworkRequestFactory {
+public enum NetworkRequestFactory: Sendable {
     static func maketNetworkRequestClient() -> NetworkRequestClientType {
         networkRequestClientShared
     }
@@ -9,7 +9,7 @@ public class NetworkRequestFactory {
 // MARK: - Private
 
 private extension NetworkRequestFactory {
-    static var networkRequestClientShared: NetworkRequestClientType = {
+    static let networkRequestClientShared: NetworkRequestClientType = {
         NetworkRequestClient(networkConnectionRequestProvider: makeNetworkConnectionRequestProvider(), endpointManager: makeEndpointManager())
     }()
 

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Common/Data/Networking/AnchorCertificateProvider.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Common/Data/Networking/AnchorCertificateProvider.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public final class AnchorCertificateProvider {
+public enum AnchorCertificateProvider {
     public static func getAnchorCertificate() -> SecCertificate? {
 
         #if SWIFT_PACKAGE

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Common/Data/Networking/NetworkConnectionRequestProvider.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Common/Data/Networking/NetworkConnectionRequestProvider.swift
@@ -1,14 +1,14 @@
 import Foundation
 import NWHttpConnection
 
-protocol NetworkConnectionRequestProviderType {
+protocol NetworkConnectionRequestProviderType: Sendable {
     func makeNetworkRequestConnection(for endpoint: PinningEndpoint, with configuration: NetworkRequestConfigurationType) -> NWHttpConnectionType?
 
 }
 
-class NetworkConnectionRequestProvider: NetworkConnectionRequestProviderType {
-    let apiTokenProvider: APITokenProviderType
-    let networkRequestURLProvider: NetworkRequestURLProviderType
+final class NetworkConnectionRequestProvider: NetworkConnectionRequestProviderType {
+    private let apiTokenProvider: APITokenProviderType
+    private let networkRequestURLProvider: NetworkRequestURLProviderType
 
     init(apiTokenProvider: APITokenProviderType, networkRequestURLProvider: NetworkRequestURLProviderType) {
         self.apiTokenProvider = apiTokenProvider

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Common/Data/Networking/NetworkRequestClient.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Common/Data/Networking/NetworkRequestClient.swift
@@ -3,12 +3,12 @@ import NWHttpConnection
 
 private let log = PIALogger.logger(for: NetworkRequestClient.self)
 
-protocol NetworkRequestClientType {
+protocol NetworkRequestClientType: Sendable {
     typealias Completion = ((NetworkRequestError?, NetworkRequestResponseType?) -> Void)
     func executeRequest(with configuration: NetworkRequestConfigurationType, completion: @escaping Completion)
 }
 
-class NetworkRequestClient: NetworkRequestClientType {
+final class NetworkRequestClient: NetworkRequestClientType {
     private let networkConnectionRequestProvider: NetworkConnectionRequestProviderType
     private let endpointManager: EndpointManagerType
 

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Common/Data/Networking/NetworkRequestURLProvider.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Common/Data/Networking/NetworkRequestURLProvider.swift
@@ -1,11 +1,10 @@
 import Foundation
 
-protocol NetworkRequestURLProviderType {
+protocol NetworkRequestURLProviderType: Sendable {
     func getURL(for endpoint: PinningEndpoint, path: RequestAPI.Path, query: [String: String]?) -> URL?
 }
 
-class NetworkRequestURLProvider: NetworkRequestURLProviderType {
-
+final class NetworkRequestURLProvider: NetworkRequestURLProviderType {
     private let stagingSubdomain = "staging"
     private let domainRegex = "^((?!-)[A-Za-z0-9-]{1,63}(?<!-)\\.)+[A-Za-z]{2,6}$"
     private let ipv4Regex = "^(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])(\\.(?!$)|$)){4}$"

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Daemons/ConnectivityDaemon.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Daemons/ConnectivityDaemon.swift
@@ -222,7 +222,7 @@ final class ConnectivityDaemon: Daemon, ConfigurationAccess, DatabaseAccess, Pre
 
 // MARK: - ConnectivityChecker
 
-private actor ConnectivityChecker {
+private actor ConnectivityChecker: Sendable {
     enum Error: Swift.Error {
         case alreadyChecking
         case other(Swift.Error)

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/InApp/PurchasePlan.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/InApp/PurchasePlan.swift
@@ -22,7 +22,7 @@
 
 import Foundation
 
-public final class PurchasePlan: NSObject {
+public final class PurchasePlan {
     private struct DummyInAppProduct: InAppProduct {
         enum Native: Equatable {
             case none
@@ -51,10 +51,8 @@ public final class PurchasePlan: NSObject {
         return f
     }()
 
-    public static let dummy = PurchasePlan()
-
     public var isDummy: Bool {
-        return (self == .dummy)
+        return product is DummyInAppProduct
     }
 
     public let plan: Plan
@@ -99,10 +97,12 @@ public final class PurchasePlan: NSObject {
         return accessibleFormatter.string(for: price)!
     }
 
-    private override init() {
-        plan = .trial
-        product = DummyInAppProduct()
-        monthlyFactor = 1.0
+    public static func dummy() -> PurchasePlan {
+        return PurchasePlan(
+            plan: .trial,
+            product: DummyInAppProduct(),
+            monthlyFactor: 1.0
+        )
     }
 
     public init(plan: Plan, product: any InAppProduct, monthlyFactor: Decimal) {
@@ -111,10 +111,10 @@ public final class PurchasePlan: NSObject {
         self.product = product
         self.monthlyFactor = monthlyFactor
     }
+}
 
-    // MARK: CustomStringConvertible
-
-    public override var description: String {
+extension PurchasePlan: CustomStringConvertible {
+    public var description: String {
         return product.identifier
     }
 }

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Mock/MockAccountProvider.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Mock/MockAccountProvider.swift
@@ -25,7 +25,7 @@ import PIABase
 import StoreKit
 
 /// Simulates account-related operations
-public final class MockAccountProvider: AccountProvider, WebServicesConsumer {
+public final class MockAccountProvider: AccountProvider, WebServicesConsumer, @unchecked Sendable {
 
     /// Mocks the outcome of a sign-up operation.
     ///

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Mock/MockDedicatedIPServerMapper.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Mock/MockDedicatedIPServerMapper.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-class MockDedicatedIPServerMapper: DedicatedIPServerMapperType {
+final class MockDedicatedIPServerMapper: DedicatedIPServerMapperType {
     func map(dedicatedIps: [DedicatedIPInformation]) -> Result<[Server], ClientError> {
         return .success([])
     }

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Mock/MockGetDedicatedIPsUseCase.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Mock/MockGetDedicatedIPsUseCase.swift
@@ -1,5 +1,5 @@
 import Foundation
 
-class MockGetDedicatedIPsUseCase: GetDedicatedIPsUseCaseType {
+final class MockGetDedicatedIPsUseCase: GetDedicatedIPsUseCaseType {
     func callAsFunction(dipTokens: [String], completion: @escaping Completion) {}
 }

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Mock/MockRenewDedicatedIPUseCase.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Mock/MockRenewDedicatedIPUseCase.swift
@@ -1,5 +1,5 @@
 import Foundation
 
-class MockRenewDedicatedIPUseCase: RenewDedicatedIPUseCaseType {
+final class MockRenewDedicatedIPUseCase: RenewDedicatedIPUseCaseType {
     func callAsFunction(dipToken: String, completion: @escaping Completion) {}
 }

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Mock/MockServerProvider.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Mock/MockServerProvider.swift
@@ -23,7 +23,7 @@
 import Foundation
 
 /// Simulates server-related operations
-public final class MockServerProvider: ServerProvider, DatabaseAccess, WebServicesConsumer {
+public final class MockServerProvider: ServerProvider, DatabaseAccess, WebServicesConsumer, @unchecked Sendable {
 
     /// Fakes a `Server` list.
     public var mockServers: [Server]

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Mock/MockWebServices.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Mock/MockWebServices.swift
@@ -23,7 +23,7 @@
 import Foundation
 import PIABase
 
-final class MockWebServices: WebServices {
+final class MockWebServices: WebServices, @unchecked Sendable {
 
     var messageType: InAppMessageType = .view
 

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/NotificationKey.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/NotificationKey.swift
@@ -23,7 +23,7 @@
 import Foundation
 
 /// Strongly typed, extensible `struct` for storing entries into the `Notification.userInfo` map.
-public struct NotificationKey: Hashable {
+public struct NotificationKey: Hashable, Sendable {
     public static let products = NotificationKey("ProductsKey")
 
     public static let token = NotificationKey("TokenKey")

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Persistence/KeychainStore.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Persistence/KeychainStore.swift
@@ -22,7 +22,7 @@
 
 import Foundation
 
-class KeychainStore: SecureStore {
+final class KeychainStore: SecureStore {
 
     private let backend: Keychain
 

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Persistence/SecureStore.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Persistence/SecureStore.swift
@@ -22,7 +22,7 @@
 
 import Foundation
 
-protocol SecureStore: AnyObject {
+protocol SecureStore: AnyObject, Sendable {
 
     func username() -> String?
 

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Util/Keychain.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Util/Keychain.swift
@@ -38,7 +38,7 @@ public enum KeychainError: Error {
 }
 
 /// Encapsulates Apple keychain operations.
-public class Keychain {
+public final class Keychain: Sendable {
     private let service: String?
 
     private let accessGroup: String?

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Util/Pages.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Util/Pages.swift
@@ -23,7 +23,7 @@
 import Foundation
 
 /// The sub-pages offered in the `PIAWelcomeViewController` user interface.
-public struct Pages: OptionSet {
+public struct Pages: OptionSet, Sendable {
 
     /// The login page.
     public static let login = Pages(rawValue: 1 << 0)

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Util/Pinger.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Util/Pinger.swift
@@ -23,7 +23,7 @@
 import Foundation
 import Network
 
-protocol Pinger {
+protocol Pinger: Sendable {
     func ping(ip: String, port: UInt16, timeout: TimeInterval) async -> Int?
 }
 

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Util/Platform.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Util/Platform.swift
@@ -28,7 +28,7 @@ public struct Platform {
 
     /// True when an iOS binary is running on Apple Silicon Mac as "Designed for iPad".
     /// Always false on real iPhone/iPad, on the iOS Simulator, and on tvOS.
-    public static var isiOSAppOnMac: Bool = {
+    public static let isiOSAppOnMac: Bool = {
         #if os(iOS)
             return ProcessInfo.processInfo.isiOSAppOnMac
         #else
@@ -37,7 +37,7 @@ public struct Platform {
     }()
 
     /// True when the platform is Max Catalyst
-    public static var isMacCatalystApp: Bool = {
+    public static let isMacCatalystApp: Bool = {
         #if targetEnvironment(macCatalyst)
             return ProcessInfo.processInfo.isMacCatalystApp
         #else

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/Util/TestFlightDetector.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/Util/TestFlightDetector.swift
@@ -22,17 +22,9 @@
 
 import Foundation
 
-public protocol TestFlightDetectorProtocol {
-    var isTestFlight: Bool { get }
-}
-
-public struct TestFlightDetector: TestFlightDetectorProtocol {
-    public static let shared = TestFlightDetector()
-
-    public init() {}
-
+public enum TestFlightDetector: Sendable {
     /// Checks if app is running in TestFlight
-    public var isTestFlight: Bool {
+    public static var isTestFlight: Bool {
         #if targetEnvironment(macCatalyst)
             return hasStoreReceipt && hasProvisioningProfile
         #else
@@ -41,15 +33,15 @@ public struct TestFlightDetector: TestFlightDetectorProtocol {
     }
 
     #if targetEnvironment(macCatalyst)
-        private var hasStoreReceipt: Bool {
+        private static var hasStoreReceipt: Bool {
             bundleContentsContain("_MASReceipt/receipt")
         }
 
-        private var hasProvisioningProfile: Bool {
+        private static var hasProvisioningProfile: Bool {
             bundleContentsContain("embedded.provisionprofile")
         }
 
-        private func bundleContentsContain(_ relativePath: String) -> Bool {
+        private static func bundleContentsContain(_ relativePath: String) -> Bool {
             let url = Bundle.main.bundleURL
                 .appendingPathComponent("Contents", isDirectory: true)
                 .appendingPathComponent(relativePath)

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/VPN/IKEv2EncryptionAlgorithm.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/VPN/IKEv2EncryptionAlgorithm.swift
@@ -23,7 +23,7 @@
 import Foundation
 import NetworkExtension
 
-public enum IKEv2EncryptionAlgorithm: String, CaseIterable {
+public enum IKEv2EncryptionAlgorithm: String, CaseIterable, Sendable {
 
     public static let `default`: IKEv2EncryptionAlgorithm = {
         #if os(iOS)

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/VPN/IKEv2IntegrityAlgorithm.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/VPN/IKEv2IntegrityAlgorithm.swift
@@ -23,7 +23,7 @@
 import Foundation
 import NetworkExtension
 
-public enum IKEv2IntegrityAlgorithm: String, CaseIterable {
+public enum IKEv2IntegrityAlgorithm: String, CaseIterable, Sendable {
 
     public static let `default`: IKEv2IntegrityAlgorithm = {
         #if os(iOS)

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/WebServices/DedicatedIP.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/WebServices/DedicatedIP.swift
@@ -20,7 +20,7 @@
 
 import Foundation
 
-public enum DedicatedIPStatus {
+public enum DedicatedIPStatus: Sendable {
 
     case active
     case expired

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/WebServices/EndpointManager.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/WebServices/EndpointManager.swift
@@ -35,7 +35,7 @@ public struct PinningEndpoint {
     }
 }
 
-public final class EndpointManager {
+public final class EndpointManager: Sendable {
 
     private let internalUrl = "10.0.0.1"
     private let proxy = "piaproxy.net"

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/WebServices/Server.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/WebServices/Server.swift
@@ -38,7 +38,7 @@ public final class Server {
     public let serial: String
 
     /// Represents a VPN server address endpoint.
-    public struct Address: CustomStringConvertible {
+    public struct Address: CustomStringConvertible, Sendable {
 
         /// The endpoint hostname.
         public let hostname: String
@@ -174,7 +174,7 @@ public final class Server {
 
     public let dipUsername: String?
 
-    var isAutomatic: Bool
+    let isAutomatic: Bool
 
     /// :nodoc:
     public init(

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/WebServices/ServersBundle.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/WebServices/ServersBundle.swift
@@ -23,15 +23,15 @@
 import Foundation
 
 /// A `ServersBundle` wraps a list of `Server` with additional metadata.
-public struct ServersBundle {
+public struct ServersBundle: Sendable {
 
     /// Holds the metadata of the `ServerProvider` configuration.
     ///
     /// - Seealso: `ServerProvider.currentServersConfiguration`
-    public struct Configuration {
+    public struct Configuration: Sendable {
 
         /// A set of available ports to connect to the VPN servers found in this configuration.
-        public struct Ports {
+        public struct Ports: Sendable {
 
             /// The available ports over UDP.
             public let udp: [UInt16]

--- a/LocalPackages/PIALibrary/Sources/PIALibrary/WebServices/WebServices.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/WebServices/WebServices.swift
@@ -23,11 +23,11 @@
 import Foundation
 import PIABase
 
-protocol WebServicesConsumer {
+protocol WebServicesConsumer: Sendable {
     var webServices: WebServices { get }
 }
 
-protocol WebServices: AnyObject {
+protocol WebServices: AnyObject, Sendable {
 
     // MARK: Account
 

--- a/PIA VPN-tvOS/Shared/Debug/View+DebugMenu.swift
+++ b/PIA VPN-tvOS/Shared/Debug/View+DebugMenu.swift
@@ -25,7 +25,7 @@ private struct DebugMenuModifier: ViewModifier {
         #if DEVELOPMENT || STAGING
             return true
         #else
-            return TestFlightDetector.shared.isTestFlight
+            return TestFlightDetector.isTestFlight
         #endif
     }
 }

--- a/PIA VPN/Core/Extensions/AppDelegate+DebugMenu.swift
+++ b/PIA VPN/Core/Extensions/AppDelegate+DebugMenu.swift
@@ -10,7 +10,7 @@ private enum DebugMenuAvailability {
         #if DEVELOPMENT || STAGING
             return true
         #else
-            return TestFlightDetector.shared.isTestFlight
+            return TestFlightDetector.isTestFlight
         #endif
     }
 }

--- a/PIA VPN/Core/Utils/RatingManager.swift
+++ b/PIA VPN/Core/Utils/RatingManager.swift
@@ -170,8 +170,7 @@ final class RatingManager: RatingManagerProtocol {
     // MARK: Configuration fetching
 
     func loadInAppRatingConfig() {
-        let testFlightDetector = TestFlightDetector.shared
-        let isStaging = testFlightDetector.isTestFlight
+        let isStaging = TestFlightDetector.isTestFlight
 
         Task {
             let inAppRatingConfig: InAppRatingConfig? = await loadConfig(

--- a/PIA VPN/UI/PurchaseViewController.swift
+++ b/PIA VPN/UI/PurchaseViewController.swift
@@ -47,7 +47,7 @@ final class PurchaseViewController: AutolayoutViewController, BrandableNavigatio
     @IBOutlet private weak var buttonPurchase: PIAButton!
 
     private var config: Config!
-    private var allPlans: [PurchasePlan] = [.dummy, .dummy]
+    private var allPlans: [PurchasePlan] = [.dummy(), .dummy()]
     private var selectedPlanIndex: Int = 0
 
     private var isExpired = false

--- a/PIAWidget/Domain/Widget/PIAWidgetAttributes.swift
+++ b/PIAWidget/Domain/Widget/PIAWidgetAttributes.swift
@@ -3,17 +3,14 @@
     import ActivityKit
     import Foundation
 
-    public struct PIAConnectionAttributes: ActivityAttributes {
+    public struct PIAConnectionAttributes: ActivityAttributes, Sendable {
         public typealias PIAConnectionStatus = ContentState
 
-        public struct ContentState: Codable, Hashable {
-            var connected: Bool
-            var regionName: String
-            var regionFlag: String
-            var vpnProtocol: String
-
+        public struct ContentState: Codable, Hashable, Sendable {
+            let connected: Bool
+            let regionName: String
+            let regionFlag: String
+            let vpnProtocol: String
         }
-
     }
-
 #endif


### PR DESCRIPTION
- Mark most types in `PIALibrary` as `Sendable` to ease the swift 6 transition.
- Types marked were already conforming but needed explicit inheritance.
- `PIALibrary` is still not compiled in Swift 6 mode, as many other types still need conversion.
- Some mocks are marked as `@unchecked Sendable` since they're only used in tests.
- Some factories were refactored from `static final class` to `enum`. Simpler.