### PR TITLE
KM-18117: Don't auto-connect the VPN on staging

### DIFF
--- a/LocalPackages/PIALibrary/Sources/PIALibrary/VPN/DefaultVPNProvider.swift
+++ b/LocalPackages/PIALibrary/Sources/PIALibrary/VPN/DefaultVPNProvider.swift
@@ -567,15 +567,23 @@ public final class DefaultVPNProvider: VPNProvider, ConfigurationAccess, Databas
 
         let customConfiguration = accessedPreferences.vpnCustomConfiguration(for: profile.vpnType)
 
+        // isOnDemand will cause the VPN to auto connect, but given in staging
+        // builds it's not possible to make a connection then we prevent that
+        let isOnDemand = if Client.environment == .staging {
+            false
+        } else {
+            // A placeholder profile must never carry on-demand rules: if an enabled
+            // manager already exists, doSave would honor them and the OS could try
+            // to bring up a tunnel to the placeholder endpoint on its own.
+            usesServerPlaceholder ? false : accessedPreferences.isPersistentConnection
+        }
+
         return VPNConfiguration(
             name: accessedConfiguration.vpnProfileName,
             username: currentUser.credentials.username,
             passwordReference: currentPasswordReference,
             server: targetServer,
-            // A placeholder profile must never carry on-demand rules: if an enabled
-            // manager already exists, doSave would honor them and the OS could try
-            // to bring up a tunnel to the placeholder endpoint on its own.
-            isOnDemand: usesServerPlaceholder ? false : accessedPreferences.isPersistentConnection,
+            isOnDemand: isOnDemand,
             disconnectsOnSleep: accessedPreferences.vpnDisconnectsOnSleep,
             customConfiguration: customConfiguration,
             leakProtection: accessedPreferences.leakProtection,


### PR DESCRIPTION
Staging builds now save the VPN profile with Connect on Demand off, so allowing the VPN configuration no longer starts a connection that can never succeed and blocks all internet.