### PR TITLE
KM-18064: Wrap long IPs (IPv6) to multiple lines

### DIFF
--- a/PIA VPN/Core/Tiles/IPTile.swift
+++ b/PIA VPN/Core/Tiles/IPTile.swift
@@ -84,9 +84,12 @@ final class IPTile: UIView, Tileable {
         self.vpnIpTitle.text = "VPN IP"
         self.localIpValue.text = Client.daemons.publicIP ?? emptyIPValue
         self.localIpValue.accessibilityLabel = Client.daemons.publicIP ?? L10n.Global.empty
+        self.localIpValue.numberOfLines = 3
+        self.localIpValue.lineBreakMode = .byWordWrapping
         self.vpnIpValue.text = emptyIPValue
         self.vpnIpValue.accessibilityLabel = L10n.Global.empty
-
+        self.vpnIpValue.numberOfLines = 3
+        self.vpnIpValue.lineBreakMode = .byWordWrapping
     }
 
     private func viewShouldRestyle() {


### PR DESCRIPTION
Wrap long IPs into multiple lines. A full IPv6 will normally fit in only 2 lines, adding 3 just in case as the maximum.
