### PR TITLE
KM-18229: Re-enable App Transport Security in PlatformSDK-Tunnel

### DIFF
--- a/LocalPackages/PIAVPN/Package.swift
+++ b/LocalPackages/PIAVPN/Package.swift
@@ -17,7 +17,8 @@ let package = Package(
     ],
     dependencies: [
         .package(path: "../KapePlatformSDK"),
-        .package(path: "../PIALibrary")
+        .package(path: "../PIALibrary"),
+        .package(url: "git@github.com:pia-foss/mobile-ios-networking.git", exact: "1.3.2")
     ],
     targets: [
         .target(
@@ -25,7 +26,8 @@ let package = Package(
             dependencies: [
                 .product(name: "KapeVPN-OpenVPN", package: "KapePlatformSDK"),
                 .product(name: "KapeVPN-PacketTunnel", package: "KapePlatformSDK"),
-                .product(name: "PIALibrary", package: "PIALibrary")
+                .product(name: "PIALibrary", package: "PIALibrary"),
+                .product(name: "NWHttpConnection", package: "mobile-ios-networking")
             ]
         )
     ],

--- a/LocalPackages/PIAVPN/Sources/PIAVPN/Extensions/NWHttpConnectionType+SingleResponse.swift
+++ b/LocalPackages/PIAVPN/Sources/PIAVPN/Extensions/NWHttpConnectionType+SingleResponse.swift
@@ -1,0 +1,49 @@
+import Foundation
+import NWHttpConnection
+
+enum NWHttpConnectionResponseError: Error {
+    case noResponse
+}
+
+extension NWHttpConnectionType {
+    func singleResponse() async throws -> NWHttpConnectionDataResponseType {
+        try await withCheckedThrowingContinuation { continuation in
+            let resumer = SingleResumer(continuation)
+            do {
+                try connect(
+                    requestHandler: { error, response in
+                        if let error {
+                            resumer.resume(with: .failure(error))
+                        } else if let response {
+                            resumer.resume(with: .success(response))
+                        } else {
+                            resumer.resume(with: .failure(NWHttpConnectionResponseError.noResponse))
+                        }
+                    },
+                    completion: {
+                        resumer.resume(with: .failure(NWHttpConnectionResponseError.noResponse))
+                    })
+            } catch {
+                resumer.resume(with: .failure(error))
+            }
+        }
+    }
+}
+
+private final class SingleResumer<T>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var continuation: CheckedContinuation<T, Error>?
+
+    init(_ continuation: CheckedContinuation<T, Error>) {
+        self.continuation = continuation
+    }
+
+    func resume(with result: Result<T, Error>) {
+        lock.lock()
+        let pending = continuation
+        continuation = nil
+        lock.unlock()
+
+        pending?.resume(with: result)
+    }
+}

--- a/LocalPackages/PIAVPN/Sources/PIAVPN/Tunnel/PIAWireguardAuthenticator.swift
+++ b/LocalPackages/PIAVPN/Sources/PIAVPN/Tunnel/PIAWireguardAuthenticator.swift
@@ -1,6 +1,7 @@
 import CryptoKit
 import Foundation
 import KapeVPN_PacketTunnel
+import NWHttpConnection
 import PIALibrary
 
 final class PIAWireguardAuthenticator: PacketTunnelWireguardAuthenticator, Sendable {
@@ -38,9 +39,6 @@ final class PIAWireguardAuthenticator: PacketTunnelWireguardAuthenticator, Senda
             throw PIAWireguardAuthError.invalidURL
         }
 
-        var request = URLRequest(url: url)
-        request.timeoutInterval = 10
-
         // Pin the key-exchange TLS connection against the bundled PIA root CA, validating that the
         // server's leaf certificate is anchored to it and its Common Name matches the per-server
         // `certDn` the app resolved. The endpoint is reached by IP with a self-signed cert, so this
@@ -49,25 +47,32 @@ final class PIAWireguardAuthenticator: PacketTunnelWireguardAuthenticator, Senda
             logger.error("Failed to load PIA anchor certificate — cannot pin key-exchange connection")
             throw PIAWireguardAuthError.missingAnchorCertificate
         }
-        let delegate = PinnedCertificateDelegate(
-            anchorCertificate: anchorCertificate, expectedCommonName: config.certDn, logger: logger)
-        let session = URLSession(configuration: .ephemeral, delegate: delegate, delegateQueue: nil)
 
-        defer {
-            session.finishTasksAndInvalidate()
-        }
+        let configuration = NWConnectionConfiguration(
+            url: url,
+            method: .get,
+            body: nil,
+            certificateValidation: .anchor(certificate: anchorCertificate, commonName: config.certDn),
+            dataResponseType: .jsonData,
+            timeout: 10)
+        let connection = NWHttpConnectionFactory.makeNWHttpConnection(with: configuration)
 
         logger.debug("Sending addKey request to \(host):\(config.authPort)")
-        let resultData: Data
-        let urlResponse: URLResponse
+        let httpResponse: NWHttpConnectionDataResponseType
         do {
-            (resultData, urlResponse) = try await session.data(for: request)
+            httpResponse = try await connection.singleResponse()
         } catch {
-            logger.error("addKey request to \(host) failed: \(error.localizedDescription)")
+            logger.error("addKey request to \(host) failed: \(String(describing: error))")
             throw error
         }
 
-        let statusCode = (urlResponse as? HTTPURLResponse)?.statusCode ?? -1
+        let statusCode = httpResponse.statusCode ?? -1
+
+        guard let resultData = httpResponse.data else {
+            logger.error("addKey to \(host):\(config.authPort) rejected — http \(statusCode), no JSON body")
+            throw PIAWireguardAuthError.serverError("http \(statusCode): no JSON body")
+        }
+
         let response: WGKeyResponse
         do {
             response = try JSONDecoder().decode(WGKeyResponse.self, from: resultData)
@@ -137,80 +142,4 @@ private struct WGKeyResponse: Decodable {
     let server_key: String
     let peer_ip: String
     let dns_servers: [String]?
-}
-
-/// `URLSessionDelegate` that pins the key-exchange TLS connection to the bundled PIA root CA.
-///
-/// The VPN server is reached by IP and presents a self-signed leaf signed by the PIA CA, so the
-/// system trust chain can't validate it. We instead require the leaf's Common Name to match the
-/// per-server `certDn` and the leaf to chain to the pinned anchor. Mirrors the legacy WireGuard
-/// pinning (`CertificateValidation.anchor`) and PIAAccount's `CertificatePinner`. Fails closed:
-/// any mismatch or evaluation failure cancels the challenge.
-///
-/// The anchor is stored as immutable DER `Data` (not a `SecCertificate`) so the type is cleanly
-/// `Sendable`; the `SecCertificate` is rebuilt inside the callback.
-private final class PinnedCertificateDelegate: NSObject, URLSessionDelegate, Sendable {
-    private let anchorCertificateData: Data
-    private let expectedCommonName: String
-    private let logger: PIATunnelLogger
-
-    init(anchorCertificate: SecCertificate, expectedCommonName: String, logger: PIATunnelLogger) {
-        self.anchorCertificateData = SecCertificateCopyData(anchorCertificate) as Data
-        self.expectedCommonName = expectedCommonName
-        self.logger = logger
-        super.init()
-    }
-
-    func urlSession(
-        _ session: URLSession,
-        didReceive challenge: URLAuthenticationChallenge,
-        completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
-    ) {
-        guard challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodServerTrust,
-            let serverTrust = challenge.protectionSpace.serverTrust,
-            let leafCertificate = (SecTrustCopyCertificateChain(serverTrust) as? [SecCertificate])?.first
-        else {
-            logger.error("Pinning failed: no server trust on key-exchange challenge")
-            completionHandler(.cancelAuthenticationChallenge, nil)
-            return
-        }
-
-        // The leaf's CN must match the per-server `certDn`.
-        var leafCommonName: CFString?
-        SecCertificateCopyCommonName(leafCertificate, &leafCommonName)
-        guard let leafCommonName = leafCommonName as String?, leafCommonName == expectedCommonName else {
-            logger.error(
-                "Pinning failed: leaf CN \"\(leafCommonName as String? ?? "nil")\" != expected \"\(expectedCommonName)\"")
-            completionHandler(.cancelAuthenticationChallenge, nil)
-            return
-        }
-
-        // Rebuild trust on the leaf with the pinned PIA CA as the sole anchor, then evaluate.
-        // No hostname check: the endpoint is an IP, so the SSL policy is created with a nil host.
-        guard let anchorCertificate = SecCertificateCreateWithData(nil, anchorCertificateData as CFData) else {
-            logger.error("Pinning failed: could not decode anchor certificate")
-            completionHandler(.cancelAuthenticationChallenge, nil)
-            return
-        }
-
-        var trust: SecTrust?
-        guard SecTrustCreateWithCertificates(leafCertificate, SecPolicyCreateSSL(true, nil), &trust) == errSecSuccess,
-            let trust,
-            SecTrustSetAnchorCertificates(trust, [anchorCertificate] as CFArray) == errSecSuccess,
-            SecTrustSetAnchorCertificatesOnly(trust, true) == errSecSuccess
-        else {
-            logger.error("Pinning failed: could not build trust for evaluation")
-            completionHandler(.cancelAuthenticationChallenge, nil)
-            return
-        }
-
-        var error: CFError?
-        guard SecTrustEvaluateWithError(trust, &error) else {
-            logger.error("Pinning failed: trust evaluation rejected the server certificate")
-            completionHandler(.cancelAuthenticationChallenge, nil)
-            return
-        }
-
-        completionHandler(.useCredential, URLCredential(trust: serverTrust))
-    }
 }

--- a/PIA VPN.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/PIA VPN.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -167,8 +167,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-async-dns-resolver",
       "state" : {
-        "revision" : "e145f21e97cc40ee744e1276b21426ed47ab9d88",
-        "version" : "0.7.1"
+        "revision" : "1bd427a37a8fa276a96189f22c714e79b7d5ac03",
+        "version" : "0.8.0"
       }
     },
     {

--- a/PlatformSDK-Tunnel/SupportingFiles/Info.plist
+++ b/PlatformSDK-Tunnel/SupportingFiles/Info.plist
@@ -24,11 +24,6 @@
 	<array>
 		<string>arm64</string>
 	</array>
-	<key>NSAppTransportSecurity</key>
-	<dict>
-		<key>NSAllowsArbitraryLoads</key>
-		<true/>
-	</dict>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>


### PR DESCRIPTION
The `addKey` now goes over `NWHttpConnection` instead of `URLSession`, so it no longer needs ATS disabled for the whole extension — `NSAllowsArbitraryLoads` removed.