### PR TITLE
KM-18186: Correctly dismiss VPN permission screen

### DIFF
--- a/PIA VPN/Core/RootCoordinator.swift
+++ b/PIA VPN/Core/RootCoordinator.swift
@@ -251,7 +251,6 @@ extension RootCoordinator: PIAWelcomeViewControllerDelegate {
         DispatchQueue.main.async { [weak self] in
             guard let self, let dashboard = self.dashboard else { return }
             let permissionVC = StoryboardScene.Main.vpnPermissionViewController.instantiate()
-            permissionVC.dismissingViewController = dashboard
             let nav = UINavigationController(rootViewController: permissionVC)
             nav.modalPresentationStyle = .fullScreen
             dashboard.present(nav, animated: true)

--- a/PIA VPN/UI/Dashboard/DashboardViewController.swift
+++ b/PIA VPN/UI/Dashboard/DashboardViewController.swift
@@ -455,9 +455,6 @@ final class DashboardViewController: AutolayoutViewController {
                     if isSignup, preset.isEphemeral {
                         Client.providers.accountProvider.currentUser = user
                     }
-                    // The modal host *pushes* the VPN permission screen, where the root host
-                    // presents it. Keeping that difference is the reason the coordinator reports
-                    // out rather than deciding for itself.
                     self.dismiss(animated: true) { self.showVPNModal(target: self) }
                 }
             }
@@ -1344,8 +1341,9 @@ extension DashboardViewController: PIAWelcomeViewControllerDelegate {
 
     private func showVPNModal(target: UIViewController) {
         let vc = StoryboardScene.Main.vpnPermissionViewController.instantiate()
-        vc.dismissingViewController = self
-        target.navigationController?.pushViewController(vc, animated: true)
+        let nav = UINavigationController(rootViewController: vc)
+        nav.modalPresentationStyle = .fullScreen
+        target.present(nav, animated: true)
     }
 }
 

--- a/PIA VPN/UI/Dashboard/VPNPermissionViewController.swift
+++ b/PIA VPN/UI/Dashboard/VPNPermissionViewController.swift
@@ -45,12 +45,6 @@ final class VPNPermissionViewController: AutolayoutViewController {
 
     @IBOutlet private weak var buttonSubmit: PIAButton!
 
-    weak var dismissingViewController: UIViewController?
-
-    override var navigationController: UINavigationController? {
-        return super.navigationController ?? parent?.navigationController
-    }
-
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -83,8 +77,18 @@ final class VPNPermissionViewController: AutolayoutViewController {
                     self.alertRequiredPermission()
                     return
                 }
-                self.dismissingViewController?.dismiss(animated: true)
+                self.finish()
             }
+        }
+    }
+
+    /// Leaves the screen whichever way it was installed: pushed onto the dashboard's stack, or
+    /// presented as the root of its own navigation controller.
+    private func finish() {
+        if let nav = navigationController, nav.viewControllers.first !== self {
+            nav.popViewController(animated: true)
+        } else {
+            presentingViewController?.dismiss(animated: true)
         }
     }
 
@@ -95,15 +99,15 @@ final class VPNPermissionViewController: AutolayoutViewController {
         }
         let alert = Macros.alert(L10n.VpnPermission.title, message)
         if MFMailComposeViewController.canSendMail() {
-            alert.addActionWithTitle(L10n.VpnPermission.Disallow.contact) {
-                self.contactCustomerSupport()
+            alert.addActionWithTitle(L10n.VpnPermission.Disallow.contact) { [weak self] in
+                self?.contactCustomerSupport()
             }
         }
         // Just dismiss the alert. The permission screen stays on screen, so the
         // user can retry via its OK button. Auto-retrying from here created an
         // undismissable alert loop when the install failed instantly (KM-17461).
-        alert.addCancelActionWithTitle(L10n.Global.ok) {}
-        present(alert, animated: true, completion: nil)
+        alert.addCancelAction(L10n.Global.ok)
+        present(alert, animated: true)
     }
 
     private func contactCustomerSupport() {
@@ -147,7 +151,11 @@ final class VPNPermissionViewController: AutolayoutViewController {
 }
 
 extension VPNPermissionViewController: MFMailComposeViewControllerDelegate {
-    func mailComposeController(_ controller: MFMailComposeViewController, didFinishWith result: MFMailComposeResult, error: Error?) {
-        dismiss(animated: true, completion: nil)
+    func mailComposeController(
+        _ controller: MFMailComposeViewController,
+        didFinishWith result: MFMailComposeResult,
+        error: Error?
+    ) {
+        controller.presentingViewController?.dismiss(animated: true)
     }
 }


### PR DESCRIPTION
- VPN permission screen assumed it was being presented, but the dashboard was pushing it into the navigation.
- Make sure to present it in the dashboard.
- VPN permission screen now checks if it's inside a navigation controller, and pops. Or dismiss like before.